### PR TITLE
fix(plan-mode): port 3 of 9 Eva bug fixes — allowlist broaden + approve injection text (issue #51 PR 8/8)

### DIFF
--- a/src/approval-state.ts
+++ b/src/approval-state.ts
@@ -194,10 +194,26 @@ export const MAX_CONCURRENT_SUBAGENTS_IN_PLAN_MODE = 1;
  */
 export function buildApprovedPlanInjection(planSteps: string[]): string {
   const stepList = planSteps.map((s, i) => `${i + 1}. ${s}`).join("\n");
+  // PR #70071 follow-up — "check and record status per step" instructions
+  // (issue #51, openclaw-1 commit 37ac8983e6). Without these instructions
+  // the agent does the work but forgets to call update_plan, leaving the
+  // plan stuck in mid-execution forever (Eva's MiniMax/David VM session
+  // log + Baoyu flyer skills failure mode). The instructions are a SOFT
+  // STEER (the agent can still skip update_plan); the close-on-complete
+  // detector in snapshot-persister is the semantic gate that auto-
+  // transitions when all steps are recorded done. But reinforcing the
+  // instruction in the approval text closes the common-case stall where
+  // the agent finishes sub-operations and goes idle without recording
+  // state.
   return (
     "[PLAN_DECISION]: approved\n\n" +
     "The user has approved the following plan. Execute it now without re-planning. " +
-    "If a step is no longer viable, mark it cancelled and add a revised step.\n\n" +
+    "Check and record the status for each step as you go. After each step " +
+    "finishes (successful or not), call `update_plan` to mark that step as " +
+    'done. The plan is not done until every step is recorded as completed ' +
+    "or cancelled. If a step is no longer viable, mark it cancelled and " +
+    "add a revised step.\n\n" +
+    "The approved plan:\n\n" +
     stepList
   );
 }

--- a/src/mutation-gate.ts
+++ b/src/mutation-gate.ts
@@ -120,6 +120,37 @@ const PLAN_MODE_ALLOWED_TOOLS = new Set([
   // and the agent shouldn't have to learn they're allowed.
   "sessions_list",
   "sessions_history",
+  // PR #70071 follow-up — Test 4a UX gap fix (issue #51, openclaw-1
+  // commit 7be42489f5). `agents_list` is a read-only directory of
+  // registered agents (used by sessions_spawn to discover valid
+  // `agentId` values). When sessions_spawn validation rejects a
+  // malformed agentId, its error message tells the agent to "use
+  // agents_list to discover valid targets" — but agents_list was
+  // blocked by the default-deny gate, creating a catch-22 (live-
+  // reproduced 2026-04-21 in Eva's Test 4a session: she guessed
+  // "openai-codex/gpt-5.4", got rejected, tried agents_list, got
+  // "Tool not in plan-mode allowlist", had to submit her plan with
+  // a fabricated subagent result). This is purely metadata read; no
+  // workspace mutation.
+  "agents_list",
+  // PR #70071 follow-up — broader allowlist audit (openclaw-1
+  // commit 7be42489f5). Pure-read analytical tools that an agent
+  // investigating visual evidence in plan mode commonly needs. Both
+  // feed media to a vision/document model and return text — no
+  // workspace state touched. Without these, an agent has to exit
+  // plan mode to inspect a screenshot or a referenced PDF, which
+  // defeats the "investigation phase" purpose.
+  "image",
+  "pdf",
+  // PR #70071 follow-up — live-blocked catch-22 audit (openclaw-1
+  // commit 3d6cbda15e). Pure-read research tools that the
+  // mutation-gate was incorrectly blocking. `sessions_yield` is the
+  // ack-only research mechanism (parallel to sessions_spawn but
+  // doesn't mutate); `lcm_grep` and `lcm_expand_query` are
+  // memory-search reads on the lossless-claw memory system.
+  "sessions_yield",
+  "lcm_grep",
+  "lcm_expand_query",
 ]);
 
 /**
@@ -151,6 +182,36 @@ const READ_ONLY_EXEC_PREFIXES = [
   "whoami",
   "hostname",
   "uname",
+  // PR #70071 follow-up — broader allowlist audit (openclaw-1 commit
+  // 7be42489f5). Structured-data + log analysis utilities. The
+  // shell-operator regex below blocks pipes (`|`), so an agent
+  // investigating logs cannot do `tail file | grep pattern`. These
+  // additions let the agent do the same work via single-command
+  // flags (`grep -A 5 pattern file`, `jq '.field' file.json`, etc.)
+  // without needing pipes. All are pure-read with no documented
+  // write modes.
+  "sort", // log line ordering
+  "uniq", // deduplication of grep output
+  "cut", // field extraction from structured logs
+  "diff", // file/output comparison (no -i / write modes)
+  "tree", // directory tree visualization
+  "jq", // JSON query (critical for structured logs / config files)
+  "column", // tabular output formatting
+  // System introspection — pure read, useful for diagnostics.
+  // Excluded per audit: `ps`, `lsof`, `top`, `dmesg`, `groups`,
+  // `last` (security-sensitive system-info exposure).
+  "env", // env var listing (not the wrapper form `env CMD ...` —
+  // that's stripped by EXEC_WRAPPER_TOKENS above)
+  "uptime", // load average + boot time
+  "date", // wall clock + timezone
+  "id", // current uid/gid
+  "nproc", // CPU count (Linux)
+  "arch", // CPU architecture
+  "vm_stat", // memory diagnostics (macOS)
+  // Excluded: `awk` and `sed` even with -n flag — both have write
+  // modes (`sed -i` is destructive) and the prefix-match logic can't
+  // reliably distinguish read-only invocations from destructive
+  // ones. Agent should use `grep`/`cut`/`jq` for the same workflows.
 ];
 
 /**

--- a/tests/approval-state.test.ts
+++ b/tests/approval-state.test.ts
@@ -148,9 +148,21 @@ describe("buildApprovedPlanInjection", () => {
     expect(result).toBe(
       "[PLAN_DECISION]: approved\n\n" +
         "The user has approved the following plan. Execute it now without re-planning. " +
-        "If a step is no longer viable, mark it cancelled and add a revised step.\n\n" +
+        "Check and record the status for each step as you go. After each step " +
+        "finishes (successful or not), call `update_plan` to mark that step as " +
+        'done. The plan is not done until every step is recorded as completed ' +
+        "or cancelled. If a step is no longer viable, mark it cancelled and " +
+        "add a revised step.\n\n" +
+        "The approved plan:\n\n" +
         "1. first\n2. second",
     );
+  });
+
+  it("includes 'check and record' instructions (P2 — Eva's MiniMax/David fix)", () => {
+    const result = buildApprovedPlanInjection(["x"]);
+    expect(result).toMatch(/check and record/i);
+    expect(result).toContain("update_plan");
+    expect(result).toMatch(/not done until every step is recorded/i);
   });
 });
 


### PR DESCRIPTION
Final PR of the surgical-port series. Ports the plugin-source-applicable subset of the 9 bug-fix commits Eva debugged in production but that were missing from `feat/plan-channel-parity-eva-stable`.

## Ported (3 of 9)

1. **Allowlist broaden** (openclaw-1 `7be42489f5` + `3d6cbda15e`) — `mutation-gate.ts`: 6 new allowlisted tools (`agents_list`, `image`, `pdf`, `sessions_yield`, `lcm_grep`, `lcm_expand_query`) + 14 new read-only exec prefixes (`sort`/`uniq`/`cut`/`diff`/`tree`/`jq`/`column`/`env`/`uptime`/`date`/`id`/`nproc`/`arch`/`vm_stat`).

   Critical: `agents_list` closes Eva's live-reproduced Test 4a catch-22 where `sessions_spawn` rejected her guess and told her to use `agents_list`, but `agents_list` was also blocked.

2. **Approved-plan injection text** (openclaw-1 `37ac8983e6`) — `approval-state.ts:buildApprovedPlanInjection`: added explicit "check and record status per step" + "call update_plan to mark each step done" + "plan is not done until every step is recorded" instructions. Closes Eva's MiniMax/David VM session failure mode (agent did the work but never recorded it).

## NOT ported in this PR (6 deferred to v0.3.0)

| # | Commit | Why |
|---|---|---|
| 2 | `7b3fc67286` | persist race fix touches host's plan-snapshot-persister.ts; plugin has its own |
| 4 | `12d31b4b31` | UI selector touches host's app.ts (NOT in installer patch surface) |
| 5 | `08217910b6` | autoApprove suppression touches app.ts (NEW patch needed) |
| 6 | `14b48bb5d8` | auto-mode resume touches handlers.tools.ts (NEW patch needed) |
| 7 | `ade5d0609a` | callback threading through embedded-runner (NEW patch needed) |
| 9 | `5e3c58e147` | diagnostic logging — plugin already has equivalent via logPlanModeDebug |

These are tracked in #51 as v0.3.0 hardening work. They don't block Phase D beta cutover — they're either architectural-difference items or require deeper integration that should land post-soak.

## Test plan

- [x] `pnpm typecheck` → green
- [x] `pnpm test --run` → 564 pass / 1 skip (1 new test added, no regressions)

## Surgical-port summary

| PR | Scope | Status |
|---|---|---|
| #52 | P2.3 — widen PlanMode to 3-state | ✅ merged |
| #53 | P2.4 — approve→executing transition | ✅ merged |
| #54 | P2.5 — gate awareness doc updates | ✅ merged |
| #55 | P2.6 — UI chip wiring | ✅ merged |
| #56 | P2.8 — plan_mode_status surfaces inExecution | ✅ merged |
| #57 | P2.9 — execution-phase nudge cron module | ✅ merged |
| #58 | P2.12b — [PLAN_STATUS] preamble | ✅ merged |
| this | 3 of 9 Eva bug fixes | this PR |

Refs #51.