### PR TITLE
fix(publish): #28 ship installer in tarball + #29 prepack tarball-shape gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,15 +8,22 @@
   "scripts": {
     "build": "tsc && cp openclaw.plugin.json dist/openclaw.plugin.json",
     "prepublishOnly": "npm run build",
+    "prepack": "node scripts/check-tarball-shape.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
   },
+  "bin": {
+    "smarter-claw-install": "installer/bin/install.mjs",
+    "smarter-claw-uninstall": "installer/bin/uninstall.mjs",
+    "smarter-claw-verify": "installer/bin/verify.mjs"
+  },
   "files": [
     "dist/",
-    "!dist/**/__tests__/",
-    "!dist/**/*.test.js",
-    "!dist/**/*.test.d.ts",
+    "installer/bin/",
+    "installer/lib/",
+    "installer/patches/",
+    "installer/patch-plan.json",
     "openclaw.plugin.json",
     "README.md",
     "LICENSE"

--- a/scripts/check-tarball-shape.mjs
+++ b/scripts/check-tarball-shape.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/**
+ * Pre-pack assertion: the tarball npm is about to publish (or that
+ * this user is about to npm-pack) MUST contain the surfaces our
+ * README + bin entries promise. If anything is missing, fail loud
+ * BEFORE the bad tarball is built.
+ *
+ * Catches:
+ *   - Missing dist/ (forgot to build, or build was interrupted)
+ *   - Missing installer/bin/ (the headline feature shadow-disappeared)
+ *   - Missing patch-plan.json or patches/ (installer would no-op on install)
+ *   - Empty bin scripts (would publish CLI commands that error on first invoke)
+ *
+ * Runs as `prepack` (npm + pnpm both honor it). Exits non-zero on any
+ * missing required file.
+ */
+
+import { existsSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT = path.resolve(__dirname, "..");
+
+// Required files — every entry MUST exist in the tarball-source state.
+// Path is relative to package root.
+const REQUIRED_FILES = [
+  // Plugin runtime — built artifacts
+  "dist/index.js",
+  "dist/index.d.ts",
+  "dist/runtime-api.js",
+  "dist/api.js",
+  "dist/openclaw.plugin.json",
+
+  // Installer — bin scripts that map to the package's `bin` entries
+  "installer/bin/install.mjs",
+  "installer/bin/uninstall.mjs",
+  "installer/bin/verify.mjs",
+
+  // Installer libs — sourced by the bin scripts
+  "installer/lib/apply-patch.mjs",
+  "installer/lib/host-fingerprint.mjs",
+  "installer/lib/install-lock.mjs",
+  "installer/lib/locate-host.mjs",
+  "installer/lib/manifest.mjs",
+
+  // Installer plan + patches — without these the installer is a no-op
+  "installer/patch-plan.json",
+
+  // Surface metadata
+  "openclaw.plugin.json",
+  "package.json",
+  "README.md",
+  "LICENSE",
+];
+
+// Required directories — must exist + be non-empty
+const REQUIRED_NON_EMPTY_DIRS = [
+  "installer/patches/ui/anchor-patches",
+  "installer/patches/ui/new-files",
+  "installer/patches/core",
+];
+
+const failures = [];
+
+for (const rel of REQUIRED_FILES) {
+  const p = path.join(ROOT, rel);
+  if (!existsSync(p)) {
+    failures.push(`missing required file: ${rel}`);
+    continue;
+  }
+  const st = statSync(p);
+  if (!st.isFile()) {
+    failures.push(`expected file but found ${st.isDirectory() ? "directory" : "other"}: ${rel}`);
+    continue;
+  }
+  if (st.size === 0) {
+    failures.push(`required file is empty (likely interrupted build): ${rel}`);
+    continue;
+  }
+}
+
+for (const rel of REQUIRED_NON_EMPTY_DIRS) {
+  const p = path.join(ROOT, rel);
+  if (!existsSync(p)) {
+    failures.push(`missing required directory: ${rel}`);
+    continue;
+  }
+  const st = statSync(p);
+  if (!st.isDirectory()) {
+    failures.push(`expected directory: ${rel}`);
+    continue;
+  }
+  // Quick non-empty check via readdirSync
+  const fs = await import("node:fs");
+  const entries = fs.readdirSync(p);
+  if (entries.length === 0) {
+    failures.push(`required directory is empty: ${rel}`);
+    continue;
+  }
+}
+
+// Sanity-check the manifest contents (catches version drift between
+// package.json and the installer's expectedHostVersion).
+try {
+  const pkg = JSON.parse(readFileSync(path.join(ROOT, "package.json"), "utf8"));
+  const plan = JSON.parse(readFileSync(path.join(ROOT, "installer/patch-plan.json"), "utf8"));
+  if (!plan.expectedHostVersion) {
+    failures.push("installer/patch-plan.json missing expectedHostVersion");
+  }
+  if (!Array.isArray(plan.patches) || plan.patches.length === 0) {
+    failures.push("installer/patch-plan.json patches[] is missing or empty");
+  }
+  if (!pkg.bin || Object.keys(pkg.bin).length === 0) {
+    failures.push("package.json bin entry is missing");
+  }
+  // Verify each bin entry's target file exists.
+  for (const [cmd, rel] of Object.entries(pkg.bin ?? {})) {
+    const p = path.join(ROOT, rel);
+    if (!existsSync(p)) failures.push(`bin "${cmd}" → ${rel} does not exist`);
+  }
+} catch (err) {
+  failures.push(`failed to validate manifests: ${err.message}`);
+}
+
+if (failures.length > 0) {
+  console.error("\nprepack tarball-shape check FAILED:");
+  for (const f of failures) console.error(`  - ${f}`);
+  console.error(
+    `\nThe tarball would publish a broken release. Build first (\`pnpm build\`),` +
+      ` then retry. See scripts/check-tarball-shape.mjs for the required surface.\n`,
+  );
+  process.exit(1);
+}
+
+console.log("prepack tarball-shape check OK:");
+console.log(`  ${REQUIRED_FILES.length} required files present`);
+console.log(`  ${REQUIRED_NON_EMPTY_DIRS.length} required directories non-empty`);
+console.log(`  bin entries point at existing files`);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "strict": true,
     "noImplicitAny": true,
     "strictNullChecks": true,
+    "noEmitOnError": true,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
## What this PR does

Fixes two release-blocker bugs that would have produced a broken first npm release:

- **#28** — installer was missing from \`files\` field. Tarball would have shipped with no \`installer/\` and no \`bin\` entries. \`npm install -g @electricsheephq/smarter-claw\` would have given users a plugin runtime they couldn't activate.
- **#29** — no pre-pack gate that asserts the tarball has the full required surface. \`tsconfig.json\` was missing \`noEmitOnError: true\`, so a typecheck warning could leave a partial \`dist/\`.

## Why

Phase C of the release-process plan. Both blockers are gating v0.2.0-beta. Combined into one PR because they're tightly coupled (publish-correctness).

Closes #28
Closes #29

## Risk

- [ ] Pure refactor (no behavior change)
- [ ] Bug fix (existing tests now pass that didn't before)
- [ ] New feature (new behavior; new tests added)
- [x] Installer patch (modifies host source — needs \`installer-roundtrip\` green)
- [x] Schema change (touches \`openclaw.plugin.json\` or \`SmarterClawSessionState\`) — actually \`package.json\` schema; closer to BC concern
- [ ] Release-process change

Calling out the BC concern: adding \`bin\` entries means \`npm install -g @electricsheephq/smarter-claw\` will now register \`smarter-claw-install\`, \`smarter-claw-uninstall\`, \`smarter-claw-verify\` as global CLI commands. If a user already has those names mapped, this collides. Acceptable risk since the package has never been published.

## Validation

- [x] \`pnpm build\` clean
- [x] \`pnpm test --run\` green (563 passing | 1 skipped — unchanged)
- [x] \`npm pack --dry-run\` includes the installer (190 files / 253 kB)
- [x] \`scripts/check-tarball-shape.mjs\` passes
- [x] check-tarball-shape correctly fails when a required file is missing (manual repro)

## Docs

- [ ] README updated — not needed; install instructions in README already reference \`smarter-claw-install\` semantics, which now actually exist
- [x] No new config knobs added
- [x] \`RELEASING.md\` not affected (the prepack gate slots in transparently before any \`npm publish\`)

## Backward compatibility

No public surface change for existing consumers (the package has never been published; this is the prep for the first publish).

## Notes for reviewer

- The 4 \`!dist/**/...\` exclusion patterns in the old \`files\` array were dead — \`tsconfig.json\` already excludes tests from the dist build, so there were no test artifacts to exclude. Removed.
- The \`prepack\` hook runs on \`pnpm pack\` and \`npm pack\` and \`npm publish\`, so the gate fires at every legitimate release moment.