### PR TITLE
fix(installer): patch Zod schema for allowConversationAccess (companion to PR #63)

### DIFF
--- a/installer/patch-plan.json
+++ b/installer/patch-plan.json
@@ -240,6 +240,12 @@
       "relPath": "src/config/schema.base.generated.ts",
       "patchRelPath": "patches/core/schema-allow-conversation-access.diff",
       "expectedOriginalSha256": "ca249d638091766d9b262d93318f33c5846155c9319cc5b15a195d0af226167c"
+    },
+    {
+      "type": "diff",
+      "relPath": "src/config/zod-schema.ts",
+      "patchRelPath": "patches/core/zod-schema-allow-conversation-access.diff",
+      "expectedOriginalSha256": "3cb6916cd44ba406605715708718dab5ea94f1e02258ebea312755accce643c9"
     }
   ]
 }

--- a/installer/patches/core/zod-schema-allow-conversation-access.diff
+++ b/installer/patches/core/zod-schema-allow-conversation-access.diff
@@ -1,0 +1,19 @@
+@@ -158,11 +158,17 @@
+ const PluginEntrySchema = z
+   .object({
+     enabled: z.boolean().optional(),
+     hooks: z
+       .object({
+         allowPromptInjection: z.boolean().optional(),
++        // Smarter-Claw conversation-access patch: companion to the
++        // schema-allow-conversation-access.diff patch on
++        // schema.base.generated.ts. The runtime config validation goes
++        // through THIS Zod schema (not the JSON schema bundle), so the
++        // field needs to be declared here too. Track upstream for
++        // removal of this patch when their codegen catches up.
++        allowConversationAccess: z.boolean().optional(),
+       })
+       .strict()
+       .optional(),
+     subagent: z
+       .object({


### PR DESCRIPTION
PR #63's schema-allow-conversation-access.diff patched only the JSON-schema bundle. The runtime config validator uses a SEPARATE Zod schema at `src/config/zod-schema.ts:158` which has `.strict()` on the `hooks` object — Zod still rejects `allowConversationAccess` even with PR #63 applied.

This patch adds the field to Zod's `PluginEntrySchema`. Together with PR #63 the operator can now set `plugins.entries.smarter-claw.hooks.allowConversationAccess: true` and the agent_end hook (escalating-retry suite) registers cleanly.

## Why two schema patches

openclaw v2026.4.23-beta.5 has dual config validation surfaces:
- `zod-schema.ts` — runtime validator (PR catches this)
- `schema.base.generated.ts` — JSON schema + help/labels (PR #63 caught this)

Both upstream missed regen-ing the new `allowConversationAccess` field. Both are temporary patches — should be removed when upstream catches up.

## Operator-side activation

After this lands, add to `~/.openclaw/openclaw.json`:
```
plugins.entries.smarter-claw.hooks.allowConversationAccess = true
```
Restart gateway. The `agent_end blocked` warning disappears, escalating-retry detectors become active.

## Test plan

- [x] `pnpm typecheck` → green
- [x] `pnpm test --run` → 564 pass / 1 skip
- [x] Local install on `/tmp/openclaw-test-v23-beta5` clean: 42/42 patches applied