### PR TITLE
fix(host-patch): tactical bundle \u2014 closes #46 + #73; partial #72

### DIFF
--- a/installer/patches/core/session-utils-row-expose-plan-mode.diff
+++ b/installer/patches/core/session-utils-row-expose-plan-mode.diff
@@ -1,4 +1,4 @@
-@@ -1434,6 +1434,17 @@ export function buildGatewaySessionRow(params: {
+@@ -1434,6 +1434,29 @@ export function buildGatewaySessionRow(params: {
      lastAccountId: deliveryFields.lastAccountId ?? entry?.lastAccountId,
      lastThreadId: deliveryFields.lastThreadId ?? entry?.lastThreadId,
      compactionCheckpointCount: entry?.compactionCheckpoints?.length,
@@ -12,8 +12,22 @@
 +    // entry.planMode.mode and gets undefined on every list refresh.
 +    // The Smarter-Claw plugin owns the namespace so exposing these
 +    // fields doesn't leak any other plugin's data.
-+    planMode: entry?.planMode,
-+    pendingQuestionApprovalId: entry?.pendingQuestionApprovalId,
-+    pluginMetadata: entry?.pluginMetadata,
++    //
++    // Type cast: SessionEntry doesn't declare these fields nor does
++    // GatewaySessionRow accept them. Spread via a Record<string,unknown>
++    // bridge so the object literal compiles without modifying either
++    // type definition (which would be a much larger surface change to
++    // patch). Runtime semantics are identical — the fields land on the
++    // returned object exactly as they did before this cast was added.
++    // The plugin-sdk dts-build (build:plugin-sdk:dts via tsgo) is strict
++    // and rejects the un-cast object literal; spreading a typed-object
++    // bypass survives that step. Long-term: upstream RFC could declare
++    // `planMode`, `pendingQuestionApprovalId`, `pluginMetadata` as
++    // optional fields on both types.
++    ...({
++      planMode: (entry as unknown as Record<string, unknown> | undefined)?.planMode,
++      pendingQuestionApprovalId: (entry as unknown as Record<string, unknown> | undefined)?.pendingQuestionApprovalId,
++      pluginMetadata: (entry as unknown as Record<string, unknown> | undefined)?.pluginMetadata,
++    } as Record<string, unknown>),
    };
  }

--- a/installer/patches/core/sessions-patch-handler-plan-mode.diff
+++ b/installer/patches/core/sessions-patch-handler-plan-mode.diff
@@ -1,4 +1,4 @@
-@@ -485,7 +485,443 @@
+@@ -485,7 +485,487 @@
        next.groupActivation = normalized;
      }
    }
@@ -54,8 +54,20 @@
 +    // turn, blowing the model's context window. Other kinds (question_answer,
 +    // plan_complete, etc) are not capped here — only plan_decision was the
 +    // observed accumulation vector.
++    //
++    // Copilot review: sort by createdAt before slicing so eviction is
++    // chronological (oldest dropped first), matching the plugin helper's
++    // policy. Filter order alone is insertion-order which can diverge from
++    // chronological if entries arrive out-of-order from concurrent paths.
 +    const PLAN_DECISION_CAP = 10;
-+    const planDecisions = filtered.filter((q) => q.kind === "plan_decision");
++    const planDecisions = filtered
++      .filter((q) => q.kind === "plan_decision")
++      .slice() // copy before sort to avoid mutating filtered's order semantics
++      .sort((a, b) => {
++        const ta = typeof a.createdAt === "number" ? a.createdAt : 0;
++        const tb = typeof b.createdAt === "number" ? b.createdAt : 0;
++        return ta - tb; // oldest first → slice(0, dropCount) drops oldest
++      });
 +    if (planDecisions.length > PLAN_DECISION_CAP) {
 +      const dropCount = planDecisions.length - PLAN_DECISION_CAP;
 +      const droppedIds = new Set(
@@ -78,7 +90,7 @@
 +      // (electricsheephq/Smarter-Claw#72): also clear pendingInteraction,
 +      // recentlyApprovedAt, and rejectionCount on full reset. Without
 +      // these clears, an orphaned pendingInteraction can persist into
-+      // the next cycle and a stale approvalId becomes accept-able under
++      // the next cycle and a stale approvalId becomes acceptable under
 +      // a new mode session — confused UI + stale-approval leak.
 +      const slot = readSmarterClawSlot(next as unknown as Record<string, unknown>) ?? {
 +        planMode: "normal",
@@ -131,6 +143,20 @@
 +            : {}),
 +          ...(writtenSlot.autoApprove ? { autoApprove: writtenSlot.autoApprove } : {}),
 +        };
++        // C7 follow-up (Eva live-test 2026-04-25 04:55Z): when slot's
++        // pendingInteraction was cleared (planMode reset / null path),
++        // also clear top-level mirror fields. The session-row hydration
++        // and chat slash-cmd-executor read entry.pendingInteraction +
++        // entry.pendingQuestionApprovalId at top level; leaving them set
++        // after a planMode:null reset traps the UI in "there's a pending
++        // approval" — every subsequent agent reply is blocked because
++        // the mutation gate sees no plan-mode but the UI keeps showing
++        // a phantom approval card. Clear both top-level mirror fields
++        // when the slot says no pending interaction exists.
++        if (!writtenSlot.pendingInteraction) {
++          delete nextEntry.pendingInteraction;
++          delete nextEntry.pendingQuestionApprovalId;
++        }
 +      }
 +    }
 +  }
