### PR TITLE
feat(ui/plan-mode): P2.6 — chip stays on Plan/Plan ⚡ during executing state (issue #51 PR 4/8)

### DIFF
--- a/installer/patches/ui/anchor-patches/ui-src-ui-app-render.ts.diff
+++ b/installer/patches/ui/anchor-patches/ui-src-ui-app-render.ts.diff
@@ -74,7 +74,19 @@
 +                  // Inline minimal copy of resolveCurrentMode's plan-aware
 +                  // logic; the imported helper isn't accessible from this
 +                  // bundling layer without a cycle. Cheap structural check:
-+                  if (activeSession?.planMode?.mode === "plan") {
++                  //
++                  // PR #70071 P2.6 (Smarter-Claw tracking issue #51) —
++                  // `"executing"` state also resolves to the plan / plan-
++                  // auto chip so the post-approve short-circuit catches
++                  // "user picked Plan ⚡ while we're already in executing
++                  // mode" as a no-op (was: the short-circuit missed
++                  // because currentChipMode returned null for executing,
++                  // letting a redundant patch fire on every selector
++                  // re-click during execution).
++                  if (
++                    activeSession?.planMode?.mode === "plan" ||
++                    activeSession?.planMode?.mode === "executing"
++                  ) {
 +                    if (activeSession.planMode.autoApprove === true) {
 +                      return "plan-auto";
 +                    }

--- a/installer/patches/ui/anchor-patches/ui-src-ui-types.ts.diff
+++ b/installer/patches/ui/anchor-patches/ui-src-ui-types.ts.diff
@@ -9,7 +9,12 @@
 +  execSecurity?: "deny" | "allowlist" | "full";
 +  execAsk?: "off" | "on-miss" | "always";
 +  planMode?: {
-+    mode: "plan" | "normal";
++    // PR #70071 P2.6 (Smarter-Claw tracking issue #51) — widened from
++    // `"plan" | "normal"` to include `"executing"` (post-approve, mid-
++    // execution). UI consumers (mode-switcher chip, hydrate, app-
++    // render selector) handle it as plan-equivalent for chip rendering
++    // — see resolveCurrentMode in mode-switcher.ts.
++    mode: "plan" | "executing" | "normal";
 +    approval: "none" | "pending" | "approved" | "edited" | "rejected" | "timed_out";
 +    approvalId?: string;
 +    cycleId?: string;

--- a/installer/patches/ui/new-files/ui/src/ui/chat/mode-switcher.ts
+++ b/installer/patches/ui/new-files/ui/src/ui/chat/mode-switcher.ts
@@ -237,10 +237,30 @@ const CUSTOM_MODE_ICON = html`<svg
 export function resolveCurrentMode(
   execSecurity?: string,
   execAsk?: string,
-  planMode?: "plan" | "normal",
+  // PR #70071 P2.6 (recovered via tracking issue #51) — accept the
+  // 3-state union from the gateway. UI consumers don't get to send
+  // "executing" via the chip (only "plan" or "normal" are user-
+  // selectable); but they MUST recognize "executing" when the gateway
+  // returns it post-approval, otherwise the chip falsely reverts to
+  // "Default" the moment the user approves a plan.
+  planMode?: "plan" | "executing" | "normal",
   planAutoApprove?: boolean,
 ): ModeDefinition {
-  if (planMode === "plan") {
+  // PR #70071 P2.6 — `"executing"` state renders the SAME chip as
+  // `"plan"` (or "Plan ⚡" if autoApprove is set). The user's mental
+  // model is "I'm in plan mode" through both designing the plan AND
+  // watching the agent execute it; the chip should not silently
+  // revert to "Default" the moment the approval lands.
+  //
+  // Pre-P2.6, mode flipped to "normal" on approve which made the chip
+  // immediately revert — confusing because autoApprove was still
+  // armed for the next cycle and the agent was actively executing.
+  // This was the most-confusing part of the broken decision tree per
+  // Eva's live observation during the MiniMax/David VM session.
+  // Now mode stays "executing" (per P2.4) until close-on-complete
+  // deletes planMode entirely; the chip stays on Plan / Plan ⚡
+  // throughout.
+  if (planMode === "plan" || planMode === "executing") {
     // PR-10: prefer the "plan-auto" entry when the session's
     // autoApprove flag is set so the chip surfaces the auto state.
     // Falls back to plain "plan" when the flag is absent so existing


### PR DESCRIPTION
PR 4/8 — wires UI chip rendering through the executing state so it stops falsely reverting to 'Default' the moment a plan is approved. Corresponds to openclaw-1 commit `a368aad2a6`.

## The bug this fixes (Eva's live observation)

Pre-fix: `resolveCurrentMode` and the inline app-render selector logic both compared `planMode === "plan"` only. After PR #53 (P2.4) the approve transition writes `mode: "executing"`, so the chip immediately returned null and reverted to 'Default' — even though autoApprove was still armed for the next cycle and the agent was actively executing the approved plan. "The most-confusing part of the broken decision tree" per Eva's MiniMax/David VM session log.

## Changes

| File | What changed |
|---|---|
| `installer/patches/ui/new-files/ui/src/ui/chat/mode-switcher.ts` | `resolveCurrentMode` param type + branch widened |
| `installer/patches/ui/anchor-patches/ui-src-ui-types.ts.diff` | `GatewaySessionRow.planMode.mode` type widened to 3-state |
| `installer/patches/ui/anchor-patches/ui-src-ui-app-render.ts.diff` | Inline `currentChipMode` short-circuit recognizes `"executing"` |

## What this PR does NOT change

Wire-protocol validator on `sessions.patch { planMode }` continues to accept `"plan" | "normal"` only. `"executing"` is server-derived (set by the approve transition in PR #53), not a client input. Selecting from the chip menu still sends `"plan"` or `"normal"`.

## Test plan

- [x] `pnpm typecheck` → green
- [x] `pnpm test --run` → 563 pass / 1 skip
- [x] CI installer-roundtrip will validate patches apply cleanly

Refs #51.