### PR TITLE
chore(installer): pin to openclaw v2026.4.23 stable

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -35,7 +35,7 @@ export {
  * `expectedHostVersion` whenever Smarter-Claw moves to a new host
  * baseline.
  */
-export const SUPPORTED_OPENCLAW_VERSION = "2026.4.22";
+export const SUPPORTED_OPENCLAW_VERSION = "2026.4.23";
 
 /**
  * Runtime guard: throw a clear error if the host version doesn't exactly

--- a/installer/patch-plan.json
+++ b/installer/patch-plan.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "expectedHostVersion": "2026.4.23-beta.5",
+  "expectedHostVersion": "2026.4.23",
   "smarterClawTargetVersion": "0.1.0",
   "_comment": "patches[] is populated as the UI/core patch authoring lands. install.mjs reads this file and dispatches each entry to applyNewFilePatch or applyDiffPatch. Each entry shape: { type: 'new-file', relPath, sourceRelPath } OR { type: 'diff', relPath, patchRelPath, expectedOriginalSha256 }.",
   "patches": [
@@ -239,7 +239,7 @@
       "type": "diff",
       "relPath": "src/config/schema.base.generated.ts",
       "patchRelPath": "patches/core/schema-allow-conversation-access.diff",
-      "expectedOriginalSha256": "ca249d638091766d9b262d93318f33c5846155c9319cc5b15a195d0af226167c"
+      "expectedOriginalSha256": "ac73854eef5b6b8494f31cb9aa5191d200e83cc3f8be15b6dbd95abc38a7fa22"
     },
     {
       "type": "diff",


### PR DESCRIPTION
Operator directive: upgrade Eva from v2026.4.23-beta.5 to v2026.4.23 release. Sub-agent verification confirmed 32/33 patched files byte-identical between beta.5 and stable; only `src/config/schema.base.generated.ts` changed (version-string \~5 KLOC away from our anchor). SHA bumped, all anchors intact.

Eva validated post-deploy: gateway ready 13:16:20 with 8 plugins including smarter-claw, on /opt/homebrew/lib/node_modules/openclaw symlinked to ~/repos/openclaw-vanilla-v2026.4.23.

Test plan:
- [x] All 33 patches apply against new worktree
- [x] Eva gateway starts cleanly with smarter-claw loaded
- [x] CI green