@@ -396,10 +422,28 @@
 +      appendInjection(nextSlot, {
 +        id: `question-answer-${approvalId}`,
 +        kind: "question_answer",
-+        text: `[QUESTION_ANSWER]: ${JSON.stringify(sanitized)}`,
++        // Copilot review: emit raw sanitized text (matches slash-command
++        // path's [QUESTION_ANSWER]: <text> format from
++        // src/slash-command-deps.ts). JSON.stringify here would surface
++        // quoted/escaped strings to the agent only on this path.
++        text: `[QUESTION_ANSWER]: ${sanitized}`,
 +        createdAt: Date.now(),
 +      });
 +      writeSmarterClawSlot(next as unknown as Record<string, unknown>, nextSlot);
++      // Codex review P2: also clear the top-level pendingQuestionApprovalId
++      // mirror in this request cycle. The webchat /plan answer resolver
++      // falls back to that top-level field when the slot is missing
++      // (BUG #1 mirror); leaving it stale means the UI keeps re-trying
++      // an answer that no longer has a pending question and gets
++      // rejected as stale. Clear in lockstep with the slot clear above.
++      const nextEntryAns = next as unknown as Record<string, unknown>;
++      delete nextEntryAns.pendingQuestionApprovalId;
++      if (nextEntryAns.pendingInteraction) {
++        const piAns = nextEntryAns.pendingInteraction as { kind?: string };
++        if (piAns.kind === "question") {
++          delete nextEntryAns.pendingInteraction;
++        }
++      }
 +    } else {
 +      return invalid(
 +        'planApproval action must be one of: approve, edit, reject, auto, answer',

--- a/installer/patches/core/sessions-patch-handler-plan-mode.diff
+++ b/installer/patches/core/sessions-patch-handler-plan-mode.diff
@@ -1,4 +1,4 @@
-@@ -485,7 +485,247 @@
+@@ -485,7 +485,443 @@
        next.groupActivation = normalized;
      }
    }
@@ -47,13 +47,39 @@
 +      : [];
 +    const filtered = queue.filter((q) => q && typeof q === "object" && q.id !== entry.id);
 +    filtered.push(entry as unknown as Record<string, unknown>);
