### PR TITLE
chore(ci): use stable job names ('ci', 'installer-roundtrip')

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   ci:
-    name: build + test + installer dry-run
+    name: ci
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/installer-roundtrip.yml
+++ b/.github/workflows/installer-roundtrip.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   installer-roundtrip:
-    name: install + verify + uninstall against openclaw v2026.4.23-beta.5
+    name: installer-roundtrip
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
## Summary

Job names were tied to the host version string (`install + verify + uninstall against openclaw v2026.4.23-beta.5`). Every host-version bump silently broke branch-protection — the new job's context name no longer matched the required-contexts list, so PRs could merge without the gate.

Stable names: `ci` + `installer-roundtrip`.

## Follow-up after merge

Update branch protection's required_status_checks.contexts:
```bash
gh api -X PATCH repos/electricsheephq/Smarter-Claw/branches/main/protection/required_status_checks \
  -f 'contexts[]=ci' -f 'contexts[]=installer-roundtrip'
```

## Test plan

- [x] Job names in workflow files
- [ ] Both workflows complete on this PR (will appear as `ci` + `installer-roundtrip`)
- [ ] After merge, branch protection updated