### PR TITLE
docs(plan-mode): P2.5 — gate awareness doc updates for 3-state PlanMode (issue #51 PR 3/8)

### DIFF
--- a/src/accept-edits-gate.ts
+++ b/src/accept-edits-gate.ts
@@ -45,6 +45,26 @@
  *     prompt layer is ignored or misinterpreted, the gate blocks the
  *     tool call with an instruction to ask the user.
  *
+ * ## Mode applicability (3-state PlanMode awareness, PR #70071 P2.5)
+ *
+ * The acceptEdits permission is granted at approve time and applies
+ * THROUGH the execution phase. The constraint-check gate must
+ * therefore fire during BOTH `mode === "executing"` AND `mode ===
+ * "normal"`, not just "normal" (the post-PR #70071 P2.4 transition
+ * leaves the session in "executing" until close-on-complete fires).
+ *
+ * In Smarter-Claw, this gate is logic-only and the seam decides when
+ * to invoke it. The seam (today: NOT yet integrated into the plugin's
+ * before_tool_call hook in index.ts; tracked separately) reads the
+ * session's `postApprovalPermissions.acceptEdits` flag — that flag is
+ * only set DURING the executing phase and is cleared by close-on-
+ * complete. So the seam's "is acceptEdits granted?" check naturally
+ * scopes the gate to the right window without needing an explicit
+ * mode-comparison guard. (Equivalent in openclaw-1's
+ * pi-tools.before-tool-call.ts:295 widened from `=== "normal"` to
+ * `=== "normal" || === "executing"` per P2.5 commit 077b425966 because
+ * its seam DID hard-code a mode check.)
+ *
  * ┌─────────────────────────────────────────────────────────────────┐
  * │ INSTALLER SEAM:                                                 │
  * │                                                                 │

--- a/src/mutation-gate.ts
+++ b/src/mutation-gate.ts
@@ -427,6 +427,26 @@ export interface ShouldBlockMutationContext {
 }
 
 export function shouldBlockMutation(ctx: ShouldBlockMutationContext): MutationGateResult {
+  // 3-state PlanMode awareness (PR #70071 P2.5 — recovered via tracking
+  // issue #51): `isInPlanMode` returns boolean true ONLY when the
+  // session's plugin-namespaced state has `planMode === "plan"`. Both
+  // `"executing"` and `"normal"` collapse to false here, which is the
+  // correct mutation-gate behavior:
+  //   - mode "plan"      → planMode "plan" → gate ENFORCED (writes blocked)
+  //   - mode "executing" → planMode "normal" → gate NOT enforced
+  //                        (writes allowed; agent is acting on the
+  //                        approved plan)
+  //   - mode "normal"    → planMode "normal" → gate NOT enforced
+  //                        (no plan activity at all)
+  //
+  // Equivalent in openclaw-1's pi-tools.before-tool-call.ts
+  // (commit 077b425966 / P2.5) which special-cases mode === "executing"
+  // to skip the plan-mode block but still report it via the diagnostic
+  // log line. Smarter-Claw's plugin abstraction (the boolean collapse
+  // above) achieves the same functional outcome with no special-casing
+  // needed at the gate level. The `[smarter-claw/before_tool_call]`
+  // diagnostic in index.ts only fires on actual blocks, not on
+  // pass-through, so executing-mode tool calls don't generate noise.
   const planMode: PlanMode = isInPlanMode(ctx.session) ? "plan" : "normal";
   return checkMutationGate(ctx.toolName, planMode, ctx.execCommand);
 }


### PR DESCRIPTION
PR 3/8 — comment-only updates documenting why Smarter-Claw's plugin abstraction (`isInPlanMode` boolean + `postApprovalPermissions` permission scope) already correctly handles 3-state PlanMode without code changes that openclaw-1 needed.

See commit message for the full architectural-delta explanation.

## Test plan

- [x] `pnpm typecheck` → green
- [x] `pnpm test --run` → 563 pass / 1 skip

Refs #51.