-+    slot.pendingAgentInjections = filtered;
++    // Sub-agent QA #72-cap: enforce keep-newest cap of 10 plan_decision
++    // entries (matches plugin's sortAndCapQueue policy in src/injections.ts).
++    // Without this cap, 100 sequential rejections accumulate 100 queued
++    // injections and the next prompt-build batches all of them into one
++    // turn, blowing the model's context window. Other kinds (question_answer,
++    // plan_complete, etc) are not capped here — only plan_decision was the
++    // observed accumulation vector.
++    const PLAN_DECISION_CAP = 10;
++    const planDecisions = filtered.filter((q) => q.kind === "plan_decision");
++    if (planDecisions.length > PLAN_DECISION_CAP) {
++      const dropCount = planDecisions.length - PLAN_DECISION_CAP;
++      const droppedIds = new Set(
++        planDecisions
++          .slice(0, dropCount)
++          .map((q) => q.id as string),
++      );
++      slot.pendingAgentInjections = filtered.filter(
++        (q) => q.kind !== "plan_decision" || !droppedIds.has(q.id as string),
++      );
++    } else {
++      slot.pendingAgentInjections = filtered;
++    }
 +  }
 +
 +  if ("planMode" in patch && (patch as { planMode?: unknown }).planMode !== undefined) {
 +    const raw = (patch as { planMode?: unknown }).planMode;
 +    if (raw === null) {
-+      // Reset to default state ("normal" + idle).
++      // Reset to default state ("normal" + idle). Sub-agent QA C7
++      // (electricsheephq/Smarter-Claw#72): also clear pendingInteraction,
++      // recentlyApprovedAt, and rejectionCount on full reset. Without
++      // these clears, an orphaned pendingInteraction can persist into
++      // the next cycle and a stale approvalId becomes accept-able under
++      // a new mode session — confused UI + stale-approval leak.
 +      const slot = readSmarterClawSlot(next as unknown as Record<string, unknown>) ?? {
 +        planMode: "normal",
 +        planApproval: "idle",
@@ -63,6 +89,9 @@
 +        ...slot,
 +        planMode: "normal",
 +        planApproval: "idle",
++        pendingInteraction: undefined,
++        recentlyApprovedAt: undefined,
++        rejectionCount: 0,
 +      });
 +    } else if (raw === "plan" || raw === "normal") {
 +      const slot = readSmarterClawSlot(next as unknown as Record<string, unknown>) ?? {
@@ -156,6 +185,26 @@
 +      if (!approvalId) {
 +        return invalid('planApproval action="' + pa.action + '" requires approvalId');
 +      }
++      // Sub-agent QA C3 / electricsheephq/Smarter-Claw#73: subagent gate.
++      // The plugin's exit_plan_mode tool refuses to submit while research
++      // subagents are in flight (src/tools/exit-plan-mode-tool.ts ~270);
++      // mirror that gate here so UI inline-button approve doesn't bypass
++      // it. Without this mirror, a UI click while subagents run can
++      // approve a stale plan whose context the subagents would have
++      // updated. v0.3.0 Sprint 2 PR a-structural retires this duplication
++      // by routing the UI path through the same gate-evaluation point as
++      // the tool path; tactical fix below until then.
++      const blockingIds = Array.isArray(slot.blockingSubagentRunIds)
++        ? (slot.blockingSubagentRunIds as unknown[]).filter(
++            (x) => typeof x === "string" && x.length > 0,
++          )
++        : [];
++      if (blockingIds.length > 0) {
++        return invalid(
++          'planApproval ignored: ' + String(blockingIds.length) +
++          ' research subagent(s) still running; wait for them to complete',
++        );
++      }
 +      // Smarter-Claw P2.4 — approve / edit transition writes
 +      // `planMode: "executing"` (was: "normal"). The session is no
 +      // longer in plan-design but it's also not "no plan activity"
@@ -217,6 +266,19 @@
 +      const lines = [`[PLAN_DECISION]: rejected`];
 +      if (sanitized) lines.push(`feedback: ${JSON.stringify(sanitized)}`);
 +      lines.push("Revise your plan based on the feedback and call update_plan again.");
++      // Sub-agent QA C21: surface "clarify their goal" auto-deescalation
++      // hint after 3+ rejections. The plugin's buildPlanDecisionInjection
++      // helper does this for slash-command rejects (types.ts ~369); the
++      // host patch built injection text inline before this fix and missed
++      // the hint, so UI-button rejecters never benefited. Replicate the
++      // hint here. Threshold matches plugin (>= 3).
++      const nextRejectionCount =
++        (typeof slot.rejectionCount === "number" ? slot.rejectionCount : 0) + 1;
++      if (nextRejectionCount >= 3) {
++        lines.push(
++          "Multiple revisions have been rejected. Consider asking the user to clarify their goal before proposing the next plan.",
++        );
++      }
 +      const nextSlot: Record<string, unknown> = {
 +        ...slot,
 +        planApproval: "rejected",
@@ -227,7 +289,7 @@
 +        // rejections via buildPlanDecisionInjection — without this
 +        // increment, UI-rejecting users never see the auto-deescalation.
 +        // Sister-fix in src/slash-command-deps.ts:applyPatchToState.
-+        rejectionCount: (typeof slot.rejectionCount === "number" ? slot.rejectionCount : 0) + 1,
++        rejectionCount: nextRejectionCount,
 +        // BUG #9: clear stale recentlyApprovedAt on reject (was carried
 +        // forward via `...slot` spread, causing UI to show "Recently
 +        // approved" indicator even after a fresh rejection cycle).
@@ -244,13 +306,103 @@
 +      if (typeof pa.autoEnabled !== "boolean") {
 +        return invalid('planApproval action="auto" requires autoEnabled: boolean');
 +      }
-+      writeSmarterClawSlot(next as unknown as Record<string, unknown>, {
++      // Sub-agent QA B5 / electricsheephq/Smarter-Claw#72: when toggling
++      // autoApprove ON while a plan approval is already pending, consume
++      // it immediately by transitioning to executing/approved (matches
++      // the slash-command path's auto-on-with-pending behavior). Without
++      // this consumer here, the user toggles auto-on and nothing visibly
++      // happens until the next agent persist event fires the consumer.
++      const pending = (slot.pendingInteraction as
++        | { kind?: string; approvalId?: string }
++        | undefined) ?? ((next as unknown as { pendingInteraction?: { kind?: string; approvalId?: string } }).pendingInteraction);
++      const isPlanApprovalPending =
++        pending?.kind === "approval" || pending?.kind === "plan";
++      if (pa.autoEnabled === true && isPlanApprovalPending && pending?.approvalId) {
++        const subagentBlocked = Array.isArray(slot.blockingSubagentRunIds)
++          ? (slot.blockingSubagentRunIds as unknown[]).filter(
++              (x) => typeof x === "string" && x.length > 0,
++            ).length > 0
++          : false;
++        if (subagentBlocked) {
++          // Auto-toggle on while subagents block: write autoApprove=true
++          // but don't consume the pending approval (mirror C3 gate).
++          writeSmarterClawSlot(next as unknown as Record<string, unknown>, {
++            ...slot,
++            autoApprove: true,
++          });
++        } else {
++          const nextSlot: Record<string, unknown> = {
++            ...slot,
++            autoApprove: true,
++            planMode: "executing",
++            planApproval: "approved",
++            pendingInteraction: undefined,
++            recentlyApprovedAt: new Date().toISOString(),
++            retryCounters: undefined,
++            rejectionCount: 0,
++          };
++          appendInjection(nextSlot, {
++            id: `plan-decision-${pending.approvalId}`,
++            kind: "plan_decision",
++            text: `[PLAN_DECISION]: approved`,
++            createdAt: Date.now(),
++          });
++          writeSmarterClawSlot(next as unknown as Record<string, unknown>, nextSlot);
++        }
++      } else {
++        writeSmarterClawSlot(next as unknown as Record<string, unknown>, {
++          ...slot,
++          autoApprove: pa.autoEnabled,
++        });
++      }
++    } else if (pa.action === "answer") {
++      // electricsheephq/Smarter-Claw#46 + sub-agent QA C9: /plan answer
++      // route was advertised but non-functional pre-fix because the schema
++      // rejected the action. With the schema patch accepting "answer",
++      // route the answer through the same pendingInteraction-validated
++      // path that approve/reject use, then enqueue a [QUESTION_ANSWER]
++      // injection so the agent's next turn sees the user's reply.
++      const pendingQ = (slot.pendingInteraction as
++        | { kind?: string; approvalId?: string; questionId?: string }
++        | undefined) ?? ((next as unknown as { pendingInteraction?: { kind?: string; approvalId?: string; questionId?: string } }).pendingInteraction);
++      // Question-shape kinds: plugin slot writes "question"; UI mirror
++      // writes "question" too (no translation, unlike approval/plan).
++      if (
++        !pendingQ ||
++        pendingQ.kind !== "question" ||
++        (pa.approvalId && pendingQ.approvalId !== pa.approvalId)
++      ) {
++        return invalid(
++          'planApproval ignored: stale approvalId or no pending question',
++        );
++      }
++      const approvalId = pa.approvalId ?? pendingQ.approvalId;
++      if (!approvalId) {
++        return invalid('planApproval action="answer" requires approvalId');
++      }
++      // Sanitize answer text — same envelope-escape protection as
++      // sanitizeFeedbackForInjection in src/types.ts. Question answers
++      // travel through the [QUESTION_ANSWER] block; an adversarial answer
++      // could close the envelope early if not escaped.
++      const sanitized = pa.answer.replace(
++        /\[\/QUESTION_ANSWER\]/gi,
++        "[\u200B/QUESTION_ANSWER]",
++      );
++      const nextSlot: Record<string, unknown> = {
 +        ...slot,
-+        autoApprove: pa.autoEnabled,
++        pendingInteraction: undefined,
++        pendingQuestionApprovalId: undefined,
++      };
++      appendInjection(nextSlot, {
++        id: `question-answer-${approvalId}`,
++        kind: "question_answer",
++        text: `[QUESTION_ANSWER]: ${JSON.stringify(sanitized)}`,
++        createdAt: Date.now(),
 +      });
++      writeSmarterClawSlot(next as unknown as Record<string, unknown>, nextSlot);
 +    } else {
 +      return invalid(
-+        'planApproval action must be one of: approve, edit, reject, auto',
++        'planApproval action must be one of: approve, edit, reject, auto, answer',
 +      );
 +    }
 +    // Mirror UI-compat shadow at SessionEntry top level so the UI
@@ -274,6 +426,15 @@
 +          ? { recentlyApprovedAt: writtenSlot.recentlyApprovedAt }
 +          : {}),
 +        ...(writtenSlot.autoApprove ? { autoApprove: writtenSlot.autoApprove } : {}),
++        // Sub-agent QA #72-mirror: include rejectionCount + blockingSubagentRunIds
++        // in the mirror so UI escalation logic and subagent gate state are
++        // visible without a separate plugin-side persist round-trip.
++        ...(typeof writtenSlot.rejectionCount === "number" && writtenSlot.rejectionCount > 0
++          ? { rejectionCount: writtenSlot.rejectionCount }
++          : {}),
++        ...(Array.isArray(writtenSlot.blockingSubagentRunIds) && writtenSlot.blockingSubagentRunIds.length > 0
++          ? { blockingSubagentRunIds: writtenSlot.blockingSubagentRunIds }
++          : {}),
 +      };
 +    }
 +  }

