### PR TITLE
fix(installer): chip-stick (Layer A + B) + agent_end conv-access schema patch

### DIFF
--- a/installer/patch-plan.json
+++ b/installer/patch-plan.json
@@ -228,6 +228,18 @@
       "relPath": "src/agents/pi-embedded-subscribe.handlers.tools.ts",
       "patchRelPath": "patches/core/pi-embedded-subscribe-exit-plan-mode-emit.diff",
       "expectedOriginalSha256": "abbd8dbff32d54b6213b4fa4af6d8afecce26181a56275793e5358f4e5cc47b8"
+    },
+    {
+      "type": "diff",
+      "relPath": "src/gateway/session-utils.ts",
+      "patchRelPath": "patches/core/session-utils-row-expose-plan-mode.diff",
+      "expectedOriginalSha256": "be4f3e44bf64078868bc20ed5035d94daac7451b32ec0c7761b70030c000fdff"
+    },
+    {
+      "type": "diff",
+      "relPath": "src/config/schema.base.generated.ts",
+      "patchRelPath": "patches/core/schema-allow-conversation-access.diff",
+      "expectedOriginalSha256": "ca249d638091766d9b262d93318f33c5846155c9319cc5b15a195d0af226167c"
     }
   ]
 }

--- a/installer/patches/core/schema-allow-conversation-access.diff
+++ b/installer/patches/core/schema-allow-conversation-access.diff
@@ -1,0 +1,16 @@
+@@ -22706,6 +22706,12 @@
+                     allowPromptInjection: {
+                       type: "boolean",
+                       title: "Allow Prompt Injection Hooks",
+                       description:
+                         "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
+                     },
++                    allowConversationAccess: {
++                      type: "boolean",
++                      title: "Allow Conversation Access Hooks",
++                      description:
++                        "Controls whether this plugin may receive raw conversation content from llm_input/llm_output/agent_end hooks. Non-bundled plugins must opt in explicitly. Smarter-Claw needs this true to power the agent_end-driven escalating-retry suite. Smarter-Claw installer adds this property because the upstream v2026.4.23-beta.5 schema generation missed it (the field is in TS types + normalization + status reader but not in the generated JSON schema). Track upstream for removal of this patch when their schema regen catches up.",
++                    },
+                   },
+                   additionalProperties: false,
+                   title: "Plugin Hook Policy",

--- a/installer/patches/core/session-utils-row-expose-plan-mode.diff
+++ b/installer/patches/core/session-utils-row-expose-plan-mode.diff
@@ -1,0 +1,19 @@
+@@ -1434,6 +1434,17 @@ export function buildGatewaySessionRow(params: {
+     lastAccountId: deliveryFields.lastAccountId ?? entry?.lastAccountId,
+     lastThreadId: deliveryFields.lastThreadId ?? entry?.lastThreadId,
+     compactionCheckpointCount: entry?.compactionCheckpoints?.length,
+     latestCompactionCheckpoint,
++    // Smarter-Claw chip-stick fix (Layer B): expose `entry.planMode`,
++    // `entry.pendingQuestionApprovalId`, and `entry.pluginMetadata`
++    // (plugin-namespaced state) on the gateway row so the UI's
++    // mode-switcher / plan-cards / plan-resume can read live plan
++    // state. Without this, the host's row builder strips these
++    // fields — chip-stick visible because resolveCurrentMode reads
++    // entry.planMode.mode and gets undefined on every list refresh.
++    // The Smarter-Claw plugin owns the namespace so exposing these
++    // fields doesn't leak any other plugin's data.
++    planMode: entry?.planMode,
++    pendingQuestionApprovalId: entry?.pendingQuestionApprovalId,
++    pluginMetadata: entry?.pluginMetadata,
+   };
+ }

--- a/installer/patches/core/sessions-patch-handler-plan-mode.diff
+++ b/installer/patches/core/sessions-patch-handler-plan-mode.diff
@@ -78,6 +78,32 @@
 +    } else {
 +      return invalid('invalid planMode (use "plan"|"normal" or null)');
 +    }
