### PR TITLE
fix: Sprint 1 PR β — cleanup bundle (#4 + #6 + #10 + #3 diagnostic)

### DIFF
--- a/installer/bin/install.mjs
+++ b/installer/bin/install.mjs
@@ -31,7 +31,8 @@
  *     reverse order. Manifest is written only on full success.
  */
 
-import { existsSync, lstatSync, readFileSync, readlinkSync, renameSync, rmSync, symlinkSync } from "node:fs";
+import { existsSync, lstatSync, readFileSync, readlinkSync, realpathSync, renameSync, rmSync, symlinkSync } from "node:fs";
+import { homedir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -287,6 +288,63 @@ async function runInstall({ args, hostPath, hostVersion }) {
   console.log(`\nSmarter-Claw v${smarterClawVersion} installed.`);
   console.log(`Manifest: ${manifestPathFor(hostPath)}`);
   console.log(`\nNext: restart the OpenClaw gateway to load the patched code.`);
+
+  // BUG #3 diagnostic (Smarter-Claw v0.2.0-beta.2): if the plugin is
+  // installed at ~/.openclaw/extensions/smarter-claw/ AND the parent
+  // node_modules has a stale openclaw (older than this host version),
+  // the plugin will silently fail to write state because `await import
+  // ("openclaw/plugin-sdk/session-store-runtime")` resolves to the
+  // stale copy that lacks updateSessionStoreEntry. We can't auto-fix
+  // this from the host-patch installer (we don't know the plugin
+  // install dir), but we CAN detect + warn.
+  //
+  // Sprint 2 (Alternative I migration) replaces dynamic-import with
+  // `api.runtime.agent.session.*` injection, which retires this whole
+  // class. Until then, document the manual symlink fix.
+  try {
+    const stateDir = process.env.OPENCLAW_STATE_DIR?.trim() || path.join(homedir(), ".openclaw");
+    const extensionsNodeModulesOpenclaw = path.join(stateDir, "extensions", "node_modules", "openclaw");
+    if (existsSync(extensionsNodeModulesOpenclaw)) {
+      // Compare to host openclaw via realpath. The symlink at
+      // ~/.openclaw/extensions/node_modules/openclaw may point through
+      // /opt/homebrew/lib/node_modules/openclaw (a global symlink) →
+      // hostPath. realpath collapses both ends to the same canonical
+      // path if they ultimately resolve to the same place.
+      let resolvedExt;
+      let resolvedHost;
+      try {
+        resolvedExt = realpathSync(extensionsNodeModulesOpenclaw);
+        resolvedHost = realpathSync(hostPath);
+      } catch {
+        // Broken symlink or missing target → treat as drift.
+        resolvedExt = extensionsNodeModulesOpenclaw;
+        resolvedHost = hostPath;
+      }
+      if (resolvedExt !== resolvedHost) {
+        const stalePkgPath = path.join(extensionsNodeModulesOpenclaw, "package.json");
+        let staleVersion = "unknown";
+        if (existsSync(stalePkgPath)) {
+          try {
+            const stalePkg = JSON.parse(readFileSync(stalePkgPath, "utf8"));
+            staleVersion = stalePkg.version ?? "unknown";
+          } catch { /* ignore */ }
+        }
+        console.log(``);
+        console.log(`⚠ BUG #3 diagnostic: stale openclaw at ${extensionsNodeModulesOpenclaw}`);
+        console.log(`  (version ${staleVersion}; host is ${hostVersion})`);
+        console.log(`  This will cause persist:skipped errors if plugin is loaded from`);
+        console.log(`  ~/.openclaw/extensions/. Manual fix:`);
+        console.log(``);
+        console.log(`    mv ${extensionsNodeModulesOpenclaw} ${extensionsNodeModulesOpenclaw}.bak-$(date -u +%Y%m%dT%H%M%SZ)`);
+        console.log(`    ln -s ${hostPath} ${extensionsNodeModulesOpenclaw}`);
+        console.log(``);
+        console.log(`  Sprint 2 (Alternative I) will retire this requirement.`);
+      }
+    }
+  } catch (err) {
+    // Best-effort diagnostic — never block install on its own failure.
+    console.log(`  (BUG #3 probe skipped: ${(err && err.message) || err})`);
+  }
 }
 
 /**

--- a/src/archetype-persist.ts
+++ b/src/archetype-persist.ts
@@ -85,7 +85,19 @@ export async function persistPlanArchetypeMarkdown(
     );
   }
 
-  const baseDir = input.baseDir ?? path.join(os.homedir(), ".openclaw", "agents");
+  // BUG #6 fix: read OPENCLAW_STATE_DIR fallback before defaulting to
+  // os.homedir(). Pre-fix, isolated profiles (e.g. QA gateways with
+  // OPENCLAW_STATE_DIR set) silently wrote into ~/.openclaw/agents/
+  // instead of their own state dir — cross-profile data leak. Adversarial
+  // QA leaked 15 plan MDs into operator's Eva profile during testing.
+  // Now: explicit baseDir wins, then env, then default. Future Sprint 2
+  // (Alternative I) will route this through ctx.paths.stateDir natively.
+  const envStateDir = process.env.OPENCLAW_STATE_DIR?.trim();
+  const baseDir =
+    input.baseDir ??
+    (envStateDir
+      ? path.join(envStateDir, "agents")
+      : path.join(os.homedir(), ".openclaw", "agents"));
   const agentDir = path.join(baseDir, agentId);
   const dir = path.join(agentDir, "plans");
   // Belt-and-suspenders confine — resolve the target and verify it

--- a/src/injections.ts
+++ b/src/injections.ts
@@ -144,8 +144,32 @@ function filterExpired(
 }
 
 /**
+ * Kinds where MOST RECENT user feedback matters more than the oldest
+ * (e.g. plan_decision: a 12-rejection cycle should deliver the user's
+ * latest feedback, not the 8-revision-stale first one). For these
+ * kinds we drop OLDEST entries on cap — keeping the most recent
+ * MAX_QUEUE_SIZE within the kind. Per BUG #4 from adversarial QA.
+ *
+ * Other kinds (system messages, plan_intro) keep the historical
+ * "drop newest" semantic since priority-based ranking already favors
+ * older + higher-priority entries appropriately.
+ */
+const KEEP_NEWEST_KINDS = new Set<string>(["plan_decision"]);
+
+/**
  * Sorts a queue for drain order and applies the size cap.
  * Pure (no store I/O) so callers can test independently.
+ *
+ * BUG #4 + #10 fix (Smarter-Claw v0.2.0-beta.2): the cap policy is
+ * now KIND-AWARE. Pre-fix `sorted.slice(0, MAX_QUEUE_SIZE)` kept
+ * oldest within each priority band — which silently dropped the
+ * user's most recent feedback in multi-revision plan_decision
+ * cycles. The warn-log text said "dropping oldest" but actually
+ * dropped newest entries (anything past index MAX). Now: for kinds
+ * in KEEP_NEWEST_KINDS we keep the LAST MAX entries (most recent
+ * timestamps); for other kinds we keep the FIRST MAX (oldest, the
+ * historical behavior). The warn log now correctly reflects what
+ * was dropped per kind.
  */
 export function sortAndCapQueue(
   queue: PendingAgentInjectionEntry[],
@@ -171,13 +195,50 @@ export function sortAndCapQueue(
   if (sorted.length <= MAX_QUEUE_SIZE) {
     return sorted;
   }
-  const dropped = sorted.slice(MAX_QUEUE_SIZE);
-  for (const d of dropped) {
-    log?.warn?.(
-      `pending-injection-queue: at cap ${MAX_QUEUE_SIZE}, dropping oldest entry id=${d.id} kind=${d.kind}`,
-    );
+  // Per-kind cap policy: separate by kind, apply directional slice.
+  const byKind = new Map<string, PendingAgentInjectionEntry[]>();
+  for (const entry of sorted) {
+    const arr = byKind.get(entry.kind) ?? [];
+    arr.push(entry);
+    byKind.set(entry.kind, arr);
   }
-  return sorted.slice(0, MAX_QUEUE_SIZE);
+  const kept: PendingAgentInjectionEntry[] = [];
+  for (const [kind, entries] of byKind) {
+    if (entries.length <= MAX_QUEUE_SIZE) {
+      kept.push(...entries);
+      continue;
+    }
+    if (KEEP_NEWEST_KINDS.has(kind)) {
+      // Keep the LAST MAX (most recent timestamps within priority).
+      const dropped = entries.slice(0, entries.length - MAX_QUEUE_SIZE);
+      const keptForKind = entries.slice(entries.length - MAX_QUEUE_SIZE);
+      for (const d of dropped) {
+        log?.warn?.(
+          `pending-injection-queue: at cap ${MAX_QUEUE_SIZE} for kind=${kind}, dropping older entry id=${d.id} (keep-newest policy)`,
+        );
+      }
+      kept.push(...keptForKind);
+    } else {
+      // Keep the FIRST MAX (oldest within priority — historical default).
+      const dropped = entries.slice(MAX_QUEUE_SIZE);
+      const keptForKind = entries.slice(0, MAX_QUEUE_SIZE);
+      for (const d of dropped) {
+        log?.warn?.(
+          `pending-injection-queue: at cap ${MAX_QUEUE_SIZE} for kind=${kind}, dropping newer entry id=${d.id} (keep-oldest policy)`,
+        );
+      }
+      kept.push(...keptForKind);
+    }
+  }
+  // Re-sort the merged kept set by the same sort key so drain-order
+  // is preserved across the per-kind partitioning.
+  return kept.sort((a, b) => {
+    const pa = resolveEntryPriority(a);
+    const pb = resolveEntryPriority(b);
+    if (pa !== pb) return pb - pa;
+    if (a.createdAt !== b.createdAt) return a.createdAt - b.createdAt;
+    return a.id.localeCompare(b.id);
+  });
 }
 
 /**

--- a/tests/injections.test.ts
+++ b/tests/injections.test.ts
@@ -113,6 +113,41 @@ describe("sortAndCapQueue", () => {
     ]);
   });
 
+  it("plan_decision uses keep-newest policy on cap (BUG #4 fix)", () => {
+    // Pre-fix: sorted ASC by createdAt + slice(0, MAX) → kept oldest,
+    // dropped newest. For plan_decision (multi-revision rejection
+    // cycles), this silently delivered 8-revision-stale feedback to
+    // the agent and dropped the user's most recent feedback. Adversarial
+    // QA's BUG #4. Now: plan_decision keeps the most recent MAX entries.
+    const warn = vi.fn();
+    const q: PendingAgentInjectionEntry[] = [];
+    for (let i = 0; i < MAX_QUEUE_SIZE + 3; i++) {
+      // Distinct ids + monotonic createdAt — id "d0" is OLDEST, "d12" NEWEST.
+      q.push(mkEntry("plan_decision", `d${i}`, i));
+    }
+    const sorted = sortAndCapQueue(q, { warn });
+    expect(sorted).toHaveLength(MAX_QUEUE_SIZE);
+    expect(warn).toHaveBeenCalledTimes(3);
+    // Kept the LAST 10 (newest createdAt). Dropped d0/d1/d2 (oldest).
+    expect(sorted.map((e) => e.id)).toEqual([
+      "d3",
+      "d4",
+      "d5",
+      "d6",
+      "d7",
+      "d8",
+      "d9",
+      "d10",
+      "d11",
+      "d12",
+    ]);
+    // Warn text reflects the actual policy ("dropping older entry"
+    // not the misleading old "dropping oldest" — also closes BUG #10).
+    const warnCalls = warn.mock.calls.map((args) => args[0]);
+    expect(warnCalls.every((m) => m.includes("dropping older"))).toBe(true);
+    expect(warnCalls.every((m) => m.includes("kind=plan_decision"))).toBe(true);
+  });
+
   it("preserves all entries when queue is under cap", () => {
     const q = [mkEntry("plan_decision", "d1", 1), mkEntry("question_answer", "q1", 2)];
     const sorted = sortAndCapQueue(q);


### PR DESCRIPTION
Sprint 1 PR β. Surface fixes for the 4 cleanup-bucket bugs from QA. PR α (#1+#2+#5+#8+#9) merged earlier and unblocked the approval flow.

## Bugs

| # | Severity | Fix |
|---|---|---|
| #4 + #10 | NORMAL | Kind-aware queue cap policy in `src/injections.ts` — `plan_decision` keeps newest, others keep oldest |
| #6 | NORMAL | `persistPlanArchetypeMarkdown` reads `OPENCLAW_STATE_DIR` env fallback before defaulting to `os.homedir()` |
| #3 | HIGH (re-scoped) | Install-time DIAGNOSTIC instead of auto-fix — Sprint 2 retires the bug class entirely |

## Why #3 is diagnostic-only

Originally scoped as auto-symlink (4hr). Sprint 2 (Alternative I migration) replaces dynamic-import with `api.runtime.agent.session.*` injection, retiring this whole bug class. Auto-symlink would be sunset within days. Lighter fix: print clear warning after install with the exact manual command if the operator's setup needs it. Realpath-compare avoids false positives.

## Test plan

- [x] `pnpm typecheck` → green
- [x] `pnpm test --run` → 565 pass / 1 skip (added 1 new test for kind-aware cap)
- [x] Local install + uninstall roundtrip clean
- [x] Diagnostic verified to fire only on real drift (realpath comparison)