### PR TITLE
fix(installer): #22 atomic manifest write

### DIFF
--- a/installer/bin/install.mjs
+++ b/installer/bin/install.mjs
@@ -43,6 +43,7 @@ import {
   manifestPathFor,
   newManifest,
   readManifest,
+  sweepStaleTempManifests,
   writeManifest,
   writeManifestBackup,
 } from "../lib/manifest.mjs";
@@ -106,6 +107,10 @@ async function main() {
   // via the cleanup handlers wired in install-lock.mjs.
   const releaseLock = acquireInstallLock(hostPath);
   try {
+    // Best-effort cleanup of stale temp files left by a previous
+    // crashed writeJsonAtomic call (#22). Safe — only matches our
+    // exact temp-name pattern.
+    sweepStaleTempManifests(hostPath);
     await runInstall({ args, hostPath, hostVersion });
   } finally {
     releaseLock();

--- a/installer/lib/manifest.mjs
+++ b/installer/lib/manifest.mjs
@@ -37,8 +37,19 @@
  * }
  */
 
-import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import {
+  closeSync,
+  existsSync,
+  fsyncSync,
+  openSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  unlinkSync,
+  writeSync,
+} from "node:fs";
 import path from "node:path";
+import { randomBytes } from "node:crypto";
 
 const MANIFEST_FILENAME = ".smarter-claw-install-manifest.json";
 const MANIFEST_BACKUP_FILENAME = ".smarter-claw-install-manifest.backup.json";
@@ -52,6 +63,102 @@ export function manifestBackupPathFor(hostPath) {
 }
 
 /**
+ * Atomically write a JSON file via temp-then-rename. POSIX rename(2) is
+ * atomic on the same filesystem — readers either see the OLD complete
+ * file or the NEW complete file, never a half-written state.
+ *
+ * Sequence:
+ *   1. Create a unique temp file in the SAME directory as the target
+ *      (must be same filesystem so rename(2) is atomic).
+ *   2. Write the JSON + fsync the file descriptor (forces kernel to
+ *      flush write to disk before we proceed; protects against power
+ *      loss between the write and the rename).
+ *   3. Rename the temp over the target atomically.
+ *   4. Best-effort fsync the parent directory so the rename itself is
+ *      durable on disk (paranoid; mostly relevant on power-loss
+ *      scenarios). Failure here is logged but doesn't roll back since
+ *      the rename has already succeeded from any reader's perspective.
+ *
+ * On crash mid-write: the temp file may be left orphaned (named
+ * `.smarter-claw-install-manifest.json.NNN.tmp` next to the real
+ * manifest). Cleanup helper available below; install.mjs sweeps stale
+ * temps at startup as belt-and-suspenders.
+ *
+ * Closes #22.
+ */
+function writeJsonAtomic(targetPath, value) {
+  const dir = path.dirname(targetPath);
+  const baseName = path.basename(targetPath);
+  // 8 bytes of randomness keeps temp filenames unique per-process and
+  // collision-resistant across concurrent installers (which the lock
+  // ALSO prevents, but defense-in-depth).
+  const suffix = randomBytes(4).toString("hex");
+  const tempPath = path.join(dir, `${baseName}.${process.pid}.${suffix}.tmp`);
+  const body = JSON.stringify(value, null, 2) + "\n";
+  let fd;
+  try {
+    fd = openSync(tempPath, "wx", 0o600);
+    writeSync(fd, body, 0, "utf8");
+    fsyncSync(fd);
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+  }
+  renameSync(tempPath, targetPath);
+  // Parent-directory fsync so the rename itself is durable. Best-
+  // effort: not all platforms support fsync on directory fds (Windows
+  // throws EISDIR; opening the dir read-only on Linux works). Swallow
+  // failures — at this point the rename has already succeeded and
+  // reads will see the new file.
+  let dirFd;
+  try {
+    dirFd = openSync(dir, "r");
+    fsyncSync(dirFd);
+  } catch {
+    // Acceptable: parent-dir fsync is hardening, not correctness.
+  } finally {
+    if (dirFd !== undefined) {
+      try {
+        closeSync(dirFd);
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+}
+
+/**
+ * Sweep orphaned temp files left by previous interrupted writeJsonAtomic
+ * calls. Safe to call any time; only removes files matching our exact
+ * temp-name pattern (`.smarter-claw-install-manifest.json.<pid>.<rand>.tmp`
+ * + the `.backup.json` variant). Used by install.mjs at startup so a
+ * previous crash doesn't leave the host directory polluted.
+ */
+export function sweepStaleTempManifests(hostPath) {
+  const fs = readdirSafe(hostPath);
+  if (!fs) return;
+  const re = new RegExp(
+    `^(${MANIFEST_FILENAME.replace(/\./g, "\\.")}|${MANIFEST_BACKUP_FILENAME.replace(/\./g, "\\.")})\\.\\d+\\.[0-9a-f]+\\.tmp$`,
+  );
+  for (const entry of fs) {
+    if (!re.test(entry)) continue;
+    try {
+      unlinkSync(path.join(hostPath, entry));
+    } catch {
+      // Tolerate failure — sweep is best-effort.
+    }
+  }
+}
+
+function readdirSafe(dir) {
+  if (!existsSync(dir)) return null;
+  try {
+    return readdirSync(dir);
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Atomically write the manifest backup. Used by `--force` reinstall to
  * preserve a recovery file in case the new install fails partway through.
  * The backup is the verbatim PRE-WIPE manifest so a user can manually
@@ -60,7 +167,7 @@ export function manifestBackupPathFor(hostPath) {
  */
 export function writeManifestBackup(hostPath, manifest) {
   const p = manifestBackupPathFor(hostPath);
-  writeFileSync(p, JSON.stringify(manifest, null, 2) + "\n", "utf8");
+  writeJsonAtomic(p, manifest);
   return p;
 }
 
@@ -87,7 +194,7 @@ export function readManifest(hostPath) {
 
 export function writeManifest(hostPath, manifest) {
   const p = manifestPathFor(hostPath);
-  writeFileSync(p, JSON.stringify(manifest, null, 2) + "\n", "utf8");
+  writeJsonAtomic(p, manifest);
 }
 
 export function deleteManifest(hostPath) {


### PR DESCRIPTION
## What this PR does

Closes blocker **#22** — \`writeManifest\` was open-write-close, vulnerable to:
- Concurrent reader (e.g., \`verify.mjs\` in parallel) seeing a truncated file mid-write
- Power loss / process kill between truncate and write leaving a permanently-corrupt manifest

Fix: standard atomic-write pattern. Temp file + fsync + atomic rename.

## Why

Phase C blocker for v0.2.0-beta. Closes #22.

## Risk

- [ ] Pure refactor
- [x] Bug fix (concurrent-reader race + crash durability)
- [ ] New feature
- [x] Installer patch (modifies installer; needs \`installer-roundtrip\` green)
- [ ] Schema change
- [ ] Release-process change

## Validation

- [x] \`pnpm build\` clean
- [x] \`pnpm test --run\` green (563 passing | 1 skipped, unchanged baseline)
- [x] Functional smoke: write v1 → readback v1; atomic-replace with v2 → readback v2; no \`.tmp\` files leak; \`sweepStaleTempManifests\` removes a faux-stale temp without touching the real manifest
- [x] CI \`installer-roundtrip\` will exercise the full apply/verify/uninstall against the patched openclaw worktree

## Backward compatibility

No public-API change. The manifest's on-disk schema is unchanged. Pre-existing installs read identically. The new \`sweepStaleTempManifests\` only removes files matching our exact temp-name pattern (\`.smarter-claw-install-manifest.json.<pid>.<rand>.tmp\` and the \`.backup.json\` variant) — never touches user files.

## Notes for reviewer

- \`fsync\` of the parent directory is a \"best-effort\" paranoia step (durability of the rename itself across power loss). Some platforms (Windows) reject dir-fsync with EISDIR; we swallow that error rather than fail the install.
- Temp-file naming includes \`process.pid + 8 hex chars\` for collision-resistance across concurrent installers (which the lock ALSO prevents — defense in depth).
- File mode \`0o600\` on the temp is intentional — the manifest contains paths into the user's filesystem and should not be world-readable.