### PR TITLE
fix(cron): payload.kind: "agentTurn" + message field for v2026.4.23-beta.5 schema

### DIFF
--- a/src/lifecycle-hooks.ts
+++ b/src/lifecycle-hooks.ts
@@ -252,6 +252,16 @@ export async function handleAgentEnd(
 // Loose local copy of the host's PluginHookGatewayCronCreateInput so
 // we don't have to depend on the host's typed exports (which differ
 // across openclaw publishes).
+//
+// openclaw v2026.4.23-beta.5 tightened the cron payload schema. The
+// permitted shapes are now:
+//   - `{ kind: "systemEvent"; text: string }` (broadcast, no session)
+//   - `{ kind: "agentTurn"; message: string; ... }` (session-targeted)
+// Our payload uses the `agentTurn` shape because the cron is
+// session-targeted (sessionTarget: "current"). Earlier openclaw
+// versions accepted `kind: "synthetic-user-message"` + `text` which
+// the host now rejects with "isolated/current/session cron jobs
+// require payload.kind=\"agentTurn\"".
 type CronCreateInput = {
   name: string;
   description: string;
@@ -259,7 +269,7 @@ type CronCreateInput = {
   schedule: { kind: string; expr: string; tz?: string };
   sessionTarget: string;
   wakeMode: string;
-  payload: { kind: string; text?: string };
+  payload: { kind: "agentTurn"; message: string } | { kind: "systemEvent"; text: string };
 };
 
 export async function handleGatewayStart(ctx: {
@@ -298,9 +308,19 @@ export async function handleGatewayStart(ctx: {
       },
       sessionTarget: "current",
       wakeMode: "auto",
+      // openclaw v2026.4.23-beta.5 tightened the cron payload schema:
+      // session-targeted crons now require `payload.kind: "agentTurn"`
+      // and use the field name `message` (not `text`). Pre-fix this
+      // registration silently failed at gateway_start with
+      // `[smarter-claw/tool_call] gateway_start:cron-failed details=
+      // "isolated/current/session cron jobs require payload.kind=
+      // \"agentTurn\""` — verified live during Eva's v2026.4.23-beta.5
+      // cutover. The other valid kind is `systemEvent` (broadcast,
+      // no session target); `agentTurn` is the right shape for our
+      // per-session plan-mode nudge.
       payload: {
-        kind: "synthetic-user-message",
-        text:
+        kind: "agentTurn",
+        message:
           "[PLAN_NUDGE]: This session is in plan mode but has been idle. Either (a) continue " +
           "investigation with a read-only tool, (b) submit the proposal via exit_plan_mode, or (c) " +
           "exit plan mode if the work is complete.",


### PR DESCRIPTION
Caught live during Eva's v2026.4.23-beta.5 cutover smoke test. openclaw v2026.4.23-beta.5 tightened the cron payload schema:

- Session-targeted crons require `payload.kind: "agentTurn"` (was: `"synthetic-user-message"`)
- Field name is `message` (was: `text`)

Pre-fix log line:
```
[smarter-claw/tool_call] gateway_start:cron-failed
  details="isolated/current/session cron jobs require payload.kind=\"agentTurn\""
```

Result: plan-nudge cron silently failed to register, leaving plan-mode sessions with no idle-stall recovery.

## Changes

`src/lifecycle-hooks.ts`:
- `handleGatewayStart` cron payload updated to `{ kind: "agentTurn", message: "..." }`
- `CronCreateInput` local type narrowed to the discriminated union the host now enforces (`agentTurn` | `systemEvent`)

## Test plan

- [x] `pnpm typecheck` → green
- [x] `pnpm test --run` → 564 pass / 1 skip
- [x] Will be live-verified on Eva's gateway post-deploy: `gateway_start:cron-failed` should be replaced by `gateway_start:cron-registered`

## Backward compat

Smarter-Claw's pinned baseline is v2026.4.23-beta.5 (via PR #60). Older openclaw versions are out of support.