++    // Smarter-Claw chip-stick fix (Layer A): mirror entry.planMode
++    // immediately after a planMode-only patch (e.g. user clicks the
++    // chip's Plan/Normal entry). Without this, the slot updates but
++    // the UI's resolveCurrentMode reads `entry.planMode.mode` which
++    // stays stale until the next plugin-side persist — so the chip
++    // visually reverts to "Default" / the previous selection. Mirror
++    // logic identical to the planApproval branch's mirror further
++    // down — kept inline (vs factored into a helper) so this patch
++    // stays drop-in compatible with older plugin SDK shapes.
++    {
++      const writtenSlot = readSmarterClawSlot(next as unknown as Record<string, unknown>);
++      if (writtenSlot) {
++        const nextEntry = next as unknown as Record<string, unknown>;
++        nextEntry.planMode = {
++          mode: writtenSlot.planMode,
++          approval: writtenSlot.planApproval,
++          ...(writtenSlot.lastPlanSteps && typeof writtenSlot.lastPlanSteps === "object" && "title" in (writtenSlot.lastPlanSteps as Record<string, unknown>)
++            ? { title: (writtenSlot.lastPlanSteps as { title?: string }).title }
++            : {}),
++          ...(writtenSlot.recentlyApprovedAt
++            ? { recentlyApprovedAt: writtenSlot.recentlyApprovedAt }
++            : {}),
++          ...(writtenSlot.autoApprove ? { autoApprove: writtenSlot.autoApprove } : {}),
++        };
++      }
++    }
 +  }
 +
 +  if ("planApproval" in patch && (patch as { planApproval?: unknown }).planApproval !== undefined) {


### PR DESCRIPTION
Three live-discovered bugs caught while Eva tested the v2026.4.23-beta.5 cutover. Bundled into one PR because all three are runtime regressions needed to make plan-mode work end-to-end.

## Bug A — chip-stick: planMode patch doesn't write UI mirror

`sessions-patch-handler-plan-mode.diff`: planMode branch updates the slot but doesn't write `entry.planMode` mirror. Fix duplicates the mirror block from the planApproval branch.

## Bug B — sessions.list strips planMode + pluginMetadata from rows

NEW patch on `src/gateway/session-utils.ts` adds `planMode`, `pendingQuestionApprovalId`, and `pluginMetadata` to the row builder return. Without this, even with Bug A fixed, any `sessions.list`/`sessions.changed` re-render reverts the chip.

## Bug C — agent_end hook blocked by upstream schema-regen miss

openclaw v2026.4.23-beta.5 added a security gate (`allowConversationAccess`) but the field is missing from the generated JSON config schema (`additionalProperties: false` blocks operators from setting it). Field IS in TS types + normalizer + status reader. Schema-regen miss in upstream.

NEW patch on `src/config/schema.base.generated.ts` adds the field. Temporary — should be removed when upstream schema regen catches up.

## Operator-side enablement (post-install)

To activate the agent_end hook (escalating-retry suite), add:
```json
plugins.entries.smarter-claw.hooks.allowConversationAccess = true
```
to `~/.openclaw/openclaw.json`. Without it, plan mode + mutation gate + approve work, but escalating-retry detectors silently skip.

## Test plan

- [x] `pnpm typecheck` → green
- [x] `pnpm test --run` → 564 pass / 1 skip
- [x] Local install + uninstall roundtrip on `/tmp/openclaw-test-v23-beta5` clean (41/41 patches applied + reversed; worktree bit-identical post-uninstall)
- [x] CI installer-roundtrip will exercise

## What this PR does NOT fix

- Duplicate hook firing (low-pri, tracking separately)
- Stale `@martian-engineering/lossless-claw` transitive openclaw v2026.4.9 in `~/.openclaw/extensions/node_modules/openclaw` (operator-side symlink workaround documented; future installer-enhancement TODO)

Refs operator's live testing 2026-04-24.