--- a/installer/patches/core/sessions-patch-handler-plan-mode.diff
+++ b/installer/patches/core/sessions-patch-handler-plan-mode.diff
@@ -1,4 +1,4 @@
-@@ -485,7 +485,487 @@
+@@ -485,7 +485,500 @@
        next.groupActivation = normalized;
      }
    }
@@ -480,6 +480,19 @@
 +          ? { blockingSubagentRunIds: writtenSlot.blockingSubagentRunIds }
 +          : {}),
 +      };
++      // Wave 2 BLOCKER fix (2026-04-25): C7 mirror clear was scoped to
++      // the planMode-reset path + answer-action path, but approve / edit /
++      // reject / auto-toggle-with-pending all consume the slot's
++      // pendingInteraction without clearing the top-level mirror. Same
++      // phantom-approval bug class as the Eva live-test failure (slot
++      // says no pending, top-level mirror still says approval pending →
++      // UI loops on stale approvalId). Clear top-level mirror in lockstep
++      // when slot pendingInteraction is empty after this branch's write,
++      // covering all four consumer paths via the unified mirror block.
++      if (!writtenSlot.pendingInteraction) {
++        delete nextEntry.pendingInteraction;
++        delete nextEntry.pendingQuestionApprovalId;
++      }
 +    }
 +  }
  

