### PR TITLE
license: relicense to PolyForm Noncommercial 1.0.0 + add TRADEMARK.md

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,133 @@
+Required Notice: Copyright 2026 Electric Sheep HQ (https://github.com/electricsheephq/Smarter-Claw)
+
+# PolyForm Noncommercial License 1.0.0
+
+<https://polyformproject.org/licenses/noncommercial/1.0.0>
+
+## Acceptance
+
+In order to get any license under these terms, you must agree
+to them as both strict obligations and conditions to all
+your licenses.
+
+## Copyright License
+
+The licensor grants you a copyright license for the
+software to do everything you might do with the software
+that would otherwise infringe the licensor's copyright
+in it for any permitted purpose.  However, you may
+only distribute the software according to [Distribution
+License](#distribution-license) and make changes or new works
+based on the software according to [Changes and New Works
+License](#changes-and-new-works-license).
+
+## Distribution License
+
+The licensor grants you an additional copyright license
+to distribute copies of the software.  Your license
+to distribute covers distributing the software with
+changes and new works permitted by [Changes and New Works
+License](#changes-and-new-works-license).
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of
+the software from you also gets a copy of these terms or the
+URL for them above, as well as copies of any plain-text lines
+beginning with `Required Notice:` that the licensor provided
+with the software.  For example:
+
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to
+make changes and new works based on the software for any
+permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that
+covers patent claims the licensor can license, or becomes able
+to license, that you would infringe by using the software.
+
+## Noncommercial Purposes
+
+Any noncommercial purpose is a permitted purpose.
+
+## Personal Uses
+
+Personal use for research, experiment, and testing for
+the benefit of public knowledge, personal study, private
+entertainment, hobby projects, amateur pursuits, or religious
+observance, without any anticipated commercial application,
+is use for a permitted purpose.
+
+## Noncommercial Organizations
+
+Use by any charitable organization, educational institution,
+public research organization, public safety or health
+organization, environmental protection organization,
+or government institution is use for a permitted purpose
+regardless of the source of funding or obligations resulting
+from the funding.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the
+law. These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of
+your licenses to anyone else, or prevent the licensor from
+granting licenses to anyone else.  These terms do not imply
+any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or
+contributes to infringement of any patent, your patent license
+for the software granted under these terms ends immediately. If
+your company makes such a claim, your patent license ends
+immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have
+violated any of these terms, or done anything with the software
+not covered by your licenses, your licenses can nonetheless
+continue if you come into full compliance with these terms,
+and take practical steps to correct past violations, within
+32 days of receiving notice.  Otherwise, all your licenses
+end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without
+any warranty or condition, and the licensor will not be liable
+to you for any damages arising out of these terms or the use
+or nature of the software, under any kind of legal claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these
+terms, and the **software** is the software the licensor makes
+available under these terms.
+
+**You** refers to the individual or entity agreeing to these
+terms.
+
+**Your company** is any legal entity, sole proprietorship,
+or other kind of organization that you work for, plus all
+organizations that have control over, are under the control of,
+or are under common control with that organization.  **Control**
+means ownership of substantially all the assets of an entity,
+or the power to direct its management and policies by vote,
+contract, or otherwise.  Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the
+software under these terms.
+
+**Use** means anything you do with the software requiring one
+of your licenses.

--- a/README.md
+++ b/README.md
@@ -237,4 +237,8 @@ All non-blocker work is in [open issues](https://github.com/electricsheephq/Smar
 
 ## License
 
-[MIT](./LICENSE) © 2026 Electric Sheep HQ
+[PolyForm Noncommercial 1.0.0](./LICENSE) © 2026 Electric Sheep HQ.
+
+**TL;DR**: free for noncommercial use — personal, hobby, research, education, public-interest, government. Commercial use (integrating Smarter-Claw into a paid product, hosted service, internal tooling at a for-profit company, or anything else where you make money from it) requires a separate paid commercial license. Open an issue at https://github.com/electricsheephq/Smarter-Claw/issues with the subject `[commercial]` to start that conversation.
+
+The name "Smarter Claw" is a trademark of Electric Sheep HQ — see [TRADEMARK.md](./TRADEMARK.md) for what you can and can't do with the name (you can fork the code freely under the license; you just can't ship the fork under the same or a confusingly similar name).

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -1,0 +1,39 @@
+# Trademark Policy
+
+The names **"Smarter Claw"**, **"Smarter-Claw"**, and **"@electricsheephq/smarter-claw"** — along with the project logo and any associated branding — are trademarks of Electric Sheep HQ.
+
+## What this means
+
+The [LICENSE](./LICENSE) file (PolyForm Noncommercial 1.0.0) governs your rights to **use, copy, modify, and distribute the software**. This document is separate — it governs your rights to **use the name**.
+
+A software license (including PolyForm Noncommercial 1.0.0, MIT, Apache 2.0, GPL, and most others) governs copyright and patent rights. It does **not** grant trademark rights. This is a deliberate, well-established distinction in open-source licensing — the FSF, OSI, Apache Foundation, and Mozilla all maintain separate trademark policies for the same reason.
+
+## You MAY (without seeking permission)
+
+- **Use the names descriptively in technical writing** — e.g., "compatible with Smarter Claw", "ported from Smarter-Claw", "this plugin extends @electricsheephq/smarter-claw".
+- **Refer to the unmodified upstream package** by its npm name (`@electricsheephq/smarter-claw`).
+- **Distribute unmodified copies of the software** with the original name and the LICENSE file attached.
+- **Link to the project** at https://github.com/electricsheephq/Smarter-Claw.
+- **Contribute to the project** under the standard GitHub fork-and-PR flow — your fork's repository name may include "Smarter-Claw" while it is intended as a contribution back upstream.
+
+## You MAY NOT (without written permission from Electric Sheep HQ)
+
+- **Brand a fork, derivative, or substantially-modified version** of the software using the names "Smarter Claw", "Smarter-Claw", "@electricsheephq/smarter-claw", or any name confusingly similar (including but not limited to "SmarterClaw", "Smartr Claw", "Smarter Talon", "Sharper Claw", "Smarter Claw Pro", etc.). Pick a different name for your derivative.
+- **Publish a package to npm, PyPI, or any other package registry** under a name that uses the trademarks above or is confusingly similar.
+- **Imply endorsement, sponsorship, or affiliation** with Electric Sheep HQ that does not exist.
+- **Use the project logo** — or a logo confusingly similar — on a fork, derivative, or any product that is not the official upstream Smarter Claw.
+
+## Why this policy exists
+
+A common failure mode in open-source ecosystems is the "fork-and-rebrand-with-similar-name" pattern: someone takes the upstream code, ships a modified version under the same or near-identical name, and confuses the user community about which is "the real" project. This is a problem regardless of whether the fork is itself open-source or proprietary. Worst-case, it lets a third party ride on the upstream's reputation while shipping changes the upstream did not make and does not endorse.
+
+This document makes the trademark stance explicit so there is no ambiguity. If you want to ship a derivative, you are welcome to — under a different name. If you want to commercialize the original software, see [LICENSE](./LICENSE) (the noncommercial license requires a separate paid commercial agreement for that case).
+
+## Requesting permission
+
+If you want to use the name for any of the prohibited cases above — including legitimate reasons we may not have anticipated (e.g., academic citation, a "best of" comparison post, a third-party plugin clearly named as such) — please open an issue at https://github.com/electricsheephq/Smarter-Claw/issues with the subject `[trademark]` and a description of your intended use. Most reasonable requests are granted; we just want to know.
+
+## Contact
+
+- GitHub: https://github.com/electricsheephq/Smarter-Claw
+- Issues: https://github.com/electricsheephq/Smarter-Claw/issues

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "gpt-5",
     "smarter-claw"
   ],
-  "license": "MIT",
+  "license": "SEE LICENSE IN LICENSE",
   "repository": {
     "type": "git",
     "url": "https://github.com/electricsheephq/Smarter-Claw.git"


### PR DESCRIPTION
## Summary

- Restores LICENSE file (was deleted in 6f2017f, leaving package.json claiming MIT with no LICENSE on disk — inconsistent state).
- Adopts **PolyForm Noncommercial 1.0.0** for the software license.
- Adds **TRADEMARK.md** for the no-rebrand requirement (a separate concern from the software license — licenses govern copyright/patent, not trademark).
- Updates `package.json` license field and README License section.

## Why this license

Operator stated the goal in plain language: free for noncommercial use; paid commercial license required for revenue-generating use; fork-rebrand-and-sell pattern (e.g., taking IE and shipping it under another name for sale) must be prevented.

Surveyed BUSL/FSL/ELv2/SSPL/PolyForm Noncommercial 1.0.0:

| License | Fits goal? | Why / why not |
|---|---|---|
| **PolyForm Noncommercial 1.0.0** | ✅ best fit | Cleanly defines noncommercial = personal/research/hobby/education/government/charity/public-interest. Any commercial use needs a separate license. Authored by professional license drafters (Heather Meeker et al). Recognized SPDX id. Short + readable. |
| BUSL 1.1 | ⚠️ partial | "Source-available now, OSS in N years" — not what we want. We want it noncommercial forever unless paid. |
| FSL (Functional Source License) | ⚠️ partial | Free for production use after a 2-year delay → grants MIT/Apache. We want noncommercial-forever, not delayed-OSS. |
| ELv2 (Elastic License 2.0) | ⚠️ partial | Permits hosted use except as a managed service. Doesn't cleanly forbid all commercial use. |
| SSPL | ⚠️ partial | Targets the SaaS-hosting case specifically; doesn't address "use it inside your own paid product". |

PolyForm Noncommercial 1.0.0 is the closest match — single concept (noncommercial = permitted; everything else needs a license), no carve-outs to leak through, no time-bombs, well-drafted.

## Why TRADEMARK.md exists separately

The "no rebrand" requirement is fundamentally a **trademark** issue, not a license issue. PolyForm-NC, MIT, Apache 2.0, GPL — none of them grant trademark rights. This is a deliberate, well-established split (FSF, OSI, Apache, Mozilla all maintain separate trademark policies for the same reason).

`TRADEMARK.md` makes the stance explicit:
- ✅ Use the name descriptively, fork the code, contribute back.
- ❌ Ship a fork or derivative under the name "Smarter Claw" / "Smarter-Claw" / "@electricsheephq/smarter-claw" or anything confusingly similar without written permission.

This pattern catches the IE-fork-rebrand scenario from two sides:
1. The **license** prevents commercial use without a paid agreement (whether the fork is rebranded or not).
2. The **trademark policy** prevents the rebrand from using the original name (whether commercial or not).

## Files

- `LICENSE` (NEW) — canonical PolyForm Noncommercial 1.0.0 text + Required Notice prepend.
- `TRADEMARK.md` (NEW) — allow/disallow list + contact path.
- `package.json` — `"license": "MIT"` → `"license": "SEE LICENSE IN LICENSE"`.
- `README.md` — License section: TL;DR + commercial-license contact + pointer to TRADEMARK.md.

## Test plan

- [x] `pnpm test --run` → 563 pass / 1 skip (no regressions)
- [x] `node scripts/check-tarball-shape.mjs` → OK (LICENSE present, prepack gate from PR #40 satisfied for future publishes)
- [x] LICENSE text matches canonical .txt at https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Noncommercial-1.0.0.txt verbatim
- [x] Required Notice line is the first non-blank line, per the Notices section's example pattern

## Risks / open questions

- npm publish may print a warning about non-SPDX-canonical license string ("SEE LICENSE IN LICENSE"). Acceptable — npm explicitly documents this pattern for non-OSI licenses. We could switch to the SPDX id `PolyForm-Noncommercial-1.0.0` later if the warning is annoying; SPDX has the id since 3.18 (late 2022).
- TRADEMARK.md is not a legal contract; it's a published policy. Enforcement still requires the trademark holder to actually pursue trademark claims. Acceptable for v0.2.0-beta — register the trademark formally if the project gains commercial traction.

Closes the license-state inconsistency from 6f2017f.