### PR TITLE
fix: Sprint 1 hotfix — mirror fallback accepts both 'approval' and 'plan' kinds

### DIFF
--- a/installer/patches/core/sessions-patch-handler-plan-mode.diff
+++ b/installer/patches/core/sessions-patch-handler-plan-mode.diff
@@ -1,4 +1,4 @@
-@@ -485,7 +485,229 @@
+@@ -485,7 +485,247 @@
        next.groupActivation = normalized;
      }
    }
@@ -134,9 +134,18 @@
 +      const pending = (slot.pendingInteraction as
 +        | { kind?: string; approvalId?: string }
 +        | undefined) ?? ((next as unknown as { pendingInteraction?: { kind?: string; approvalId?: string } }).pendingInteraction);
++      // Mirror-fallback shape note: plugin's slot writes
++      // `kind: "approval"`; UI-compat top-level mirror translates to
++      // `kind: "plan"` for legacy chat slash-cmd-executor compat (see
++      // runtime-api.ts:buildUiCompatMirror line ~315). Accept BOTH so
++      // the fallback path works regardless of which mirror was the
++      // surviving source of truth.
++      const pendingKind = pending?.kind;
++      const isApprovalPending =
++        pendingKind === "approval" || pendingKind === "plan";
 +      if (
 +        !pending ||
-+        pending.kind !== "approval" ||
++        !isApprovalPending ||
 +        (pa.approvalId && pending.approvalId !== pa.approvalId)
 +      ) {
 +        return invalid(
@@ -179,9 +188,18 @@
 +      const pending = (slot.pendingInteraction as
 +        | { kind?: string; approvalId?: string }
 +        | undefined) ?? ((next as unknown as { pendingInteraction?: { kind?: string; approvalId?: string } }).pendingInteraction);
++      // Mirror-fallback shape note: plugin's slot writes
++      // `kind: "approval"`; UI-compat top-level mirror translates to
++      // `kind: "plan"` for legacy chat slash-cmd-executor compat (see
++      // runtime-api.ts:buildUiCompatMirror line ~315). Accept BOTH so
++      // the fallback path works regardless of which mirror was the
++      // surviving source of truth.
++      const pendingKind = pending?.kind;
++      const isApprovalPending =
++        pendingKind === "approval" || pendingKind === "plan";
 +      if (
 +        !pending ||
-+        pending.kind !== "approval" ||
++        !isApprovalPending ||
 +        (pa.approvalId && pending.approvalId !== pa.approvalId)
 +      ) {
 +        return invalid(


### PR DESCRIPTION
## Summary

Live-test failure on Eva at 03:16:43 caught BUG #1 still firing despite PR #65's mirror-fallback fix. Root cause: shape mismatch between the two `pendingInteraction` surfaces.

## What was happening

1. Plan-mode persist hook writes `pluginMetadata['smarter-claw'].pendingInteraction = { kind: "approval", approvalId: "..." }` to the plugin slot.
2. Agent reply lands → `mergeSessionEntry` shallow-spreads the agent's `entry`, clobbering `pluginMetadata` (the original BUG #1).
3. UI-compat layer in `runtime-api.ts:buildUiCompatMirror` writes a TOP-LEVEL `pendingInteraction` field as part of the entry — but TRANSLATES it: slot's `kind: "approval"` → mirror's `kind: "plan"`.
4. Slash-command approve fires; PR #65's fallback reads top-level `entry.pendingInteraction` (good, survives the clobber) but rejected it because the guard checked `pending.kind !== "approval"`.

The mirror's `kind` is `"plan"`, not `"approval"`. Both shapes legitimately represent "a plan is awaiting approval"; the fallback just needs to accept both.

## The fix

```diff
+      const pendingKind = pending?.kind;
+      const isApprovalPending =
+        pendingKind === "approval" || pendingKind === "plan";
+      if (
+        !pending ||
+        !isApprovalPending ||
+        (pa.approvalId && pending.approvalId !== pa.approvalId)
+      ) {
```

Same change applied to both the approve/edit branch and the reject branch in `installer/patches/core/sessions-patch-handler-plan-mode.diff`.

## Sprint 2 will retire this entire bug class

Sprint 2 (Alternative I) moves plugin state OUT of the session JSON entirely — into a plugin-owned file that `mergeSessionEntry` cannot touch. The whole "slot vs mirror, kind translation, fallback chain" tax goes away. This hotfix is the surface-fix that gets Sprint 1's beta validation unblocked while Sprint 2 lands the structural fix.

## Test plan

- [x] Hotfix pushed to branch `fix/sprint1-mirror-kind-shape`
- [ ] Re-deploy installer on Eva's openclaw-1 worktree (rebuild + restart gateway)
- [ ] Live test: enter plan mode → submit plan → click approve → verify state transitions to `executing` (not "ignored: stale approvalId")
- [ ] Tail `~/.openclaw/logs/gateway.err.log` for clean approve event