--- a/installer/patches/core/sessions-patch-schema-plan-mode.diff
+++ b/installer/patches/core/sessions-patch-schema-plan-mode.diff
@@ -1,4 +1,4 @@
-@@ -132,6 +132,53 @@
+@@ -132,6 +132,67 @@
    {
      key: NonEmptyString,
      label: Type.Optional(Type.Union([SessionLabelString, Type.Null()])),
@@ -44,6 +44,19 @@
 +          {
 +            action: Type.Literal("auto"),
 +            autoEnabled: Type.Boolean(),
++          },
++          { additionalProperties: false },
++        ),
++        // Smarter-Claw issue #46 + sub-agent QA C9: /plan answer + UI
++        // answer-card route. Accept the answer payload so the slash
++        // command and inline question card can resolve a pending
++        // ask_user_question approval. The handler validates approvalId,
++        // sanitizes the answer text before injection.
++        Type.Object(
++          {
++            action: Type.Literal("answer"),
++            approvalId: Type.Optional(NonEmptyString),
++            answer: Type.String(),
 +          },
 +          { additionalProperties: false },
 +        ),

--- a/installer/patches/core/sessions-patch-schema-plan-mode.diff
+++ b/installer/patches/core/sessions-patch-schema-plan-mode.diff
@@ -1,4 +1,4 @@
-@@ -132,6 +132,67 @@
+@@ -132,6 +132,71 @@
    {
      key: NonEmptyString,
      label: Type.Optional(Type.Union([SessionLabelString, Type.Null()])),
@@ -56,6 +56,11 @@
 +          {
 +            action: Type.Literal("answer"),
 +            approvalId: Type.Optional(NonEmptyString),
++            // Codex review P1: webchat executor conditionally sends
++            // questionId on answer submissions when the pending question
++            // surfaces an id. Without accepting it, valid requests are
++            // rejected at schema validation before the handler runs.
++            questionId: Type.Optional(NonEmptyString),
 +            answer: Type.String(),
 +          },
 +          { additionalProperties: false },


### PR DESCRIPTION
## Summary

Bundles 7 host-patch fixes that close the highest-impact patch-handler bugs found in QA. Tactical fix unblocks v0.2.0-beta; structural Sprint 2 PR a (file-state migration per #70) remains v0.3.0 scope.

## Closes

- #46 — `/plan answer` + `planApproval action="answer"` route was advertised but non-functional (schema rejected the action). Now: schema accepts; handler validates approvalId match against pending question, sanitizes answer, emits `[QUESTION_ANSWER]` injection.
- #73 — security blocker: subagent gate bypass via `sessions.patch`. Inline-button approve now mirrors the `exit-plan-mode-tool.ts` gate; refuses approval when `blockingSubagentRunIds.length > 0`.

## Partial

- #72 — three patch-vs-slash parity gaps:
  - Queue cap of 10 plan_decision entries via patch path (was unbounded — `longrun.mjs` showed 81 entries before fix)
  - `rejectionCount` + `blockingSubagentRunIds` mirrored to `entry.planMode` (UI can now see them without round-trip)
  - Auto-toggle ON with pending approval consumes it (mirrors slash-command behavior)

## Other QA findings closed

- C7 (sub-agent normal) — `planMode: null` now also clears `pendingInteraction`, `recentlyApprovedAt`, `rejectionCount`. Prevents stale-approval leak across cycles.
- C21 (sub-agent normal) — UI-button reject after 3+ cycles now surfaces "clarify their goal" hint inline (was only in plugin's `buildPlanDecisionInjection`).

## Files changed

- `installer/patches/core/sessions-patch-schema-plan-mode.diff` — adds `Type.Literal("answer")` to the action union
- `installer/patches/core/sessions-patch-handler-plan-mode.diff` — handler updates per above

## Verification

| Surface | Before | After |
|---|---|---|
| Plugin unit tests | 565/1 | 565/1 (no regression) |
| `adversarial.mjs` | 14 PASS / 1 FAIL | 14 PASS / 0 FAIL |
| `extra.mjs` B1 (queue cap) | FAIL | PASS |
| `extra.mjs` B2-B4 | PASS | PASS |
| `sub-agent-scenarios.mjs` | 14 PASS / 3 FAIL | 16 PASS / 1 FAIL* |
| `longrun.mjs` injection count after 100 turns | 81 | 10 (capped) |
| C9 end-to-end (`/tmp/sc-qa/c9-verify.mjs`) | N/A (broken) | PASSES |

\* Remaining FAIL is C9 test-logic outdated — the test pre-supposed `action="answer"` would always be rejected; my fix flipped that. The feature actually works (see c9-verify.mjs evidence).

## Why tactical not structural

Sprint 2 PR a-structural (file-state migration + host-mutation queue per docs/SPRINT-2-PLAN.md and SPRINT-2-HOST-MUTATION-QUEUE.md) is ~1200 LOC + multi-day work that retires this whole patch surface. This tactical bundle is ~190 LOC, closes the same bug class for the patch path, and unblocks the beta gate. Sprint 2 ships in v0.3.0 to retire the patch.

## Test plan

- [x] Patch applies cleanly to vanilla v2026.4.23-beta.5
- [x] Plugin unit tests green
- [x] Live QA gateway regression (adversarial + extra + sub-agent + longrun)
- [x] C9 end-to-end via custom verify script
- [ ] CI green
- [ ] After merge: re-deploy to Eva, operator click-test on plan→approve cycle