### PR TITLE
feat(plan-mode): P2.4 — approve/edit transitions write mode: executing (issue #51 PR 2/8)

### DIFF
--- a/installer/patches/core/sessions-patch-handler-plan-mode.diff
+++ b/installer/patches/core/sessions-patch-handler-plan-mode.diff
@@ -107,9 +107,18 @@
 +      if (!approvalId) {
 +        return invalid('planApproval action="' + pa.action + '" requires approvalId');
 +      }
++      // Smarter-Claw P2.4 — approve / edit transition writes
++      // `planMode: "executing"` (was: "normal"). The session is no
++      // longer in plan-design but it's also not "no plan activity"
++      // — the agent is now executing the approved steps. The
++      // close-on-complete detector in snapshot-persister fires
++      // `sessions.patch { planMode: "normal" }` when all steps
++      // mark completed/cancelled, which goes through the planMode
++      // branch above and DOES reset planApproval to "idle".
++      // Lifecycle: plan → executing → (close-on-complete) → normal.
 +      const nextSlot: Record<string, unknown> = {
 +        ...slot,
-+        planMode: "normal",
++        planMode: "executing",
 +        planApproval: "approved",
 +        pendingInteraction: undefined,
 +        recentlyApprovedAt: new Date().toISOString(),

--- a/src/approval-state.ts
+++ b/src/approval-state.ts
@@ -89,9 +89,32 @@ export function resolvePlanApproval(
     case "approve":
       // Approve clears feedback AND resets rejectionCount — the user is
       // moving forward, so cycle history is no longer relevant.
+      //
+      // PR #70071 follow-up (P2.4) — transitions to `mode: "executing"`
+      // (was: `mode: "normal"`). The plan was approved and the agent
+      // is now executing the steps; the session is no longer in plan
+      // design but it's also not "no plan activity at all". This
+      // unlocks downstream behavior that depends on knowing the
+      // session is mid-execution:
+      //   - UI chip rendering accurately reflects "plan is active"
+      //     (PR #70071 P2.6)
+      //   - execution-phase nudge crons (PR #70071 P2.9) can fire
+      //     during stalls
+      //   - `plan_mode_status` introspection reports the precise
+      //     state (PR #70071 P2.8)
+      //   - `[PLAN_STATUS]` per-turn preamble auto-injection
+      //     (PR #70071 P2.12b)
+      //
+      // The close-on-complete detector (snapshot-persister.ts
+      // `shouldAutoClosePlan`) continues to fire the
+      // executing → "normal" transition when all steps are
+      // completed/cancelled. Lifecycle: plan → executing →
+      // (close-on-complete) → normal. Mutation gate is unaffected
+      // by the new value (executing passes through like normal —
+      // mutations are allowed once the plan is approved).
       return {
         ...current,
-        mode: "normal",
+        mode: "executing",
         approval: "approved",
         confirmedAt: now,
         updatedAt: now,
@@ -101,9 +124,13 @@ export function resolvePlanApproval(
 
     case "edit":
       // Edit counts as approval — same reset behavior as approve.
+      // Same `mode: "executing"` transition rationale as the approve
+      // case above (see comment block there). Distinguished only by
+      // `approval: "edited"` (vs "approved") for downstream signals
+      // like `postApprovalPermissions.acceptEdits`.
       return {
         ...current,
-        mode: "normal",
+        mode: "executing",
         approval: "edited",
         confirmedAt: now,
         updatedAt: now,

--- a/tests/approval-state.test.ts
+++ b/tests/approval-state.test.ts
@@ -19,17 +19,26 @@ const BASE_STATE: PlanModeSessionState = {
 };
 
 describe("resolvePlanApproval", () => {
-  it("approve transitions to normal mode with approved state", () => {
+  it("approve transitions to executing mode with approved state (P2.4)", () => {
+    // PR #70071 P2.4 — approve no longer flips mode → "normal" (which
+    // conflated "no plan activity" with "plan approved + agent
+    // executing"). New 3-state union: approve → "executing" so the
+    // session retains plan context (title, steps, autoApprove) through
+    // the execution phase. close-on-complete in snapshot-persister
+    // is what eventually transitions executing → "normal".
     const result = resolvePlanApproval(BASE_STATE, "approve");
-    expect(result.mode).toBe("normal");
+    expect(result.mode).toBe("executing");
     expect(result.approval).toBe("approved");
     expect(result.confirmedAt).toBeGreaterThan(0);
     expect(result.feedback).toBeUndefined();
   });
 
-  it("edit transitions to normal mode (user edits count as approval)", () => {
+  it("edit transitions to executing mode (user edits count as approval, P2.4)", () => {
+    // Same `mode: "executing"` rationale as the approve case above;
+    // only the approval field differs ("edited" vs "approved") to
+    // drive the postApprovalPermissions.acceptEdits grant downstream.
     const result = resolvePlanApproval(BASE_STATE, "edit");
-    expect(result.mode).toBe("normal");
+    expect(result.mode).toBe("executing");
     expect(result.approval).toBe("edited");
     expect(result.confirmedAt).toBeGreaterThan(0);
   });
@@ -59,13 +68,16 @@ describe("resolvePlanApproval", () => {
   });
 
   it("ignores stale timeout after approval is already resolved", () => {
+    // Updated for P2.4: post-approval state is now "executing" (was
+    // "normal"). This test is about the terminal-state guard, not
+    // the mode value — both modes pass; "executing" is canonical.
     const approved: PlanModeSessionState = {
       ...BASE_STATE,
       approval: "approved",
-      mode: "normal",
+      mode: "executing",
     };
     const result = resolvePlanApproval(approved, "timeout");
-    expect(result.mode).toBe("normal");
+    expect(result.mode).toBe("executing");
     expect(result.approval).toBe("approved");
   });
 


### PR DESCRIPTION
PR 2/8 of the surgical-port series. Wires the actual approve→executing transition on top of PR #52's type widening. Corresponds to openclaw-1 commit `ade814683d`.

## Changes

1. **`src/approval-state.ts`** — `resolvePlanApproval` for approve/edit now writes `mode: "executing"` instead of `"normal"`.
2. **`installer/patches/core/sessions-patch-handler-plan-mode.diff`** — the host-side approve/edit branch writes `planMode: "executing"` into the plugin's pluginMetadata slot. Wire-protocol validator KEPT as `"plan" | "normal"` (executing is server-derived, not client-acceptable).
3. **`tests/approval-state.test.ts`** — 3 places updated.

## Architectural difference vs openclaw-1

Openclaw-1 P2.4 also split the gateway-side post-approval cleanup into 2 responsibilities (nudge cleanup vs planMode delete). In Smarter-Claw the plugin owns its own state in pluginMetadata rather than having a separate planMode object that gets deleted, so the cleanup-split is implicit. Functional behavior equivalent.

## Test plan

- [x] `pnpm typecheck` → green
- [x] `pnpm test --run` → 563 pass / 1 skip (no regressions)
- [x] Installer patch syntactically valid (will verify via installer-roundtrip CI)

## NOT in this PR

- Mutation gate awareness (PR 3 / P2.5)
- Nudge suppression (PR 3)
- UI chip wiring (PR 4 / P2.6)
- plan_mode_status inExecution surface (PR 5 / P2.8)
- Execution-phase nudge cron (PR 6 / P2.9)

Refs #51.