### PR TITLE
feat(plan-mode): P2.3 — widen PlanMode to plan|executing|normal (issue #51 PR 1/8)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -36,10 +36,46 @@
 export const SMARTER_CLAW_PLUGIN_ID = "smarter-claw" as const;
 
 /**
- * Top-level mode for a session. Plan mode means proposed-write actions
- * route through the approval gate; normal mode means writes execute directly.
+ * Top-level mode for a session.
+ *
+ * 3-state union (PR #70071's Phase-2 architectural refactor — recovered
+ * via tracking issue #51):
+ *   - `"plan"`      — designing. Mutation gate ARMED, design-phase
+ *                     nudges fire, agent allowlist enforced.
+ *   - `"executing"` — plan approved, agent acting on the steps.
+ *                     Mutation gate DISARMED (mutations allowed),
+ *                     execution-phase nudges legal at tighter intervals,
+ *                     UI chip stays on the plan-mode entry so the
+ *                     visual state matches the persisted state instead
+ *                     of reverting to "Default" the instant approval
+ *                     lands.
+ *   - `"normal"`    — no plan activity (default; UI chip shows
+ *                     Default/Ask/Accept/Bypass per execSecurity).
+ *
+ * Most consumers only care about `"plan"` vs not-plan and continue to
+ * work correctly with the widened type: `"executing"` is treated like
+ * `"normal"` for mutation gating (mutations allowed). The new value
+ * unlocks:
+ *   - execution-phase nudge crons that fire only during `"executing"`
+ *   - UI chip rendering through the execution phase
+ *   - `plan_mode_status` introspection reporting accurate state
+ *   - `[PLAN_STATUS]` per-turn preamble auto-injection
+ *
+ * Transitions:
+ *   - `enter_plan_mode` tool / `/plan on`            → mode = "plan"
+ *   - approval (`approve` or `edit` action)          → mode = "executing"
+ *   - close-on-complete (all steps done/cancelled)   → mode = "normal"
+ *   - `/plan off`                                     → mode = "normal"
+ *
+ * NOTE: previously this was the 2-state union `"plan" | "normal"`. The
+ * widening conflated two cases the runtime needs to distinguish:
+ * "plan was approved + agent is executing" vs "no plan ever touched
+ * this session". That conflation was the root cause of multiple bugs
+ * Eva debugged in production (chip reverting, missed execution-phase
+ * stalls, autoApprove mis-rendering). See tracking issue #51 for the
+ * full set of follow-up fixes that depend on this widening.
  */
-export type PlanMode = "plan" | "normal";
+export type PlanMode = "plan" | "executing" | "normal";
 
 /**
  * Approval-card state machine. The plugin emits each transition as a debug


### PR DESCRIPTION
## Summary

PR 1 of 8 in the surgical port to recover the executing-state lifecycle work missed because Smarter-Claw was extracted from the wrong openclaw-1 branch. See tracking issue #51 for the full context.

This PR corresponds to openclaw-1 commit \`c50dc08b04\` (Eva, 2026-04-21 — "feat(plan-mode): widen mode to plan|executing|normal + backfill migration").

## Scope

- Widen \`PlanMode\` from \`"plan" | "normal"\` to \`"plan" | "executing" | "normal"\` in \`src/types.ts\`.
- Update the type's docstring with the 3-state lifecycle table + transition diagram.
- No transition logic, no migration, no new behavior. Pure type widening.

## Why this widening matters

The 2-state union collapsed two distinct meanings into "normal":
- (a) "no plan ever touched this session"
- (b) "plan was approved and is mid-execution"

This conflation was the root cause of multiple bugs Eva debugged in production:
- UI chip reverting to "Default" the instant approval lands (live-observed during Eva's MiniMax/David VM session).
- Execution-phase stalls with no nudge mechanism (subagent returns + steps not marked complete).
- \`plan_mode_status\` introspection inaccurate during execution.

The widening doesn't fix those bugs by itself — it unblocks the follow-on PRs (PR 2-7) that wire the new value through.

## Why this is safe today

Existing call sites in plugin source comparing \`planMode === "plan"\` or \`planMode !== "plan"\` continue to work correctly. Each of the 6 sites was checked:

| File:line | Comparison | Behavior with "executing" | Correct? |
|---|---|---|---|
| escalating-retry.ts:378 | \`=== "plan"\` (planModeActive) | false | ✅ planning-only-acks shouldn't fire during execution |
| lifecycle-hooks.ts:55 | \`!== "plan"\` (early return) | early return | ✅ this gate is for design-phase behavior only |
| archetype-hook.ts:85 | \`!== "plan"\` (skip) | skip | ✅ archetypes are for design, not execution |
| slash-command-deps.ts:146 | \`=== "normal"\` (collapse to idle) | NOT collapsed | ✅ executing still has approval context, not idle |
| plan-mode-status-tool.ts:133 | \`=== "plan"\` (inPlanMode) | false | ✅ PR 5 adds the inExecution branch |

## Test plan

- [x] \`pnpm typecheck\` → green
- [x] \`pnpm test --run\` → 563 pass / 1 skip (no regressions)
- [x] All 6 \`planMode === "plan"\` / \`!== "plan"\` call sites visually inspected — each correctly handles "executing" as "not plan" with the right semantics for that site.

## Risk

Minimal — type widening with no behavior changes. Tests prove no regressions in any of the 18 test files.

## What this PR does NOT do

- Does not transition any session to \`mode: "executing"\` (PR 2 / P2.4 does)
- Does not change the mutation gate behavior (PR 3 / P2.5)
- Does not change UI rendering (PR 4 / P2.6)
- Does not add the execution-phase nudge cron (PR 6 / P2.9)
- Does not migrate existing on-disk state (deferred — plugin starts fresh at v0.2.0-dev; Eva's stale v0.1.0 install will be re-installed during Phase D cutover)

Refs #51.