### PR TITLE
fix(cron): schedule shape — kind: "every" + everyMs for v2026.4.23-beta.5 schema

### DIFF
--- a/src/lifecycle-hooks.ts
+++ b/src/lifecycle-hooks.ts
@@ -266,7 +266,18 @@ type CronCreateInput = {
   name: string;
   description: string;
   enabled: boolean;
-  schedule: { kind: string; expr: string; tz?: string };
+  // openclaw v2026.4.23-beta.5 reshaped CronSchedule:
+  //   { kind: "at"; at: string }
+  //   { kind: "every"; everyMs: number; anchorMs?: number }
+  //   { kind: "cron"; expr: string; tz?: string; staggerMs?: number }
+  // The previous loose `{ kind: string; expr: string }` shape silently
+  // mis-routed our `kind: "interval", expr: "30m"` registration to the
+  // cron parser, which rejected "30m" as an invalid 5-7 part cron
+  // expression. Now correctly modeled as a discriminated union.
+  schedule:
+    | { kind: "at"; at: string }
+    | { kind: "every"; everyMs: number; anchorMs?: number }
+    | { kind: "cron"; expr: string; tz?: string; staggerMs?: number };
   sessionTarget: string;
   wakeMode: string;
   payload: { kind: "agentTurn"; message: string } | { kind: "systemEvent"; text: string };
@@ -302,9 +313,14 @@ export async function handleGatewayStart(ctx: {
         "before_prompt_build injection-queue drain. The drain itself is the gate: it only emits the " +
         "nudge when planMode === 'plan' AND no pendingInteraction.",
       enabled: true,
+      // openclaw v2026.4.23-beta.5 dropped `kind: "interval"` —
+      // replaced by `kind: "every"` with explicit milliseconds. 30
+      // minutes = 30 * 60 * 1000 = 1_800_000 ms. The previous
+      // `expr: "30m"` was being mis-routed to the cron-string parser
+      // and rejected with "CronPattern: invalid configuration format".
       schedule: {
-        kind: "interval",
-        expr: "30m",
+        kind: "every",
+        everyMs: 30 * 60 * 1000,
       },
       sessionTarget: "current",
       wakeMode: "auto",


### PR DESCRIPTION
Caught live during Eva's v2026.4.23-beta.5 cutover smoke test (second schema break in the cron path; PR #61 fixed the payload kind).

openclaw v2026.4.23-beta.5 reshaped `CronSchedule`:
- DROPPED `kind: "interval"`
- New shapes: `{ kind: "at"; at: string }`, `{ kind: "every"; everyMs: number; anchorMs? }`, `{ kind: "cron"; expr: string; tz?; staggerMs? }`

Pre-fix log line:
```
[smarter-claw/tool_call] gateway_start:cron-failed
  details="CronPattern: invalid configuration format ('30m'), exactly five, six, or seven space separated parts are required."
```

Result: plan-nudge cron silently failed. Old `kind: "interval"` was being mis-routed to the cron parser.

## Changes

`src/lifecycle-hooks.ts`:
- `handleGatewayStart` schedule → `{ kind: "every", everyMs: 30 * 60 * 1000 }`
- `CronCreateInput` schedule field narrowed to the 3-variant discriminated union

## Test plan

- [x] `pnpm typecheck` → green
- [x] `pnpm test --run` → 564 pass / 1 skip
- [x] CI installer-roundtrip will exercise the install
- [x] Live verification post-deploy: log should show `gateway_start:cron-registered` instead of `cron-failed`