### PR TITLE
fix: Sprint 1 PR α — approval-flow restoration (#1 + #2 + #5 + #8 + #9)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ logs/
 
 # pnpm
 pnpm-debug.log*
+.claude/

--- a/index.ts
+++ b/index.ts
@@ -31,6 +31,7 @@ import {
 } from "./src/lifecycle-hooks.js";
 import { shouldBlockMutation } from "./src/mutation-gate.js";
 import { bustPlanModeCache, getPlanModeCache, setPlanModeCache } from "./src/plan-mode-cache.js";
+import { claimToolResultPersist } from "./src/tool-result-dedup.js";
 import { buildSlashCommandDeps } from "./src/slash-command-deps.js";
 import { createPlanCommandHandler } from "./src/slash-commands.js";
 import { handleToolResultPersist } from "./src/tool-result-persist-hook.js";
@@ -444,6 +445,16 @@ export default definePluginEntry({
     //   - exit_plan_mode: write plan-YYYY-MM-DD-<slug>.md to disk under
     //     ~/.openclaw/agents/<id>/plans/ for operator audit trail
     api.on("tool_result_persist", (event, ctx) => {
+      // BUG #5 dedup: vanilla openclaw v2026.4.23-beta.5 fires BOTH
+      // `tool_result_persist` and `before_message_write` for every
+      // exit_plan_mode/update_plan call. Without dedup we double-write
+      // archetype MDs + race the slice. Claim first; the
+      // before_message_write handler below skips if we won.
+      const msgWithId = (event as { message?: { id?: string }; toolName?: string });
+      const claimed = claimToolResultPersist(msgWithId.toolName, msgWithId.message?.id);
+      if (!claimed) {
+        return;
+      }
       // Returns void per the SDK contract — the hook is fire-and-forget
       // for our purposes (we never replace the persisted message).
       // Caught + logged inside the handler so any failure here doesn't
@@ -537,9 +548,17 @@ export default definePluginEntry({
     }
 
     api.on("before_message_write", (event, ctx) => {
-      const msg = event.message as { toolName?: string; type?: string };
+      const msg = event.message as { toolName?: string; type?: string; id?: string };
       const toolName = msg?.toolName;
       if (toolName !== "update_plan" && toolName !== "exit_plan_mode") {
+        return undefined;
+      }
+      // BUG #5 dedup: tool_result_persist hook above already claims for
+      // these tool names on current host versions. Only fire the
+      // fallback path if no one claimed (i.e. tool_result_persist
+      // didn't fire for this message — older host or synthetic path).
+      const claimed = claimToolResultPersist(toolName, msg?.id);
+      if (!claimed) {
         return undefined;
       }
       void handleToolResultPersist(

--- a/installer/patches/core/sessions-patch-handler-plan-mode.diff
+++ b/installer/patches/core/sessions-patch-handler-plan-mode.diff
@@ -1,4 +1,4 @@
-@@ -485,7 +485,200 @@
+@@ -485,7 +485,229 @@
        next.groupActivation = normalized;
      }
    }
@@ -117,9 +117,23 @@
 +      autoApprove: false,
 +    };
 +    if (pa.action === "approve" || pa.action === "edit") {
-+      const pending = slot.pendingInteraction as
++      // BUG #1 mirror fallback (Smarter-Claw v0.2.0-beta.2): the
++      // plugin's persist writes `pendingInteraction` to the slot, but
++      // the host's `mergeSessionEntry` in src/config/sessions/types.ts
++      // does a shallow spread — any agent-side `persistSessionEntry`
++      // call carrying a stale snapshot (no plugin awareness) overwrites
++      // the entire `pluginMetadata` bag and erases our slot's
++      // `pendingInteraction`. The plugin ALSO writes a top-level
++      // `entry.pendingInteraction` mirror further down (UI-compat
++      // mirror block) which the host's mergeSessionEntry preserves
++      // because it's a known SessionEntry field, not a plugin slice.
++      // So when the slot is empty due to clobber, fall back to the
++      // top-level mirror as the source of truth for the approval guard.
++      // This is a band-aid; the structural fix is in v0.3.0 (Sprint 2)
++      // when state moves to a plugin-owned file.
++      const pending = (slot.pendingInteraction as
 +        | { kind?: string; approvalId?: string }
-+        | undefined;
++        | undefined) ?? ((next as unknown as { pendingInteraction?: { kind?: string; approvalId?: string } }).pendingInteraction);
 +      if (
 +        !pending ||
 +        pending.kind !== "approval" ||
@@ -149,6 +163,9 @@
 +        pendingInteraction: undefined,
 +        recentlyApprovedAt: new Date().toISOString(),
 +        retryCounters: undefined,
++        // BUG #8: reset rejectionCount on approve/edit. Sister-fix in
++        // src/slash-command-deps.ts:applyPatchToState (slash-command path).
++        rejectionCount: 0,
 +      };
 +      appendInjection(nextSlot, {
 +        id: `plan-decision-${approvalId}`,
@@ -158,9 +175,10 @@
 +      });
 +      writeSmarterClawSlot(next as unknown as Record<string, unknown>, nextSlot);
 +    } else if (pa.action === "reject") {
-+      const pending = slot.pendingInteraction as
++      // BUG #1 mirror fallback — same rationale as approve branch above.
++      const pending = (slot.pendingInteraction as
 +        | { kind?: string; approvalId?: string }
-+        | undefined;
++        | undefined) ?? ((next as unknown as { pendingInteraction?: { kind?: string; approvalId?: string } }).pendingInteraction);
 +      if (
 +        !pending ||
 +        pending.kind !== "approval" ||
@@ -185,6 +203,17 @@
 +        ...slot,
 +        planApproval: "rejected",
 +        pendingInteraction: undefined,
++        // BUG #8: increment rejectionCount on UI-button reject (was only
++        // incremented in the slash-command path before this fix). The
++        // "clarify their goal" hint at types.ts:369 fires after 3+
++        // rejections via buildPlanDecisionInjection — without this
++        // increment, UI-rejecting users never see the auto-deescalation.
++        // Sister-fix in src/slash-command-deps.ts:applyPatchToState.
++        rejectionCount: (typeof slot.rejectionCount === "number" ? slot.rejectionCount : 0) + 1,
++        // BUG #9: clear stale recentlyApprovedAt on reject (was carried
++        // forward via `...slot` spread, causing UI to show "Recently
++        // approved" indicator even after a fresh rejection cycle).
++        recentlyApprovedAt: undefined,
 +      };
 +      appendInjection(nextSlot, {
 +        id: `plan-decision-${approvalId}`,

--- a/src/slash-command-deps.ts
+++ b/src/slash-command-deps.ts
@@ -183,12 +183,18 @@ export function applyPatchToState(
       // planning → execution boundary.
       return {
         ...base,
-        planMode: "normal",
+        // BUG-fix parity: gateway sessions-patch path writes "executing"
+        // post PR #53 (P2.4); slash-command path was left on "normal"
+        // until this PR. Now both paths produce the same state.
+        planMode: "executing",
         planApproval: "approved",
         pendingInteraction: undefined,
         recentlyApprovedAt: new Date().toISOString(),
         pendingAgentInjections: queueHost.pendingAgentInjections,
         retryCounters: undefined,
+        // BUG #8: reset rejectionCount on approve (sister-fix in
+        // installer/patches/core/sessions-patch-handler-plan-mode.diff).
+        rejectionCount: 0,
       };
     }
     if (pa.action === "reject") {
@@ -221,6 +227,17 @@ export function applyPatchToState(
         planApproval: "rejected",
         pendingInteraction: undefined,
         pendingAgentInjections: rejectHost.pendingAgentInjections,
+        // BUG #8: increment rejectionCount on slash-command reject. Was
+        // present in approval-state.ts:resolvePlanApproval but not in
+        // applyPatchToState (the actual slash-command dispatch path) —
+        // so the "clarify their goal" hint at types.ts:369 never fired
+        // for either UI-button OR slash-command rejections. Now both
+        // paths increment. Sister-fix in sessions-patch-handler-plan-mode.diff.
+        rejectionCount: (base.rejectionCount ?? 0) + 1,
+        // BUG #9: clear stale recentlyApprovedAt on reject (UI confusion
+        // when a fresh rejection cycle inherits the prior approve's
+        // timestamp via the `...base` spread).
+        recentlyApprovedAt: undefined,
       };
     }
     if (pa.action === "answer") {

--- a/src/tool-result-dedup.ts
+++ b/src/tool-result-dedup.ts
@@ -1,0 +1,100 @@
+/**
+ * Dedup ledger for tool-result persist events.
+ *
+ * # Why this exists (BUG #5 — operator-reported, real-agent QA confirmed)
+ *
+ * `index.ts` registers TWO handlers that each route to
+ * `handleToolResultPersist`:
+ *   1. `api.on("tool_result_persist")` — the canonical hook
+ *   2. `api.on("before_message_write")` — a "belt-and-suspenders fallback"
+ *      added because tool_result_persist historically didn't fire for
+ *      every plugin-registered tool path in the Pi runtime
+ *
+ * On openclaw v2026.4.23-beta.5 BOTH fire for every `exit_plan_mode` and
+ * `update_plan` tool call. Result: each call writes archetype markdown
+ * 3x (once from tool body, twice from duplicate persist hooks),
+ * `pluginMetadata` is written twice (race window for BUG #1's slice
+ * clobber), and the operator sees `tool_result_persist:received` log
+ * lines firing in pairs.
+ *
+ * # The dedup contract
+ *
+ * Each event carries a message with an id. We maintain a small in-process
+ * Set of recently-seen `(toolName + messageId)` keys with a sliding TTL.
+ * Whichever handler fires first claims the key — the loser short-circuits.
+ *
+ * If the message lacks an id (older host versions or synthetic messages),
+ * we fall back to letting the event through (bias toward NOT skipping
+ * persists since silent skip is worse than duplicate write).
+ *
+ * # TTL choice
+ *
+ * 30 seconds is enough that a "typical tool call → persist → next agent
+ * turn" cycle (sub-second) is well within the window, but short enough
+ * that an entry from yesterday's same-id message (extremely rare —
+ * message ids are random uuids) couldn't accidentally dedup with today's.
+ */
+
+type DedupEntry = { key: string; expiresAtMs: number };
+
+/** Soft cap on entries kept (not strict — sweep removes expired first). */
+const MAX_ENTRIES = 500;
+
+/** TTL after which an entry is forgotten — see docstring rationale. */
+const ENTRY_TTL_MS = 30_000;
+
+const ledger = new Map<string, DedupEntry>();
+
+function sweepExpired(nowMs: number): void {
+  // Cheap O(n) walk — n is bounded by MAX_ENTRIES + recent burst. Called
+  // on each claim, but only does work when entries are actually expired.
+  for (const [key, entry] of ledger) {
+    if (entry.expiresAtMs <= nowMs) {
+      ledger.delete(key);
+    }
+  }
+}
+
+/**
+ * Returns true if the caller should proceed (it claimed the dedup key);
+ * false if a previous handler already claimed it (caller should skip).
+ *
+ * Pass undefined `messageId` to opt out — the call always returns true.
+ * This is the safer default when the caller can't construct a stable
+ * dedup key (silent skips are worse than duplicate writes).
+ */
+export function claimToolResultPersist(
+  toolName: string | undefined,
+  messageId: string | undefined,
+): boolean {
+  if (!toolName || !messageId) {
+    return true;
+  }
+  const key = `${toolName}::${messageId}`;
+  const nowMs = Date.now();
+  const existing = ledger.get(key);
+  if (existing && existing.expiresAtMs > nowMs) {
+    return false;
+  }
+  if (ledger.size >= MAX_ENTRIES) {
+    sweepExpired(nowMs);
+    // If still at cap after sweep (edge: 500 active entries within TTL),
+    // accept the duplicate rather than evict an in-flight key — duplicate
+    // writes are recoverable, lost writes are not.
+    if (ledger.size >= MAX_ENTRIES) {
+      return true;
+    }
+  }
+  ledger.set(key, { key, expiresAtMs: nowMs + ENTRY_TTL_MS });
+  return true;
+}
+
+/** Test helper — clear the ledger between test cases. */
+export function _resetDedupLedgerForTesting(): void {
+  ledger.clear();
+}
+
+/** Test helper — inspect ledger size. */
+export function _dedupLedgerSizeForTesting(): number {
+  return ledger.size;
+}

--- a/src/tool-result-persist-hook.ts
+++ b/src/tool-result-persist-hook.ts
@@ -254,6 +254,76 @@ async function handleExitPlanModePersist(args: {
       details: { reason: (err as Error)?.message ?? String(err) },
     });
   }
+
+  // BUG #2 fix: autoApprove consumer. The plugin manifest advertises
+  // `autoApprove: "Toggle whether plans auto-execute without user
+  // approval"` and the chip shows "Plan ⚡" when set, but pre-this-fix
+  // ZERO code consumed the flag — `runtime-api.isAutoApproveEnabled` was
+  // exported with no callers. Result: user toggles auto, sees confirma-
+  // tion, plan still requires manual click. Cosmetic-only feature.
+  //
+  // Fix wires the consumer here, AFTER exit_plan_mode persists. We
+  // re-read the slice (the persist already wrote the
+  // pendingInteraction:approval shape via the plugin's tool body) and
+  // if `autoApprove === true`, fire a synthetic approve-equivalent
+  // state mutation that mirrors what the manual approve path produces:
+  //   - planMode → "executing"
+  //   - planApproval → "approved"
+  //   - pendingInteraction → undefined
+  //   - recentlyApprovedAt → now
+  //   - rejectionCount → 0
+  //   - retryCounters → undefined
+  //   - append [PLAN_DECISION]: approved injection
+  //
+  // Idempotency: the synthetic write is gated on `pendingInteraction`
+  // being present (the just-persisted approval). If it's already gone
+  // (concurrent UI click won the race), we no-op safely. We also gate
+  // on `planApproval !== "approved"` to avoid double-firing on
+  // duplicate hook invocation if BUG #5 dedup ever degrades.
+  try {
+    await persistSmarterClawState({
+      agentId: args.agentId,
+      sessionKey: args.sessionKey,
+      update: (current) => {
+        if (!current) return undefined;
+        if (current.autoApprove !== true) return undefined;
+        if (current.planApproval === "approved") return undefined;
+        const pending = current.pendingInteraction;
+        if (!pending || pending.kind !== "approval") return undefined;
+        const approvalId = pending.approvalId;
+        if (!approvalId) return undefined;
+        const queueHost = { pendingAgentInjections: current.pendingAgentInjections };
+        appendToInjectionQueue(queueHost, {
+          id: `plan-decision-${approvalId}`,
+          kind: "plan_decision",
+          text: `[PLAN_DECISION]: approved`,
+          createdAt: Date.now(),
+        });
+        logPlanModeDebug({
+          kind: "tool_call",
+          sessionKey: args.sessionKey,
+          tool: `tool_result_persist:auto-approved:${approvalId}`,
+        });
+        return {
+          ...current,
+          planMode: "executing",
+          planApproval: "approved",
+          pendingInteraction: undefined,
+          recentlyApprovedAt: new Date().toISOString(),
+          rejectionCount: 0,
+          retryCounters: undefined,
+          pendingAgentInjections: queueHost.pendingAgentInjections,
+        };
+      },
+    });
+  } catch (err) {
+    logPlanModeDebug({
+      kind: "tool_call",
+      sessionKey: args.sessionKey,
+      tool: `tool_result_persist:auto-approve-failed`,
+      details: { reason: (err as Error)?.message ?? String(err) },
+    });
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/types.ts
+++ b/src/types.ts
@@ -168,6 +168,17 @@ export type SmarterClawSessionState = {
   planModeIntroDeliveredAt?: string;
   /** ISO timestamp of the most recent approval. */
   recentlyApprovedAt?: string;
+  /**
+   * Number of plan-mode rejection cycles in this session. Incremented
+   * by both the slash-command path (`applyPatchToState`) and the
+   * gateway-side sessions.patch handler on every reject action. Reset
+   * to 0 on approve/edit. After 3+ rejections, `buildPlanDecisionInjection`
+   * adds a "consider asking the user to clarify their goal" hint to
+   * the next [PLAN_DECISION]: rejected injection — auto-deescalation
+   * to prevent infinite re-revision loops. Was missing from this type
+   * (and the runtime increment) until v0.2.0-beta.2 fix for BUG #8.
+   */
+  rejectionCount?: number;
   /** Pending interaction (e.g. ask_user_question) awaiting response. */
   pendingInteraction?: {
     kind: "question" | "approval";


### PR DESCRIPTION
Sprint 1 of the operator-approved hybrid plan from synthesis of 3 opus-level architecture reports. Path A surface fixes for shippable beta; Sprint 2 (Alternative I structural migration) follows.

Bundles four operator-priority bug fixes that together restore the broken plan-mode approval flow end-to-end. Each independently confirmed by adversarial-QA or real-agent QA sub-agent.

## Bugs fixed

| # | Severity | Title |
|---|---|---|
| #5 | NORMAL | `tool_result_persist` hook fires twice — dedup ledger added |
| #2 | HIGH | `autoApprove` flag never consumed — wired in tool-result-persist hook |
| #1 | HIGH | `pendingInteraction` lost on agent run — gateway approval guard mirror-fallback workaround |
| #8 | NORMAL | `rejectionCount` not incremented (extended scope: NEITHER path was incrementing) |
| #9 | NIT | `recentlyApprovedAt` survives reject — explicit clear in both paths |

Plus **bonus parity fix** discovered while auditing: slash-command `applyPatchToState` was still writing `planMode: "normal"` on approve (PR #53 only updated approval-state.ts; slash-command path was orphaned). Now both paths write `"executing"`.

## Files

- NEW `src/tool-result-dedup.ts` — small in-process dedup ledger (claim-first, 30s TTL)
- `index.ts` — both hook handlers claim before dispatch; second short-circuits
- `src/tool-result-persist-hook.ts` — autoApprove consumer added after archetype-md persist (idempotent + non-fatal)
- `src/types.ts` — `SmarterClawSessionState.rejectionCount` field added
- `src/slash-command-deps.ts` — slash approve writes "executing" + reject increments rejectionCount + clears recentlyApprovedAt
- `installer/patches/core/sessions-patch-handler-plan-mode.diff` — gateway approval guard mirror-fallback + rejectionCount + recentlyApprovedAt clear

## What this fix DOES NOT do

#1 is a workaround, not a structural fix. The plugin's slot still gets clobbered by host's `mergeSessionEntry` shallow spread; the workaround restores the approval flow by reading the surviving top-level mirror. **Sprint 2 (Alternative I) moves plugin state to a plugin-owned file outside SessionEntry, structurally eliminating the clobber.**

PR β (cleanup bundle: #3 installer auto-symlink + #4 queue cap + #6 state-dir + #10 log text) follows.

## Test plan

- [x] `pnpm typecheck` → green
- [x] `pnpm test --run` → 564 pass / 1 skip (no regressions)
- [x] Local install + uninstall roundtrip on `/tmp/openclaw-test-v23-beta5` clean: 42/42 patches applied + reversed; worktree bit-identical
- [x] CI installer-roundtrip will exercise

## Refs

Sprint 1 of the hybrid plan synthesized from 3 opus-level architecture sub-agent reports. Operator-approved 2026-04-25.