### PR TITLE
feat(patcher): chat-stream seam tactical patch (upstream PR #80982 not yet merged)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,35 @@ start when the flag is missing.
 Minimum host version: `openclaw >= 2026.5.10-beta.5` (declared via
 `minHostVersion` in `openclaw.plugin.json`).
 
+## Optional: chat-stream seam patch (for inline UI before upstream merges)
+
+The plugin's v0.x sidebar UI works out of the box. For the v1.0 **inline UI** (mode-switcher chip, inline plan cards, input-bar suppression on pending approval), Smarter-Claw needs SDK seams that aren't in the upstream openclaw release yet — they're filed as draft PR [openclaw/openclaw#80982](https://github.com/openclaw/openclaw/pull/80982).
+
+Until that merges, you can tactically apply the seam to your local `node_modules/openclaw/` via a small, reversible patcher:
+
+```bash
+# From the Smarter-Claw clone directory:
+npm run patch:chat-stream-seam              # apply patch (with SHA pre-flight)
+npm run patch:chat-stream-seam:verify       # check applied state
+npm run patch:chat-stream-seam:uninstall    # restore originals
+```
+
+Or directly:
+
+```bash
+node scripts/install-chat-stream-seam.mjs --host /path/to/your/openclaw
+```
+
+What the patcher does:
+- Validates the installed openclaw version matches the patcher's manifest (refuses on mismatch)
+- SHA256-checks the 2 dist files that will be replaced against the manifest's expected baseline (refuses on drift — use `--force` to override at your own risk)
+- Backs up the originals into `node_modules/openclaw/.smarter-claw-backups/`
+- Replaces 2 compiled JS bundle files with seam-built equivalents (~370KB total; ~80 lines of new code inside larger bundles)
+- Writes a sentinel at `node_modules/openclaw/.smarter-claw-chat-stream-seam-applied.json`
+- The plugin's startup advisory reports whether the patch is applied
+
+The patch is a **temporary tactical unblock**. When upstream openclaw merges PR #80982 into a published release, we'll bump `peerDependencies.openclaw` + drop the patcher.
+
 ## What works in 1.0.0-port.14
 
 | Feature | Status |

--- a/package.json
+++ b/package.json
@@ -11,11 +11,18 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
-    "parity-harness": "vitest run tests/parity/parity-harness.test.ts"
+    "parity-harness": "vitest run tests/parity/parity-harness.test.ts",
+    "patch:chat-stream-seam": "node scripts/install-chat-stream-seam.mjs",
+    "patch:chat-stream-seam:verify": "node scripts/verify-chat-stream-seam.mjs",
+    "patch:chat-stream-seam:uninstall": "node scripts/uninstall-chat-stream-seam.mjs"
   },
   "files": [
     "dist/",
     "openclaw.plugin.json",
+    "patches/",
+    "scripts/install-chat-stream-seam.mjs",
+    "scripts/verify-chat-stream-seam.mjs",
+    "scripts/uninstall-chat-stream-seam.mjs",
     "README.md",
     "LICENSE",
     "TRADEMARK.md",

--- a/patches/openclaw-2026.5.10-beta.5/loader-DdN5GTsW.js
+++ b/patches/openclaw-2026.5.10-beta.5/loader-DdN5GTsW.js
@@ -1,0 +1,5973 @@
+import { a as normalizeLowercaseStringOrEmpty, c as normalizeOptionalString, d as normalizeStringifiedOptionalString } from "./string-coerce-LndEvhRk.js";
+import { C as sanitizeCommandDescriptorDescription, S as normalizeCommandDescriptorName } from "./argv-MdBfPgbe.js";
+import { i as formatErrorMessage } from "./errors-sU2O_9Pv.js";
+import { n as resolveGlobalSingleton } from "./global-singleton-Bq6e5lAP.js";
+import { d as safeRealpathSync, f as safeStatSync, i as isPathInside } from "./path-Bv_HaZDb.js";
+import { t as discoverOpenClawPlugins, u as shouldRejectHardlinkedPluginFiles } from "./discovery-CGdelrfT.js";
+import { i as openRootFileSync } from "./root-file-lqGTwlnZ.js";
+import { p as resolveUserPath } from "./utils-BKwDmOLK.js";
+import { u as resolveAgentIdFromSessionKey } from "./session-key-8g_Q03Po.js";
+import { o as resolveAgentWorkspaceDir } from "./agent-scope-config-CZDrYwyz.js";
+import { l as normalizeTrimmedStringList } from "./string-normalization-DgUPESoD.js";
+import "./agent-scope-DP_cLHM2.js";
+import "./boundary-file-read-G9zPaQBo.js";
+import "./bundle-manifest-CnIrKmGZ.js";
+import { i as fingerprintPluginDiscoveryContext, o as resolvePluginDiscoveryContext } from "./plugin-metadata-snapshot-DPOIHysL.js";
+import { g as isPluginEnabledByDefaultForPlatform, p as collectPluginManifestCompatCodes } from "./installed-plugin-index-store-BLSbYib1.js";
+import { f as writeJsonSync, u as tryReadJsonSync } from "./json-files-CilvvYWi.js";
+import { t as PluginLruCache } from "./plugin-cache-primitives-ip_BGHgo.js";
+import { r as loadInstalledPluginIndexInstallRecordsSync } from "./channel-catalog-registry-Co7iV7jv.js";
+import { i as kindsEqual, n as defaultSlotIdForKey, r as hasKind } from "./slots-BpEPHdhK.js";
+import { c as resolveEffectiveEnableState, d as resolveMemorySlotDecision, l as resolveEffectivePluginActivationState, n as createPluginActivationSource, s as normalizePluginsConfig, t as applyTestPluginDefaults } from "./config-state-CZrv2wrz.js";
+import { t as loadPluginManifestRegistry } from "./manifest-registry-wTF8uWcH.js";
+import { n as getCachedPluginModuleLoader, s as toSafeImportPath, t as createPluginModuleLoaderCache } from "./plugin-module-loader-cache-C1MjGpo8.js";
+import { a as listPluginSdkAliasCandidates, c as resolveExtensionApiAlias, f as resolvePluginRuntimeModulePath, g as shouldPreferNativeModuleLoad, h as resolvePluginSdkScopedAliasMap, m as resolvePluginSdkAliasFile, n as buildPluginLoaderJitiOptions, o as listPluginSdkExportedSubpaths, p as resolvePluginSdkAliasCandidateOrder, t as buildPluginLoaderAliasMap } from "./sdk-alias-B4eXgBoZ.js";
+import { t as createSubsystemLogger } from "./subsystem-DZHcpbSg.js";
+import "./installed-plugin-index-records-B2kw_9-L.js";
+import { i as getRuntimeConfigSnapshot, s as getRuntimeConfigSourceSnapshot } from "./runtime-snapshot-CO_gFTwv.js";
+import { t as validateJsonSchemaValue } from "./schema-validator-BHE2U2ab.js";
+import { n as listChatChannels } from "./chat-meta-BAoz5g0x.js";
+import { s as isDeliverableMessageChannel, u as normalizeMessageChannel } from "./message-channel-C32MUXqZ.js";
+import { t as normalizePluginGatewayMethodScope } from "./gateway-method-policy-oojgHhDk.js";
+import { s as isOperatorScope } from "./operator-scopes-mN0Xhtlq.js";
+import { p as normalizeChannelMeta } from "./bundled-C1XjKG3e.js";
+import { a as serializePluginIdScope, i as normalizePluginIdScope, n as hasExplicitPluginIdScope, t as createPluginIdScopeSet } from "./plugin-scope-nM1wbhNA.js";
+import { t as unwrapDefaultModuleExport } from "./module-export-C5AvBsUt.js";
+import { t as attachPluginApiFacades } from "./api-facades-Sp9CbrAG.js";
+import { t as buildPluginApi } from "./api-builder-B1iBxmEQ.js";
+import { a as listRegisteredAgentHarnesses, c as restoreRegisteredAgentHarnesses, o as registerAgentHarness, r as getRegisteredAgentHarness, t as clearAgentHarnesses } from "./registry-CQTW-EUy.js";
+import { G as resolveMemoryDreamingConfig, K as resolveMemoryDreamingPluginConfig, _ as DEFAULT_MEMORY_DREAMING_PLUGIN_ID } from "./dreaming-BkvGcGnP.js";
+import { a as restoreDetachedTaskLifecycleRuntimeRegistration, i as registerDetachedTaskLifecycleRuntime, n as getDetachedTaskLifecycleRuntimeRegistration, t as clearDetachedTaskLifecycleRuntimeRegistration } from "./detached-task-runtime-state-56WAV4jJ.js";
+import { n as inspectBundleMcpRuntimeSupport } from "./bundle-mcp-DjVHFCv5.js";
+import { A as pluginCommands, E as clearPluginCommandsForPlugin, T as clearPluginCommands, _ as clearPluginInteractiveHandlersForPlugin, a as isConversationHookName, g as clearPluginInteractiveHandlers, h as validatePluginCommandDefinition, j as restorePluginCommands, k as listRegisteredPluginCommands, l as stripPromptMutationFieldsFromLegacyHookResult, o as isPluginHookName, p as registerPluginCommand, s as isPromptInjectionHookName, u as isReservedCommandName, v as listPluginInteractiveHandlers, x as restorePluginInteractiveHandlers, y as registerPluginInteractiveHandler } from "./types-Cyo2UPTi.js";
+import { i as initializeGlobalHookRunner, t as getGlobalHookRunner } from "./hook-runner-global-BrLmvsPB.js";
+import { a as resolveSetupChannelRegistration, i as resolveBundledRuntimeChannelRegistration, n as loadBundledRuntimeChannelPlugin, o as shouldLoadChannelPluginInSetupRuntime, r as mergeSetupRuntimeChannelPlugin, t as channelPluginIdBelongsToManifest } from "./loader-channel-setup-CkRT8SMa.js";
+import { a as listRegisteredMemoryEmbeddingProviders, o as registerMemoryEmbeddingProvider, r as getRegisteredMemoryEmbeddingProvider, s as restoreRegisteredMemoryEmbeddingProviders, t as clearMemoryEmbeddingProviders } from "./memory-embedding-providers-BS1qfV6P.js";
+import { S as restoreMemoryPluginState, _ as registerMemoryPromptSectionForPlugin, b as registerMemoryRuntimeForPlugin, d as listMemoryPromptSupplements, f as registerMemoryCapability, h as registerMemoryFlushPlanResolverForPlugin, i as getMemoryCapabilityRegistration, p as registerMemoryCorpusSupplement, r as clearMemoryPluginState, u as listMemoryCorpusSupplements, v as registerMemoryPromptSupplement } from "./memory-state-DcoJ1SBK.js";
+import { i as withProfile } from "./plugin-load-profile-1Q1ycozE.js";
+import { A as registerPluginSessionSchedulerJob, C as isPluginRegistryRetired, D as getPluginRunContext, E as deletePluginSessionSchedulerJob, F as isPluginJsonValue, I as createEmptyPluginRegistry, N as buildPluginAgentTurnPrepareContext, O as getPluginSessionSchedulerJobGeneration, P as normalizePluginHostHookId, S as isPluginRegistryActivated, T as clearPluginRunContext, a as getActivePluginRegistry, j as setPluginRunContext, l as getActivePluginRuntimeSubagentMode, o as getActivePluginRegistryKey, p as recordImportedPluginId, x as setActivePluginRegistry } from "./runtime-CjpW8NnM.js";
+import { r as registerContextEngineForOwner, t as clearContextEnginesForOwner } from "./registry-CmMKBIhr.js";
+import { f as registerInternalHook, h as unregisterInternalHook } from "./internal-hooks-CeoA7yQy.js";
+import { i as NODE_SYSTEM_RUN_COMMANDS, n as NODE_EXEC_APPROVALS_COMMANDS, r as NODE_SYSTEM_NOTIFY_COMMAND } from "./node-commands-CtUW-J-z.js";
+import { t as createPluginStateKeyedStore } from "./plugin-state-store-BXKYd7Rg.js";
+import { i as emitAgentEvent } from "./agent-events-BNulmQqy.js";
+import { a as normalizeAgentToolResultMiddlewareRuntimeIds, n as normalizePluginToolContractNames, o as normalizeAgentToolResultMiddlewareRuntimes, r as normalizePluginToolNames, t as findUndeclaredPluginToolNames } from "./tool-contracts-DSx__1wQ.js";
+import { n as resolveWorkspaceRoot, r as resolvePathFromInput } from "./workspace-dir-BckOjcyE.js";
+import { n as resolveAgentMainSessionKey } from "./main-session-BmgCfNAb.js";
+import { a as resolveSessionStoreKey, i as resolveSessionStoreAgentId } from "./combined-store-gateway-DccrnQz_.js";
+import { u as resolveStorePath } from "./paths-Cb9jGR8D.js";
+import { t as loadSessionStore } from "./store-load-BzhhVfWn.js";
+import { s as updateSessionStore } from "./store-JkeHQo22.js";
+import { r as resolveAllAgentSessionStoreTargetsSync } from "./targets-B2TeEqeN.js";
+import { c as extractDeliveryInfo } from "./sessions-COf3--8F.js";
+import { n as detectMime, t as FILE_TYPE_SNIFF_MAX_BYTES, u as normalizeMimeType } from "./mime-CZq4WGfd.js";
+import { i as normalizeSessionEntrySlotKey } from "./host-hook-cleanup-NIlnopef.js";
+import { n as normalizePluginHttpPath, t as findOverlappingPluginHttpRoute } from "./http-route-overlap-Hg7HLw9S.js";
+import { r as withPluginRuntimePluginIdScope } from "./gateway-request-scope-C6ftwu8p.js";
+import fs from "node:fs";
+import path from "node:path";
+import { lstat, open } from "node:fs/promises";
+import { createHash, randomUUID } from "node:crypto";
+//#region src/plugins/activation-source-config.ts
+function resolvePluginActivationSourceConfig(params) {
+	if (params.activationSourceConfig !== void 0) return params.activationSourceConfig;
+	const sourceSnapshot = getRuntimeConfigSourceSnapshot();
+	if (sourceSnapshot && params.config === getRuntimeConfigSnapshot()) return sourceSnapshot;
+	return params.config ?? {};
+}
+//#endregion
+//#region src/plugins/api-lifecycle.ts
+const PLUGIN_API_METHOD_POLICIES = {
+	emitAgentEvent: {
+		phase: "runtime",
+		lateCallable: true
+	},
+	sendSessionAttachment: {
+		phase: "runtime",
+		lateCallable: true
+	},
+	scheduleSessionTurn: {
+		phase: "runtime",
+		lateCallable: true
+	},
+	unscheduleSessionTurnsByTag: {
+		phase: "runtime",
+		lateCallable: true
+	}
+};
+function getPluginApiMethodLifecyclePolicy(methodName) {
+	return PLUGIN_API_METHOD_POLICIES[methodName];
+}
+function isLateCallablePluginApiMethod(methodName) {
+	return getPluginApiMethodLifecyclePolicy(methodName)?.lateCallable === true;
+}
+//#endregion
+//#region src/plugins/compaction-provider.ts
+const COMPACTION_PROVIDER_REGISTRY_STATE = Symbol.for("openclaw.compactionProviderRegistryState");
+function getCompactionProviderRegistryState() {
+	const globalState = globalThis;
+	if (!globalState[COMPACTION_PROVIDER_REGISTRY_STATE]) globalState[COMPACTION_PROVIDER_REGISTRY_STATE] = { providers: /* @__PURE__ */ new Map() };
+	return globalState[COMPACTION_PROVIDER_REGISTRY_STATE];
+}
+/**
+* Register a compaction provider implementation.
+* Pass `ownerPluginId` so the loader can snapshot/restore correctly.
+*/
+function registerCompactionProvider(provider, options) {
+	getCompactionProviderRegistryState().providers.set(provider.id, {
+		provider,
+		ownerPluginId: options?.ownerPluginId
+	});
+}
+/** Return the provider for the given id, or undefined. */
+function getCompactionProvider(id) {
+	return getCompactionProviderRegistryState().providers.get(id)?.provider;
+}
+/** Return the registered entry (provider + owner) for the given id. */
+function getRegisteredCompactionProvider(id) {
+	return getCompactionProviderRegistryState().providers.get(id);
+}
+/** List all registered entries with owner metadata (for snapshot/restore). */
+function listRegisteredCompactionProviders() {
+	return Array.from(getCompactionProviderRegistryState().providers.values());
+}
+/** Clear all compaction providers. Used by clearPluginLoaderCache() and reload. */
+function clearCompactionProviders() {
+	getCompactionProviderRegistryState().providers.clear();
+}
+/** Restore from a snapshot, replacing all current entries. */
+function restoreRegisteredCompactionProviders(entries) {
+	const map = getCompactionProviderRegistryState().providers;
+	map.clear();
+	for (const entry of entries) map.set(entry.provider.id, entry);
+}
+//#endregion
+//#region src/plugins/loader-cache-state.ts
+var PluginLoadReentryError = class extends Error {
+	constructor(cacheKey) {
+		super(`plugin load reentry detected for cache key: ${cacheKey}`);
+		this.name = "PluginLoadReentryError";
+		this.cacheKey = cacheKey;
+	}
+};
+var PluginLoaderCacheState = class {
+	#registryCache;
+	#inFlightLoads = /* @__PURE__ */ new Set();
+	#openAllowlistWarningCache = /* @__PURE__ */ new Set();
+	constructor(defaultMaxEntries) {
+		this.#registryCache = new PluginLruCache(defaultMaxEntries);
+	}
+	get maxEntries() {
+		return this.#registryCache.maxEntries;
+	}
+	setMaxEntriesForTest(value) {
+		this.#registryCache.setMaxEntriesForTest(value);
+	}
+	clear() {
+		this.#registryCache.clear();
+		this.#inFlightLoads.clear();
+		this.#openAllowlistWarningCache.clear();
+	}
+	clearCachedRegistries() {
+		this.#registryCache.clear();
+		this.#openAllowlistWarningCache.clear();
+	}
+	get(cacheKey) {
+		return this.#registryCache.get(cacheKey);
+	}
+	set(cacheKey, state) {
+		this.#registryCache.set(cacheKey, state);
+	}
+	isLoadInFlight(cacheKey) {
+		return this.#inFlightLoads.has(cacheKey);
+	}
+	beginLoad(cacheKey) {
+		if (this.#inFlightLoads.has(cacheKey)) throw new PluginLoadReentryError(cacheKey);
+		this.#inFlightLoads.add(cacheKey);
+	}
+	finishLoad(cacheKey) {
+		this.#inFlightLoads.delete(cacheKey);
+	}
+	hasOpenAllowlistWarning(cacheKey) {
+		return this.#openAllowlistWarningCache.has(cacheKey);
+	}
+	recordOpenAllowlistWarning(cacheKey) {
+		this.#openAllowlistWarningCache.add(cacheKey);
+	}
+};
+//#endregion
+//#region src/plugins/loader-provenance.ts
+function createPathMatcher() {
+	return {
+		exact: /* @__PURE__ */ new Set(),
+		dirs: []
+	};
+}
+function addPathToMatcher(matcher, rawPath, env = process.env) {
+	const trimmed = rawPath.trim();
+	if (!trimmed) return;
+	const resolved = resolveUserPath(trimmed, env);
+	if (!resolved) return;
+	const canonical = safeRealpathSync(resolved) ?? resolved;
+	if (matcher.exact.has(canonical) || matcher.dirs.includes(canonical)) return;
+	if (safeStatSync(canonical)?.isDirectory()) {
+		matcher.dirs.push(canonical);
+		return;
+	}
+	matcher.exact.add(canonical);
+}
+function matchesPathMatcher(matcher, sourcePath) {
+	if (matcher.exact.has(sourcePath)) return true;
+	return matcher.dirs.some((dirPath) => isPathInside(dirPath, sourcePath));
+}
+function buildProvenanceIndex(params) {
+	const loadPathMatcher = createPathMatcher();
+	for (const loadPath of params.normalizedLoadPaths) addPathToMatcher(loadPathMatcher, loadPath, params.env);
+	const installRules = /* @__PURE__ */ new Map();
+	const installs = loadInstalledPluginIndexInstallRecordsSync({ env: params.env });
+	for (const [pluginId, install] of Object.entries(installs)) {
+		const rule = {
+			trackedWithoutPaths: false,
+			matcher: createPathMatcher()
+		};
+		const trackedPaths = [install.installPath, install.sourcePath].map((entry) => normalizeOptionalString(entry)).filter((entry) => Boolean(entry));
+		if (trackedPaths.length === 0) rule.trackedWithoutPaths = true;
+		else for (const trackedPath of trackedPaths) addPathToMatcher(rule.matcher, trackedPath, params.env);
+		installRules.set(pluginId, rule);
+	}
+	return {
+		loadPathMatcher,
+		installRules
+	};
+}
+function isTrackedByProvenance(params) {
+	const sourcePath = resolveUserPath(params.source, params.env);
+	const canonicalSourcePath = safeRealpathSync(sourcePath) ?? sourcePath;
+	const installRule = params.index.installRules.get(params.pluginId);
+	if (installRule) {
+		if (installRule.trackedWithoutPaths) return true;
+		if (matchesPathMatcher(installRule.matcher, canonicalSourcePath)) return true;
+	}
+	return matchesPathMatcher(params.index.loadPathMatcher, canonicalSourcePath);
+}
+function matchesExplicitInstallRule(params) {
+	const sourcePath = resolveUserPath(params.source, params.env);
+	const canonicalSourcePath = safeRealpathSync(sourcePath) ?? sourcePath;
+	const installRule = params.index.installRules.get(params.pluginId);
+	if (!installRule || installRule.trackedWithoutPaths) return false;
+	return matchesPathMatcher(installRule.matcher, canonicalSourcePath);
+}
+function resolveCandidateDuplicateRank(params) {
+	const pluginId = params.manifestByRoot.get(params.candidate.rootDir)?.id;
+	const isExplicitInstall = params.candidate.origin === "global" && pluginId !== void 0 && matchesExplicitInstallRule({
+		pluginId,
+		source: params.candidate.source,
+		index: params.provenance,
+		env: params.env
+	});
+	if (params.candidate.origin === "config") return 0;
+	if (params.candidate.origin === "global" && isExplicitInstall) return 1;
+	if (params.candidate.origin === "bundled") return 2;
+	if (params.candidate.origin === "workspace") return 3;
+	return 4;
+}
+function compareDuplicateCandidateOrder(params) {
+	const leftPluginId = params.manifestByRoot.get(params.left.rootDir)?.id;
+	const rightPluginId = params.manifestByRoot.get(params.right.rootDir)?.id;
+	if (!leftPluginId || leftPluginId !== rightPluginId) return 0;
+	return resolveCandidateDuplicateRank({
+		candidate: params.left,
+		manifestByRoot: params.manifestByRoot,
+		provenance: params.provenance,
+		env: params.env
+	}) - resolveCandidateDuplicateRank({
+		candidate: params.right,
+		manifestByRoot: params.manifestByRoot,
+		provenance: params.provenance,
+		env: params.env
+	});
+}
+function warnWhenAllowlistIsOpen(params) {
+	if (!params.emitWarning) return;
+	if (!params.pluginsEnabled) return;
+	if (params.allow.length > 0) return;
+	const autoDiscoverable = params.discoverablePlugins.filter((entry) => entry.origin === "workspace" || entry.origin === "global");
+	if (autoDiscoverable.length === 0) return;
+	if (params.warningCache.hasOpenAllowlistWarning(params.warningCacheKey)) return;
+	const preview = autoDiscoverable.slice(0, 6).map((entry) => `${entry.id} (${entry.source})`).join(", ");
+	const extra = autoDiscoverable.length > 6 ? ` (+${autoDiscoverable.length - 6} more)` : "";
+	params.warningCache.recordOpenAllowlistWarning(params.warningCacheKey);
+	params.logger.warn(`[plugins] plugins.allow is empty; discovered non-bundled plugins may auto-load: ${preview}${extra}. Set plugins.allow to explicit trusted ids.`);
+}
+function warnAboutUntrackedLoadedPlugins(params) {
+	const allowSet = new Set(params.allowlist);
+	for (const plugin of params.registry.plugins) {
+		if (plugin.status !== "loaded" || plugin.origin === "bundled") continue;
+		if (allowSet.has(plugin.id)) continue;
+		if (isTrackedByProvenance({
+			pluginId: plugin.id,
+			source: plugin.source,
+			index: params.provenance,
+			env: params.env
+		})) continue;
+		const message = "loaded without install/load-path provenance; treat as untracked local code and pin trust via plugins.allow or install records";
+		params.registry.diagnostics.push({
+			level: "warn",
+			pluginId: plugin.id,
+			source: plugin.source,
+			message
+		});
+		if (params.emitWarning) params.logger.warn(`[plugins] ${plugin.id}: ${message} (${plugin.source})`);
+	}
+}
+//#endregion
+//#region src/plugins/loader-records.ts
+function createPluginRecord(params) {
+	return {
+		id: params.id,
+		name: params.name ?? params.id,
+		description: params.description,
+		version: params.version,
+		packageName: params.packageName,
+		format: params.format ?? "openclaw",
+		bundleFormat: params.bundleFormat,
+		bundleCapabilities: params.bundleCapabilities,
+		source: params.source,
+		rootDir: params.rootDir,
+		origin: params.origin,
+		workspaceDir: params.workspaceDir,
+		trustedOfficialInstall: params.trustedOfficialInstall,
+		enabled: params.enabled,
+		compat: params.compat,
+		explicitlyEnabled: params.activationState?.explicitlyEnabled,
+		activated: params.activationState?.activated,
+		activationSource: params.activationState?.source,
+		activationReason: params.activationState?.reason,
+		syntheticAuthRefs: params.syntheticAuthRefs ?? [],
+		status: params.enabled ? "loaded" : "disabled",
+		toolNames: [],
+		hookNames: [],
+		channelIds: [...params.channelIds ?? []],
+		cliBackendIds: [],
+		providerIds: [...params.providerIds ?? []],
+		speechProviderIds: [...params.contracts?.speechProviders ?? []],
+		realtimeTranscriptionProviderIds: [...params.contracts?.realtimeTranscriptionProviders ?? []],
+		realtimeVoiceProviderIds: [...params.contracts?.realtimeVoiceProviders ?? []],
+		mediaUnderstandingProviderIds: [...params.contracts?.mediaUnderstandingProviders ?? []],
+		imageGenerationProviderIds: [...params.contracts?.imageGenerationProviders ?? []],
+		videoGenerationProviderIds: [...params.contracts?.videoGenerationProviders ?? []],
+		musicGenerationProviderIds: [...params.contracts?.musicGenerationProviders ?? []],
+		webFetchProviderIds: [...params.contracts?.webFetchProviders ?? []],
+		webSearchProviderIds: [...params.contracts?.webSearchProviders ?? []],
+		migrationProviderIds: [...params.contracts?.migrationProviders ?? []],
+		contextEngineIds: [],
+		memoryEmbeddingProviderIds: [...params.contracts?.memoryEmbeddingProviders ?? []],
+		agentHarnessIds: [],
+		gatewayMethods: [],
+		cliCommands: [],
+		services: [],
+		gatewayDiscoveryServiceIds: [],
+		commands: [],
+		httpRoutes: 0,
+		hookCount: 0,
+		configSchema: params.configSchema,
+		configUiHints: void 0,
+		configJsonSchema: void 0,
+		contracts: params.contracts
+	};
+}
+function markPluginActivationDisabled(record, reason) {
+	record.activated = false;
+	record.activationSource = "disabled";
+	record.activationReason = reason;
+}
+function formatAutoEnabledActivationReason(reasons) {
+	if (!reasons || reasons.length === 0) return;
+	return reasons.join("; ");
+}
+function recordPluginError(params) {
+	const errorText = process.env.OPENCLAW_PLUGIN_LOADER_DEBUG_STACKS === "1" && params.error instanceof Error && typeof params.error.stack === "string" ? params.error.stack : String(params.error);
+	const deprecatedApiHint = errorText.includes("api.registerHttpHandler") && errorText.includes("is not a function") ? "deprecated api.registerHttpHandler(...) was removed; use api.registerHttpRoute(...) for plugin-owned routes or registerPluginHttpRoute(...) for dynamic lifecycle routes" : null;
+	const displayError = deprecatedApiHint ? `${deprecatedApiHint} (${errorText})` : errorText;
+	params.logger.error(`${params.logPrefix}${displayError}`);
+	params.record.status = "error";
+	params.record.error = displayError;
+	params.record.failedAt = /* @__PURE__ */ new Date();
+	params.record.failurePhase = params.phase;
+	params.registry.plugins.push(params.record);
+	params.seenIds.set(params.pluginId, params.origin);
+	params.registry.diagnostics.push({
+		level: "error",
+		pluginId: params.record.id,
+		source: params.record.source,
+		message: `${params.diagnosticMessagePrefix}${displayError}`
+	});
+}
+function formatPluginFailureSummary(failedPlugins) {
+	const grouped = /* @__PURE__ */ new Map();
+	for (const plugin of failedPlugins) {
+		const phase = plugin.failurePhase ?? "load";
+		const ids = grouped.get(phase);
+		if (ids) {
+			ids.push(plugin.id);
+			continue;
+		}
+		grouped.set(phase, [plugin.id]);
+	}
+	return [...grouped.entries()].map(([phase, ids]) => `${phase}: ${ids.join(", ")}`).join("; ");
+}
+function isPluginLoadDebugEnabled(env) {
+	const normalized = normalizeLowercaseStringOrEmpty(env.OPENCLAW_PLUGIN_LOAD_DEBUG);
+	return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+function describePluginModuleExportShape(value, label = "export", seen = /* @__PURE__ */ new Set()) {
+	if (value === null) return [`${label}:null`];
+	if (typeof value !== "object") return [`${label}:${typeof value}`];
+	if (seen.has(value)) return [`${label}:circular`];
+	seen.add(value);
+	const record = value;
+	const keys = Object.keys(record).toSorted();
+	const visibleKeys = keys.slice(0, 8);
+	const extraCount = keys.length - visibleKeys.length;
+	const details = [`${label}:object keys=${visibleKeys.length > 0 ? `${visibleKeys.join(",")}${extraCount > 0 ? `,+${extraCount}` : ""}` : "none"}`];
+	for (const key of [
+		"default",
+		"module",
+		"register",
+		"activate"
+	]) if (Object.prototype.hasOwnProperty.call(record, key)) details.push(...describePluginModuleExportShape(record[key], `${label}.${key}`, seen));
+	return details;
+}
+function formatMissingPluginRegisterError(moduleExport, env) {
+	const message = "plugin export missing register/activate";
+	if (!isPluginLoadDebugEnabled(env)) return message;
+	return `${message} (module shape: ${describePluginModuleExportShape(moduleExport).join("; ")})`;
+}
+//#endregion
+//#region src/plugins/plugin-sdk-dist-alias.ts
+function writeRuntimeJsonFile(targetPath, value) {
+	writeJsonSync(targetPath, value);
+}
+function writeRuntimeModuleWrapper(sourcePath, targetPath) {
+	const relative = `./${path.relative(path.dirname(targetPath), sourcePath).split(path.sep).join("/")}`;
+	const content = [`export * from ${JSON.stringify(relative)};`, ""].join("\n");
+	try {
+		if (fs.readFileSync(targetPath, "utf8") === content) return;
+	} catch {}
+	fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+	fs.writeFileSync(targetPath, content, "utf8");
+}
+function ensureOpenClawPluginSdkAlias(distRoot) {
+	const pluginSdkDir = path.join(distRoot, "plugin-sdk");
+	if (!fs.existsSync(pluginSdkDir)) return;
+	const aliasDir = path.join(distRoot, "extensions", "node_modules", "openclaw");
+	const pluginSdkAliasDir = path.join(aliasDir, "plugin-sdk");
+	writeRuntimeJsonFile(path.join(aliasDir, "package.json"), {
+		name: "openclaw",
+		type: "module",
+		exports: {
+			"./plugin-sdk": "./plugin-sdk/index.js",
+			"./plugin-sdk/*": "./plugin-sdk/*.js"
+		}
+	});
+	try {
+		if (fs.existsSync(pluginSdkAliasDir) && !fs.lstatSync(pluginSdkAliasDir).isDirectory()) fs.rmSync(pluginSdkAliasDir, {
+			recursive: true,
+			force: true
+		});
+	} catch {}
+	fs.mkdirSync(pluginSdkAliasDir, { recursive: true });
+	for (const entry of fs.readdirSync(pluginSdkDir, { withFileTypes: true })) {
+		if (!entry.isFile() || path.extname(entry.name) !== ".js") continue;
+		writeRuntimeModuleWrapper(path.join(pluginSdkDir, entry.name), path.join(pluginSdkAliasDir, entry.name));
+	}
+}
+//#endregion
+//#region src/plugins/agent-event-emission.ts
+const HOST_OWNED_AGENT_EVENT_STREAMS = new Set([
+	"lifecycle",
+	"tool",
+	"assistant",
+	"error",
+	"item",
+	"plan",
+	"approval",
+	"command_output",
+	"patch",
+	"compaction",
+	"thinking",
+	"model"
+]);
+function isPluginOwnedAgentEventStream(pluginId, stream) {
+	return stream === pluginId || stream.startsWith(`${pluginId}.`);
+}
+function normalizePluginEventData(params) {
+	if (params.data && typeof params.data === "object" && !Array.isArray(params.data)) return {
+		...params.data,
+		pluginId: params.pluginId,
+		...params.pluginName ? { pluginName: params.pluginName } : {}
+	};
+	return {
+		value: params.data,
+		pluginId: params.pluginId,
+		...params.pluginName ? { pluginName: params.pluginName } : {}
+	};
+}
+function emitPluginAgentEvent(params) {
+	const runId = normalizeOptionalString(params.event.runId);
+	const sessionKey = normalizeOptionalString(params.event.sessionKey);
+	const stream = normalizeOptionalString(params.event.stream);
+	if (!runId || !stream) return {
+		emitted: false,
+		reason: "runId and stream are required"
+	};
+	if (!isPluginJsonValue(params.event.data)) return {
+		emitted: false,
+		reason: "event data must be JSON-compatible"
+	};
+	if (params.origin !== "bundled" && HOST_OWNED_AGENT_EVENT_STREAMS.has(stream)) return {
+		emitted: false,
+		reason: `stream ${stream} is reserved for bundled plugins`
+	};
+	if (params.origin !== "bundled" && !isPluginOwnedAgentEventStream(params.pluginId, stream)) return {
+		emitted: false,
+		reason: `stream ${stream} must be scoped to plugin ${params.pluginId}`
+	};
+	emitAgentEvent({
+		runId,
+		stream,
+		...sessionKey ? { sessionKey } : {},
+		data: normalizePluginEventData({
+			pluginId: params.pluginId,
+			pluginName: params.pluginName,
+			data: params.event.data
+		})
+	});
+	return {
+		emitted: true,
+		stream
+	};
+}
+//#endregion
+//#region src/plugins/validation-diagnostics.ts
+function pushPluginValidationDiagnostic(params) {
+	params.pushDiagnostic({
+		level: params.level,
+		pluginId: params.pluginId,
+		source: params.source,
+		message: params.message
+	});
+}
+//#endregion
+//#region src/plugins/channel-validation.ts
+function resolveBundledChannelMeta(id) {
+	return listChatChannels().find((meta) => meta?.id === id);
+}
+function collectMissingChannelMetaFields(meta) {
+	const missing = [];
+	if (!normalizeOptionalString(meta?.label)) missing.push("label");
+	if (!normalizeOptionalString(meta?.selectionLabel)) missing.push("selectionLabel");
+	if (!normalizeOptionalString(meta?.docsPath)) missing.push("docsPath");
+	if (typeof meta?.blurb !== "string") missing.push("blurb");
+	return missing;
+}
+function normalizeRegisteredChannelPlugin(params) {
+	const id = normalizeOptionalString(params.plugin?.id) ?? normalizeStringifiedOptionalString(params.plugin?.id) ?? "";
+	if (!id) {
+		pushPluginValidationDiagnostic({
+			level: "error",
+			pluginId: params.pluginId,
+			source: params.source,
+			message: "channel registration missing id",
+			pushDiagnostic: params.pushDiagnostic
+		});
+		return null;
+	}
+	if (typeof params.plugin.config?.listAccountIds !== "function" || typeof params.plugin.config?.resolveAccount !== "function") {
+		pushPluginValidationDiagnostic({
+			level: "error",
+			pluginId: params.pluginId,
+			source: params.source,
+			message: `channel "${id}" registration missing required config helpers`,
+			pushDiagnostic: params.pushDiagnostic
+		});
+		return null;
+	}
+	const rawMeta = params.plugin.meta;
+	const rawMetaId = normalizeOptionalString(rawMeta?.id);
+	if (rawMetaId && rawMetaId !== id) pushPluginValidationDiagnostic({
+		level: "warn",
+		pluginId: params.pluginId,
+		source: params.source,
+		message: `channel "${id}" meta.id mismatch ("${rawMetaId}"); using registered channel id`,
+		pushDiagnostic: params.pushDiagnostic
+	});
+	const missingFields = collectMissingChannelMetaFields(rawMeta);
+	if (missingFields.length > 0) pushPluginValidationDiagnostic({
+		level: "warn",
+		pluginId: params.pluginId,
+		source: params.source,
+		message: `channel "${id}" registered incomplete metadata; filled missing ${missingFields.join(", ")}`,
+		pushDiagnostic: params.pushDiagnostic
+	});
+	return {
+		...params.plugin,
+		id,
+		meta: normalizeChannelMeta({
+			id,
+			meta: rawMeta,
+			existing: resolveBundledChannelMeta(id)
+		})
+	};
+}
+function listCodexAppServerExtensionFactories() {
+	return getActivePluginRegistry()?.codexAppServerExtensionFactories?.map((entry) => entry.factory) ?? [];
+}
+//#endregion
+//#region src/plugins/host-hook-attachments.ts
+const DEFAULT_ATTACHMENT_MAX_BYTES = 25 * 1024 * 1024;
+const MAX_ATTACHMENT_FILES = 10;
+let sendMessagePromise;
+async function loadSendMessage() {
+	sendMessagePromise ??= import("./message-C4KecB6y.js").then((module) => module.sendMessage);
+	return sendMessagePromise;
+}
+let getChannelPluginPromise;
+async function loadGetChannelPlugin() {
+	getChannelPluginPromise ??= import("./plugins-Djr7cHaC.js").then((module) => module.getChannelPlugin);
+	return getChannelPluginPromise;
+}
+function captionFormatToParseMode(captionFormat) {
+	if (captionFormat === "html") return "HTML";
+}
+function escapeHtmlText(text) {
+	return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+async function readMimeSniffBuffer(filePath, size) {
+	let handle;
+	try {
+		handle = await open(filePath, "r");
+		const length = Math.min(Math.max(0, size), FILE_TYPE_SNIFF_MAX_BYTES);
+		const buffer = Buffer.alloc(length);
+		const { bytesRead } = await handle.read(buffer, 0, length, 0);
+		return buffer.subarray(0, bytesRead);
+	} catch (error) {
+		return { error: `attachment file MIME read failed for ${filePath}: ${formatErrorMessage(error)}` };
+	} finally {
+		await handle?.close().catch(() => void 0);
+	}
+}
+function resolveAttachmentDelivery(params) {
+	const fallbackParseMode = captionFormatToParseMode(params.captionFormat);
+	const channel = params.channel.trim().toLowerCase();
+	if (channel === "telegram") {
+		const hint = params.channelHints?.telegram;
+		const parseMode = hint?.parseMode ?? (params.captionFormat === "plain" ? "HTML" : fallbackParseMode);
+		const escapePlainHtmlCaption = params.captionFormat === "plain" && parseMode === "HTML";
+		const forceDocumentMime = normalizeMimeType(hint?.forceDocumentMime);
+		return {
+			...parseMode ? { parseMode } : {},
+			...escapePlainHtmlCaption ? { escapePlainHtmlCaption: true } : {},
+			...hint?.disableNotification !== void 0 ? { disableNotification: hint.disableNotification } : {},
+			...forceDocumentMime ? { forceDocumentMime } : {}
+		};
+	}
+	if (channel === "discord") return fallbackParseMode ? { parseMode: fallbackParseMode } : {};
+	if (channel === "slack") {
+		const hint = params.channelHints?.slack;
+		const threadTs = normalizeOptionalString(hint?.threadTs);
+		return {
+			...fallbackParseMode ? { parseMode: fallbackParseMode } : {},
+			...threadTs ? { threadTs } : {}
+		};
+	}
+	return fallbackParseMode ? { parseMode: fallbackParseMode } : {};
+}
+async function validateAttachmentFiles(files, maxBytes, options) {
+	if (files.length > MAX_ATTACHMENT_FILES) return { error: `at most ${MAX_ATTACHMENT_FILES} attachment files are allowed` };
+	const paths = [];
+	let totalBytes = 0;
+	for (const file of files) {
+		if (!file || typeof file !== "object" || Array.isArray(file)) return { error: "attachment file entry must be an object" };
+		const filePath = normalizeOptionalString(file.path);
+		if (!filePath) return { error: "attachment file path is required" };
+		const resolvedPath = resolveAttachmentFilePath({
+			filePath,
+			config: options?.config,
+			sessionKey: options?.sessionKey
+		});
+		const info = await lstat(resolvedPath).catch(() => void 0);
+		if (info?.isSymbolicLink()) return { error: `attachment file symlinks are not allowed: ${resolvedPath}` };
+		if (!info?.isFile()) return { error: `attachment file not found: ${resolvedPath}` };
+		if (info.size > maxBytes) return { error: `attachment file exceeds ${maxBytes} bytes: ${resolvedPath}` };
+		if (options?.forceDocumentMime) {
+			const fileBuffer = await readMimeSniffBuffer(resolvedPath, info.size);
+			if (!Buffer.isBuffer(fileBuffer)) return fileBuffer;
+			let detectedMime;
+			try {
+				detectedMime = normalizeMimeType(await detectMime({ buffer: fileBuffer }));
+			} catch (error) {
+				return { error: `attachment file MIME detection failed for ${filePath}: ` + formatErrorMessage(error) };
+			}
+			if (detectedMime !== options.forceDocumentMime) return { error: `attachment file MIME mismatch for ${resolvedPath}: expected ${options.forceDocumentMime}, got ${detectedMime ?? "unknown"}` };
+		}
+		totalBytes += info.size;
+		if (totalBytes > maxBytes) return { error: `attachment files exceed ${maxBytes} bytes total` };
+		paths.push(resolvedPath);
+	}
+	return paths;
+}
+function resolveAttachmentFilePath(params) {
+	const workspaceDir = params.sessionKey && params.config ? resolveAgentWorkspaceDir(params.config, resolveAgentIdFromSessionKey(params.sessionKey)) : void 0;
+	return resolvePathFromInput(params.filePath, resolveWorkspaceRoot(workspaceDir));
+}
+function normalizeOptionalThreadId(value) {
+	if (typeof value === "number" && Number.isFinite(value)) return value;
+	return normalizeOptionalString(value);
+}
+async function sendPluginSessionAttachment(params) {
+	if (params.origin !== "bundled") return {
+		ok: false,
+		error: "session attachments are restricted to bundled plugins"
+	};
+	const sessionKey = normalizeOptionalString(params.sessionKey);
+	if (!sessionKey) return {
+		ok: false,
+		error: "sessionKey is required"
+	};
+	if (!Array.isArray(params.files) || params.files.length === 0) return {
+		ok: false,
+		error: "at least one attachment file is required"
+	};
+	const maxBytes = typeof params.maxBytes === "number" && Number.isFinite(params.maxBytes) ? Math.min(DEFAULT_ATTACHMENT_MAX_BYTES, Math.max(1, Math.floor(params.maxBytes))) : DEFAULT_ATTACHMENT_MAX_BYTES;
+	const { deliveryContext, threadId } = extractDeliveryInfo(sessionKey, { cfg: params.config });
+	if (!deliveryContext?.channel || !deliveryContext.to) return {
+		ok: false,
+		error: `session has no active delivery route: ${sessionKey}`
+	};
+	const normalizedChannel = normalizeMessageChannel(deliveryContext.channel);
+	try {
+		if ((normalizedChannel && isDeliverableMessageChannel(normalizedChannel) ? (await loadGetChannelPlugin())(normalizedChannel) : void 0)?.outbound?.deliveryMode === "gateway") return {
+			ok: false,
+			error: `session attachments require direct outbound delivery for channel ${deliveryContext.channel}; channel uses gateway delivery`
+		};
+	} catch (error) {
+		return {
+			ok: false,
+			error: `attachment delivery setup failed: ${formatErrorMessage(error)}`
+		};
+	}
+	const rawText = normalizeOptionalString(params.text) ?? "";
+	const explicitThreadId = normalizeOptionalThreadId(params.threadId);
+	const deliveryThreadId = normalizeOptionalThreadId(deliveryContext.threadId);
+	const fallbackThreadId = normalizeOptionalThreadId(threadId);
+	const resolvedDelivery = resolveAttachmentDelivery({
+		channel: deliveryContext.channel,
+		captionFormat: params.captionFormat,
+		channelHints: params.channelHints
+	});
+	const validated = await validateAttachmentFiles(params.files, maxBytes, {
+		forceDocumentMime: resolvedDelivery.forceDocumentMime,
+		config: params.config,
+		sessionKey
+	});
+	if (!Array.isArray(validated)) return {
+		ok: false,
+		error: validated.error
+	};
+	const resolvedThreadId = resolvedDelivery.threadTs ?? explicitThreadId ?? fallbackThreadId ?? deliveryThreadId;
+	let result;
+	try {
+		result = await (await loadSendMessage())({
+			to: deliveryContext.to,
+			content: resolvedDelivery.escapePlainHtmlCaption ? escapeHtmlText(rawText) : rawText,
+			channel: deliveryContext.channel,
+			accountId: deliveryContext.accountId,
+			threadId: resolvedThreadId,
+			requesterSessionKey: sessionKey,
+			mediaUrls: validated,
+			forceDocument: resolvedDelivery.forceDocumentMime ? true : params.forceDocument,
+			bestEffort: false,
+			cfg: params.config,
+			...resolvedDelivery.parseMode ? { parseMode: resolvedDelivery.parseMode } : {},
+			...resolvedDelivery.disableNotification !== void 0 ? { silent: resolvedDelivery.disableNotification } : {}
+		});
+	} catch (error) {
+		return {
+			ok: false,
+			error: `attachment delivery failed: ${formatErrorMessage(error)}`
+		};
+	}
+	if (!result.result) return {
+		ok: false,
+		error: "attachment delivery failed: no delivery result returned"
+	};
+	return {
+		ok: true,
+		channel: result.channel,
+		deliveredTo: deliveryContext.to,
+		count: validated.length
+	};
+}
+//#endregion
+//#region src/plugins/host-hook-scheduled-turns.ts
+const log$1 = createSubsystemLogger("plugins/host-scheduled-turns");
+const PLUGIN_CRON_NAME_PREFIX = "plugin:";
+const PLUGIN_CRON_TAG_MARKER = ":tag:";
+function resolveSchedule(params) {
+	const cron = normalizeOptionalString(params.cron);
+	if (cron) {
+		const tz = normalizeOptionalString(params.tz);
+		return {
+			kind: "cron",
+			expr: cron,
+			...tz ? { tz } : {}
+		};
+	}
+	if ("delayMs" in params) {
+		if (!Number.isFinite(params.delayMs) || params.delayMs < 0) return;
+		const timestamp = Date.now() + Math.max(1, Math.floor(params.delayMs));
+		if (!Number.isFinite(timestamp)) return;
+		const at = new Date(timestamp);
+		if (!Number.isFinite(at.getTime())) return;
+		return {
+			kind: "at",
+			at: at.toISOString()
+		};
+	}
+	const rawAt = params.at;
+	const at = rawAt instanceof Date ? rawAt : new Date(rawAt);
+	if (!Number.isFinite(at.getTime())) return;
+	return {
+		kind: "at",
+		at: at.toISOString()
+	};
+}
+function resolveSessionTurnDeliveryMode(deliveryMode) {
+	if (deliveryMode === void 0) return;
+	if (deliveryMode === "none" || deliveryMode === "announce") return deliveryMode;
+}
+function formatScheduleLogContext(params) {
+	const parts = [`pluginId=${params.pluginId}`];
+	if (params.sessionKey) parts.push(`sessionKey=${params.sessionKey}`);
+	if (params.name) parts.push(`name=${params.name}`);
+	if (params.jobId) parts.push(`jobId=${params.jobId}`);
+	return parts.join(" ");
+}
+async function removeScheduledSessionTurn(params) {
+	try {
+		return didCronCleanupJob(await params.cron.remove(params.jobId));
+	} catch (error) {
+		log$1.warn(`plugin session turn cleanup failed (${formatScheduleLogContext(params)}): ${formatErrorMessage(error)}`);
+		return false;
+	}
+}
+function didCronRemoveJob(value) {
+	return isCronRemoveResult(value) && value.ok && value.removed;
+}
+function didCronCleanupJob(value) {
+	return isCronRemoveResult(value) && value.ok;
+}
+const PLUGIN_CRON_RESERVED_DELIMITER = ":";
+function resolvePluginSessionTurnTag(value) {
+	const tag = normalizeOptionalString(value);
+	if (!tag) return { invalid: false };
+	if (tag.includes(PLUGIN_CRON_RESERVED_DELIMITER)) return { invalid: true };
+	return {
+		tag,
+		invalid: false
+	};
+}
+function buildPluginSchedulerCronName(params) {
+	const uniqueId = params.uniqueId ?? randomUUID();
+	if (!params.tag) return `${PLUGIN_CRON_NAME_PREFIX}${params.pluginId}:${params.sessionKey}:${uniqueId}`;
+	return `${PLUGIN_CRON_NAME_PREFIX}${params.pluginId}${PLUGIN_CRON_TAG_MARKER}${params.tag}:${params.sessionKey}:${uniqueId}`;
+}
+function buildPluginSchedulerTagPrefix(params) {
+	return `${PLUGIN_CRON_NAME_PREFIX}${params.pluginId}${PLUGIN_CRON_TAG_MARKER}${params.tag}:${params.sessionKey}:`;
+}
+function isCronRemoveResult(value) {
+	return Boolean(value) && typeof value === "object" && !Array.isArray(value) && typeof value.ok === "boolean" && typeof value.removed === "boolean";
+}
+async function listAllCronJobsForPluginTagCleanup(cron, query) {
+	const jobs = [];
+	let offset = 0;
+	for (;;) {
+		const listResult = await cron.listPage({
+			includeDisabled: true,
+			limit: 200,
+			query,
+			sortBy: "name",
+			sortDir: "asc",
+			...offset > 0 ? { offset } : {}
+		});
+		jobs.push(...listResult.jobs);
+		if (!listResult.hasMore) return jobs;
+		if (listResult.nextOffset === null || listResult.nextOffset <= offset) return jobs;
+		offset = listResult.nextOffset;
+	}
+}
+async function schedulePluginSessionTurn(params) {
+	if (params.origin !== "bundled") return;
+	const sessionKey = normalizeOptionalString(params.schedule.sessionKey);
+	const message = normalizeOptionalString(params.schedule.message);
+	if (!sessionKey || !message) return;
+	const cronSchedule = resolveSchedule(params.schedule);
+	if (!cronSchedule) return;
+	const rawDeliveryMode = params.schedule.deliveryMode;
+	const deliveryMode = resolveSessionTurnDeliveryMode(rawDeliveryMode);
+	const scheduleName = normalizeOptionalString(params.schedule.name);
+	if (rawDeliveryMode !== void 0 && !deliveryMode) {
+		log$1.warn(`plugin session turn scheduling failed (${formatScheduleLogContext({
+			pluginId: params.pluginId,
+			sessionKey,
+			...scheduleName ? { name: scheduleName } : {}
+		})}): unsupported deliveryMode`);
+		return;
+	}
+	if (cronSchedule.kind === "cron" && params.schedule.deleteAfterRun === true) {
+		log$1.warn(`plugin session turn scheduling failed (${formatScheduleLogContext({
+			pluginId: params.pluginId,
+			sessionKey,
+			...scheduleName ? { name: scheduleName } : {}
+		})}): deleteAfterRun requires a one-shot schedule`);
+		return;
+	}
+	const { tag, invalid: invalidTag } = resolvePluginSessionTurnTag(params.schedule.tag);
+	if (invalidTag) {
+		log$1.warn(`plugin session turn scheduling failed (${formatScheduleLogContext({
+			pluginId: params.pluginId,
+			sessionKey,
+			...scheduleName ? { name: scheduleName } : {}
+		})}): tag contains reserved delimiter ":"`);
+		return;
+	}
+	const cronDeliveryMode = deliveryMode ?? "announce";
+	if (params.shouldCommit && !params.shouldCommit()) return;
+	if (!params.cron) {
+		log$1.warn(`plugin session turn scheduling failed (${formatScheduleLogContext({
+			pluginId: params.pluginId,
+			sessionKey,
+			...scheduleName ? { name: scheduleName } : {}
+		})}): cron service unavailable`);
+		return;
+	}
+	const cron = params.cron;
+	const cronJobName = buildPluginSchedulerCronName({
+		pluginId: params.pluginId,
+		sessionKey,
+		...tag !== void 0 ? { tag } : {},
+		...scheduleName ? { uniqueId: scheduleName } : {}
+	});
+	const cronPayload = {
+		kind: "agentTurn",
+		message
+	};
+	let result;
+	try {
+		result = await cron.add({
+			name: cronJobName,
+			enabled: true,
+			schedule: cronSchedule,
+			sessionTarget: `session:${sessionKey}`,
+			payload: cronPayload,
+			...params.schedule.agentId ? { agentId: params.schedule.agentId } : {},
+			deleteAfterRun: params.schedule.deleteAfterRun ?? cronSchedule.kind === "at",
+			wakeMode: "now",
+			delivery: {
+				mode: cronDeliveryMode,
+				...cronDeliveryMode === "announce" ? { channel: "last" } : {}
+			}
+		});
+	} catch (error) {
+		log$1.warn(`plugin session turn scheduling failed (${formatScheduleLogContext({
+			pluginId: params.pluginId,
+			sessionKey,
+			name: cronJobName
+		})}): ${formatErrorMessage(error)}`);
+		return;
+	}
+	const jobId = result.id;
+	if (!jobId) return;
+	if (params.shouldCommit && !params.shouldCommit()) {
+		if (!await removeScheduledSessionTurn({
+			cron,
+			jobId,
+			pluginId: params.pluginId,
+			sessionKey,
+			name: cronJobName
+		})) log$1.warn(`plugin session turn scheduling rollback failed (${formatScheduleLogContext({
+			pluginId: params.pluginId,
+			sessionKey,
+			name: cronJobName,
+			jobId
+		})}): failed to remove stale scheduled session turn`);
+		return;
+	}
+	return registerPluginSessionSchedulerJob({
+		pluginId: params.pluginId,
+		pluginName: params.pluginName,
+		ownerRegistry: params.ownerRegistry,
+		job: {
+			id: jobId,
+			sessionKey,
+			kind: "session-turn",
+			cleanup: async () => {
+				if (!await removeScheduledSessionTurn({
+					cron,
+					jobId,
+					pluginId: params.pluginId,
+					sessionKey,
+					name: cronJobName
+				})) throw new Error(`failed to remove scheduled session turn: ${jobId}`);
+			}
+		}
+	});
+}
+async function unschedulePluginSessionTurnsByTag(params) {
+	if (params.origin !== "bundled") return {
+		removed: 0,
+		failed: 0
+	};
+	const sessionKey = normalizeOptionalString(params.request.sessionKey);
+	const { tag, invalid: invalidTag } = resolvePluginSessionTurnTag(params.request.tag);
+	if (!sessionKey || !tag || invalidTag) return {
+		removed: 0,
+		failed: 0
+	};
+	if (!params.cron) {
+		log$1.warn("plugin session turn untag-list failed: cron service unavailable");
+		return {
+			removed: 0,
+			failed: 1
+		};
+	}
+	const cron = params.cron;
+	const namePrefix = buildPluginSchedulerTagPrefix({
+		pluginId: params.pluginId,
+		tag,
+		sessionKey
+	});
+	let jobs;
+	try {
+		jobs = await listAllCronJobsForPluginTagCleanup(cron, namePrefix);
+	} catch (error) {
+		log$1.warn(`plugin session turn untag-list failed: ${formatErrorMessage(error)}`);
+		return {
+			removed: 0,
+			failed: 1
+		};
+	}
+	const candidates = jobs.filter((job) => {
+		return job.name.startsWith(namePrefix) && job.sessionTarget === `session:${sessionKey}`;
+	});
+	let removed = 0;
+	let failed = 0;
+	for (const job of candidates) {
+		const id = job.id.trim();
+		if (!id) continue;
+		try {
+			if (didCronRemoveJob(await cron.remove(id))) {
+				removed += 1;
+				deletePluginSessionSchedulerJob({
+					pluginId: params.pluginId,
+					jobId: id,
+					sessionKey
+				});
+			} else failed += 1;
+		} catch (error) {
+			log$1.warn(`plugin session turn untag-remove failed: id=${id} error=${formatErrorMessage(error)}`);
+			failed += 1;
+		}
+	}
+	return {
+		removed,
+		failed
+	};
+}
+//#endregion
+//#region src/plugins/host-hook-state.ts
+const log = createSubsystemLogger("plugins/host-hook-state");
+const PROJECTION_FAILED = Symbol("plugin-session-extension-projection-failed");
+const MAX_PLUGIN_NEXT_TURN_INJECTION_TEXT_LENGTH = 32 * 1024;
+const MAX_PLUGIN_NEXT_TURN_INJECTION_IDEMPOTENCY_KEY_LENGTH = 512;
+const MAX_PLUGIN_NEXT_TURN_INJECTIONS_PER_SESSION = 32;
+function isStorePathTemplate(store) {
+	return typeof store === "string" && store.includes("{agentId}");
+}
+function normalizeNamespace(value) {
+	return value.trim();
+}
+function copyJsonValue(value) {
+	return structuredClone(value);
+}
+function isPluginNextTurnInjectionPlacement(value) {
+	return value === "prepend_context" || value === "append_context";
+}
+function isPluginNextTurnInjectionRecord(value) {
+	if (!value || typeof value !== "object") return false;
+	const candidate = value;
+	return typeof candidate.id === "string" && typeof candidate.pluginId === "string" && typeof candidate.text === "string" && typeof candidate.createdAt === "number" && Number.isFinite(candidate.createdAt) && isPluginNextTurnInjectionPlacement(candidate.placement) && (candidate.ttlMs === void 0 || typeof candidate.ttlMs === "number" && Number.isFinite(candidate.ttlMs) && candidate.ttlMs >= 0) && (candidate.idempotencyKey === void 0 || typeof candidate.idempotencyKey === "string");
+}
+function isExpired(entry, now) {
+	if (!isPluginNextTurnInjectionRecord(entry)) return true;
+	return typeof entry.ttlMs === "number" && entry.ttlMs >= 0 && now - entry.createdAt > entry.ttlMs;
+}
+function findStoreKeysIgnoreCase(store, targetKey) {
+	const lowered = normalizeLowercaseStringOrEmpty(targetKey);
+	const matches = [];
+	for (const key of Object.keys(store)) if (normalizeLowercaseStringOrEmpty(key) === lowered) matches.push(key);
+	return matches;
+}
+function findFreshestStoreMatch(store, ...candidates) {
+	let freshest;
+	for (const candidate of candidates) {
+		const trimmed = normalizeOptionalString(candidate) ?? "";
+		if (!trimmed) continue;
+		const exact = store[trimmed];
+		if (exact && (!freshest || (exact.updatedAt ?? 0) >= (freshest.entry.updatedAt ?? 0))) freshest = {
+			entry: exact,
+			key: trimmed
+		};
+		for (const legacyKey of findStoreKeysIgnoreCase(store, trimmed)) {
+			const entry = store[legacyKey];
+			if (entry && (!freshest || (entry.updatedAt ?? 0) >= (freshest.entry.updatedAt ?? 0))) freshest = {
+				entry,
+				key: legacyKey
+			};
+		}
+	}
+	return freshest;
+}
+function resolveSessionStoreCandidates(params) {
+	const storeConfig = params.cfg.session?.store;
+	const defaultTarget = {
+		agentId: params.agentId,
+		storePath: resolveStorePath(storeConfig, { agentId: params.agentId })
+	};
+	if (!isStorePathTemplate(storeConfig)) return [defaultTarget];
+	const targets = /* @__PURE__ */ new Map();
+	targets.set(defaultTarget.storePath, defaultTarget);
+	for (const target of resolveAllAgentSessionStoreTargetsSync(params.cfg)) if (target.agentId === params.agentId) targets.set(target.storePath, target);
+	return [...targets.values()];
+}
+function buildSessionStoreScanTargets(params) {
+	const targets = /* @__PURE__ */ new Set();
+	if (params.canonicalKey) targets.add(params.canonicalKey);
+	if (params.key && params.key !== params.canonicalKey) targets.add(params.key);
+	if (params.canonicalKey === "global" || params.canonicalKey === "unknown") return [...targets];
+	const agentMainKey = resolveAgentMainSessionKey({
+		cfg: params.cfg,
+		agentId: params.agentId
+	});
+	if (params.canonicalKey === agentMainKey) targets.add(`agent:${params.agentId}:main`);
+	return [...targets];
+}
+function loadPluginHostHookSessionEntry(params) {
+	const key = normalizeOptionalString(params.sessionKey) ?? "";
+	const cfg = params.cfg;
+	const canonicalKey = resolveSessionStoreKey({
+		cfg,
+		sessionKey: key
+	});
+	const agentId = resolveSessionStoreAgentId(cfg, canonicalKey);
+	const scanTargets = buildSessionStoreScanTargets({
+		cfg,
+		key,
+		canonicalKey,
+		agentId
+	});
+	const candidates = resolveSessionStoreCandidates({
+		cfg,
+		agentId
+	});
+	const fallback = candidates[0] ?? {
+		agentId,
+		storePath: resolveStorePath(cfg.session?.store, { agentId })
+	};
+	let selectedStorePath = fallback.storePath;
+	let selectedMatch = findFreshestStoreMatch(loadSessionStore(fallback.storePath), ...scanTargets);
+	for (let index = 1; index < candidates.length; index += 1) {
+		const candidate = candidates[index];
+		if (!candidate) continue;
+		const match = findFreshestStoreMatch(loadSessionStore(candidate.storePath), ...scanTargets);
+		if (match && (!selectedMatch || (match.entry.updatedAt ?? 0) >= (selectedMatch.entry.updatedAt ?? 0))) {
+			selectedStorePath = candidate.storePath;
+			selectedMatch = match;
+		}
+	}
+	return {
+		storePath: selectedStorePath,
+		entry: selectedMatch?.entry,
+		canonicalKey,
+		storeKey: selectedMatch?.key ?? canonicalKey
+	};
+}
+function isPluginPromptInjectionEnabled(cfg, pluginId) {
+	return (cfg.plugins?.entries?.[pluginId])?.hooks?.allowPromptInjection !== false;
+}
+function toPluginNextTurnInjectionRecord(params) {
+	return {
+		id: params.injection.idempotencyKey?.trim() || randomUUID(),
+		pluginId: params.pluginId,
+		pluginName: params.pluginName,
+		text: params.injection.text,
+		idempotencyKey: params.injection.idempotencyKey?.trim() || void 0,
+		placement: params.injection.placement ?? "prepend_context",
+		ttlMs: params.injection.ttlMs,
+		createdAt: params.now,
+		metadata: params.injection.metadata
+	};
+}
+async function enqueuePluginNextTurnInjection(params) {
+	if (typeof params.injection.sessionKey !== "string") return {
+		enqueued: false,
+		id: "",
+		sessionKey: ""
+	};
+	const sessionKey = params.injection.sessionKey.trim();
+	if (!sessionKey) return {
+		enqueued: false,
+		id: "",
+		sessionKey
+	};
+	if (typeof params.injection.text !== "string") return {
+		enqueued: false,
+		id: "",
+		sessionKey
+	};
+	const text = params.injection.text.trim();
+	if (!text) return {
+		enqueued: false,
+		id: "",
+		sessionKey
+	};
+	if (text.length > MAX_PLUGIN_NEXT_TURN_INJECTION_TEXT_LENGTH) return {
+		enqueued: false,
+		id: "",
+		sessionKey
+	};
+	if (params.injection.metadata !== void 0 && !isPluginJsonValue(params.injection.metadata)) return {
+		enqueued: false,
+		id: "",
+		sessionKey
+	};
+	if (params.injection.idempotencyKey !== void 0 && (typeof params.injection.idempotencyKey !== "string" || params.injection.idempotencyKey.trim().length === 0 || params.injection.idempotencyKey.length > MAX_PLUGIN_NEXT_TURN_INJECTION_IDEMPOTENCY_KEY_LENGTH)) return {
+		enqueued: false,
+		id: "",
+		sessionKey
+	};
+	if (params.injection.placement !== void 0 && !isPluginNextTurnInjectionPlacement(params.injection.placement)) return {
+		enqueued: false,
+		id: "",
+		sessionKey
+	};
+	if (params.injection.ttlMs !== void 0 && (!Number.isFinite(params.injection.ttlMs) || params.injection.ttlMs < 0)) return {
+		enqueued: false,
+		id: "",
+		sessionKey
+	};
+	const loaded = loadPluginHostHookSessionEntry({
+		cfg: params.cfg,
+		sessionKey
+	});
+	if (!loaded.entry) return {
+		enqueued: false,
+		id: "",
+		sessionKey
+	};
+	const canonicalKey = loaded.canonicalKey ?? sessionKey;
+	const now = params.now ?? Date.now();
+	const record = toPluginNextTurnInjectionRecord({
+		pluginId: params.pluginId,
+		pluginName: params.pluginName,
+		injection: {
+			...params.injection,
+			sessionKey,
+			text
+		},
+		now
+	});
+	let enqueued = false;
+	let resultId = record.id;
+	await updateSessionStore(loaded.storePath, (store) => {
+		const entry = store[loaded.storeKey];
+		if (!entry) return;
+		const injections = { ...entry.pluginNextTurnInjections };
+		const rawExisting = injections[params.pluginId];
+		const existing = (Array.isArray(rawExisting) ? [...rawExisting] : []).filter((candidate) => !isExpired(candidate, now));
+		const duplicate = record.idempotencyKey ? existing.find((candidate) => candidate.idempotencyKey === record.idempotencyKey) : void 0;
+		if (duplicate) {
+			resultId = duplicate.id;
+			injections[params.pluginId] = existing;
+			entry.pluginNextTurnInjections = injections;
+			return;
+		}
+		if (existing.length >= MAX_PLUGIN_NEXT_TURN_INJECTIONS_PER_SESSION) {
+			injections[params.pluginId] = existing;
+			entry.pluginNextTurnInjections = injections;
+			return;
+		}
+		injections[params.pluginId] = [...existing, record];
+		entry.pluginNextTurnInjections = injections;
+		entry.updatedAt = now;
+		enqueued = true;
+	});
+	return {
+		enqueued,
+		id: resultId,
+		sessionKey: canonicalKey
+	};
+}
+async function drainPluginNextTurnInjections(params) {
+	const sessionKey = params.sessionKey?.trim();
+	if (!sessionKey) return [];
+	const loaded = loadPluginHostHookSessionEntry({
+		cfg: params.cfg,
+		sessionKey
+	});
+	if (!loaded.entry) return [];
+	if (!loaded.entry.pluginNextTurnInjections || Object.keys(loaded.entry.pluginNextTurnInjections).length === 0) return [];
+	const now = params.now ?? Date.now();
+	return await updateSessionStore(loaded.storePath, (store) => {
+		const entry = store[loaded.storeKey];
+		if (!entry?.pluginNextTurnInjections) return [];
+		const activePluginIds = new Set((getActivePluginRegistry()?.plugins ?? []).filter((plugin) => plugin.status === "loaded").map((plugin) => plugin.id));
+		const drained = [];
+		for (const [pluginId, entries] of Object.entries(entry.pluginNextTurnInjections)) {
+			if (!activePluginIds.has(pluginId) || !isPluginPromptInjectionEnabled(params.cfg, pluginId)) continue;
+			if (!Array.isArray(entries)) continue;
+			const liveEntries = entries.filter((candidate) => !isExpired(candidate, now));
+			drained.push(...liveEntries);
+		}
+		drained.sort((left, right) => left.createdAt - right.createdAt);
+		delete entry.pluginNextTurnInjections;
+		if (drained.length > 0) entry.updatedAt = now;
+		return drained;
+	});
+}
+async function drainPluginNextTurnInjectionContext(params) {
+	const queuedInjections = await drainPluginNextTurnInjections(params);
+	return {
+		queuedInjections,
+		...buildPluginAgentTurnPrepareContext({ queuedInjections })
+	};
+}
+function getPluginSessionExtensionStateSync(params) {
+	const pluginId = params.pluginId.trim();
+	const sessionKey = normalizeOptionalString(params.sessionKey);
+	if (!pluginId || !sessionKey) return;
+	const value = loadPluginHostHookSessionEntry({
+		cfg: params.cfg,
+		sessionKey
+	}).entry?.pluginExtensions?.[pluginId];
+	return value ? copyJsonValue(value) : void 0;
+}
+async function patchPluginSessionExtension(params) {
+	const namespace = normalizeNamespace(params.namespace);
+	const pluginId = params.pluginId.trim();
+	if (!pluginId || !namespace) return {
+		ok: false,
+		error: "pluginId and namespace are required"
+	};
+	if (params.unset === true && params.value !== void 0) return {
+		ok: false,
+		error: "plugin session extension cannot specify both unset and value"
+	};
+	if (params.value !== void 0 && !isPluginJsonValue(params.value)) return {
+		ok: false,
+		error: "plugin session extension value must be JSON-compatible"
+	};
+	if (params.unset !== true && params.value === void 0) return {
+		ok: false,
+		error: "plugin session extension value is required unless unset is true"
+	};
+	const nextPluginValue = params.value;
+	const registration = (getActivePluginRegistry()?.sessionExtensions ?? []).find((entry) => entry.pluginId === pluginId && entry.extension.namespace === namespace);
+	if (!registration) return {
+		ok: false,
+		error: `unknown plugin session extension: ${pluginId}/${namespace}`
+	};
+	const loaded = loadPluginHostHookSessionEntry({
+		cfg: params.cfg,
+		sessionKey: params.sessionKey
+	});
+	if (!loaded.entry) return {
+		ok: false,
+		error: `unknown session key: ${params.sessionKey}`
+	};
+	const canonicalKey = loaded.canonicalKey ?? params.sessionKey;
+	const rawSlotKey = normalizeOptionalString(registration.extension.sessionEntrySlotKey);
+	const normalizedSlotKey = rawSlotKey ? normalizeSessionEntrySlotKey(rawSlotKey) : void 0;
+	if (normalizedSlotKey?.ok === false) log.warn(`plugin session extension slot promotion skipped for ${pluginId}/${namespace}: ${normalizedSlotKey.error}`);
+	const slotKey = normalizedSlotKey?.ok === true ? normalizedSlotKey.key : void 0;
+	return {
+		ok: true,
+		key: canonicalKey,
+		value: await updateSessionStore(loaded.storePath, (store) => {
+			const entry = store[loaded.storeKey];
+			if (!entry) return;
+			const entryRecord = entry;
+			const pluginExtensions = { ...entry.pluginExtensions };
+			const pluginState = { ...pluginExtensions[pluginId] };
+			if (params.unset === true) delete pluginState[namespace];
+			else pluginState[namespace] = copyJsonValue(nextPluginValue);
+			if (Object.keys(pluginState).length > 0) pluginExtensions[pluginId] = pluginState;
+			else delete pluginExtensions[pluginId];
+			if (Object.keys(pluginExtensions).length > 0) entry.pluginExtensions = pluginExtensions;
+			else delete entry.pluginExtensions;
+			const storedSlotKeys = { ...entry.pluginExtensionSlotKeys };
+			const pluginSlotKeys = { ...storedSlotKeys[pluginId] };
+			const previousSlotKey = normalizeSessionEntrySlotKey(pluginSlotKeys[namespace]);
+			if (previousSlotKey.ok && previousSlotKey.key !== slotKey) delete entryRecord[previousSlotKey.key];
+			if (slotKey && params.unset !== true) pluginSlotKeys[namespace] = slotKey;
+			else delete pluginSlotKeys[namespace];
+			if (Object.keys(pluginSlotKeys).length > 0) storedSlotKeys[pluginId] = pluginSlotKeys;
+			else delete storedSlotKeys[pluginId];
+			if (Object.keys(storedSlotKeys).length > 0) entry.pluginExtensionSlotKeys = storedSlotKeys;
+			else delete entry.pluginExtensionSlotKeys;
+			if (slotKey) {
+				const projected = projectSessionExtensionValueForSlot({
+					registration,
+					sessionKey: canonicalKey,
+					sessionId: entry.sessionId,
+					nextValue: params.unset === true ? void 0 : nextPluginValue
+				});
+				if (projected === void 0) delete entryRecord[slotKey];
+				else entryRecord[slotKey] = projected;
+			}
+			entry.updatedAt = Date.now();
+			return pluginState[namespace];
+		})
+	};
+}
+/**
+* Resolve the value that should be mirrored to `SessionEntry[slotKey]` for a
+* promoted session-extension namespace. Failures are swallowed so a
+* misbehaving projector cannot block the primary patch from being persisted.
+*/
+function projectSessionExtensionValueForSlot(params) {
+	if (params.nextValue === void 0) return;
+	const projected = projectSessionExtensionValue({
+		pluginId: params.registration.pluginId,
+		namespace: params.registration.extension.namespace,
+		project: params.registration.extension.project,
+		sessionKey: params.sessionKey,
+		sessionId: params.sessionId,
+		state: params.nextValue
+	});
+	if (projected === PROJECTION_FAILED) return;
+	if (isPromiseLike$1(projected)) {
+		discardUnexpectedPromiseProjection(projected);
+		return;
+	}
+	if (projected === void 0 || !isPluginJsonValue(projected)) return;
+	return copyJsonValue(projected);
+}
+function isPromiseLike$1(value) {
+	return Boolean(value && typeof value.then === "function");
+}
+function discardUnexpectedPromiseProjection(value) {
+	Promise.resolve(value).catch(() => void 0);
+}
+function projectSessionExtensionValue(params) {
+	try {
+		return params.project ? params.project({
+			sessionKey: params.sessionKey,
+			sessionId: params.sessionId,
+			state: params.state
+		}) : params.state;
+	} catch (error) {
+		log.warn(`plugin session extension projection failed: plugin=${params.pluginId} namespace=${params.namespace} error=${String(error)}`);
+		return PROJECTION_FAILED;
+	}
+}
+function projectPluginSessionExtensionsSync(params) {
+	const extensions = getActivePluginRegistry()?.sessionExtensions ?? [];
+	if (extensions.length === 0) return [];
+	const projections = [];
+	for (const registration of extensions) {
+		const state = params.entry.pluginExtensions?.[registration.pluginId]?.[registration.extension.namespace];
+		if (state === void 0) continue;
+		const projected = projectSessionExtensionValue({
+			pluginId: registration.pluginId,
+			namespace: registration.extension.namespace,
+			project: registration.extension.project,
+			sessionKey: params.sessionKey,
+			sessionId: params.entry.sessionId,
+			state
+		});
+		if (projected === PROJECTION_FAILED) continue;
+		if (isPromiseLike$1(projected)) {
+			discardUnexpectedPromiseProjection(projected);
+			continue;
+		}
+		if (projected === void 0 || !isPluginJsonValue(projected)) continue;
+		projections.push({
+			pluginId: registration.pluginId,
+			namespace: registration.extension.namespace,
+			value: copyJsonValue(projected)
+		});
+	}
+	return projections;
+}
+//#endregion
+//#region src/media-generation/catalog.ts
+function uniqueModels(provider) {
+	const seen = /* @__PURE__ */ new Set();
+	const models = [];
+	for (const candidate of [provider.defaultModel, ...provider.models ?? []]) {
+		const model = candidate?.trim();
+		if (!model || seen.has(model)) continue;
+		seen.add(model);
+		models.push(model);
+	}
+	return models;
+}
+function synthesizeMediaGenerationCatalogEntries(params) {
+	return uniqueModels(params.provider).map((model) => {
+		const entry = {
+			kind: params.kind,
+			provider: params.provider.id,
+			model,
+			source: "static",
+			capabilities: params.provider.capabilities
+		};
+		if (params.provider.label) entry.label = params.provider.label;
+		if (model === params.provider.defaultModel) entry.default = true;
+		if (params.modes) entry.modes = params.modes;
+		return entry;
+	});
+}
+function listMediaGenerationProviderModels(provider) {
+	return uniqueModels(provider);
+}
+//#endregion
+//#region src/plugins/model-catalog-registration.ts
+function projectProviderCatalogResultToUnifiedTextRows(params) {
+	if (!params.result) return [];
+	const providers = "provider" in params.result ? { [params.providerId]: params.result.provider } : params.result.providers;
+	const rows = [];
+	for (const [providerId, providerConfig] of Object.entries(providers)) for (const model of providerConfig.models ?? []) rows.push({
+		kind: "text",
+		provider: providerId,
+		model: model.id,
+		...model.name ? { label: model.name } : {},
+		source: params.source
+	});
+	return rows;
+}
+function createModelCatalogRegistrationHandlers(params) {
+	const registerModelCatalogProvider = (record, provider) => {
+		const providerId = normalizeOptionalString(provider.provider) ?? "";
+		if (!providerId) {
+			params.pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: "model catalog provider registration missing provider"
+			});
+			return;
+		}
+		if (!provider.kinds || provider.kinds.length === 0) {
+			params.pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: `model catalog provider "${providerId}" registration missing kinds`
+			});
+			return;
+		}
+		const existing = params.registry.modelCatalogProviders.find((entry) => entry.provider.provider === providerId && entry.pluginId !== record.id);
+		if (existing) {
+			params.pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: `model catalog provider already registered: ${providerId} (${existing.pluginId})`
+			});
+			return;
+		}
+		const normalizedKinds = [...new Set(provider.kinds)];
+		const samePluginOverlapping = params.registry.modelCatalogProviders.find((entry) => entry.provider.provider === providerId && entry.pluginId === record.id && entry.provider.kinds.some((kind) => normalizedKinds.includes(kind)));
+		if (samePluginOverlapping) {
+			samePluginOverlapping.provider = {
+				...samePluginOverlapping.provider,
+				...provider,
+				provider: providerId,
+				kinds: [...new Set([...samePluginOverlapping.provider.kinds, ...normalizedKinds])],
+				staticCatalog: provider.staticCatalog ?? samePluginOverlapping.provider.staticCatalog,
+				liveCatalog: provider.liveCatalog ?? samePluginOverlapping.provider.liveCatalog
+			};
+			return;
+		}
+		params.registry.modelCatalogProviders.push({
+			pluginId: record.id,
+			pluginName: record.name,
+			provider: {
+				...provider,
+				provider: providerId,
+				kinds: normalizedKinds
+			},
+			source: record.source,
+			rootDir: record.rootDir
+		});
+	};
+	const registerSynthesizedTextModelCatalogProvider = (registration) => {
+		if (!registration.provider.catalog && !registration.provider.staticCatalog) return;
+		registerModelCatalogProvider(registration.record, {
+			provider: registration.provider.id,
+			kinds: ["text"],
+			...registration.provider.staticCatalog ? { staticCatalog: async (ctx) => projectProviderCatalogResultToUnifiedTextRows({
+				providerId: registration.provider.id,
+				result: await registration.provider.staticCatalog.run(ctx),
+				source: "static"
+			}) } : {},
+			...registration.provider.catalog ? { liveCatalog: async (ctx) => projectProviderCatalogResultToUnifiedTextRows({
+				providerId: registration.provider.id,
+				result: await registration.provider.catalog.run(ctx),
+				source: "live"
+			}) } : {}
+		});
+	};
+	const registerSynthesizedMediaModelCatalogProvider = (registration) => {
+		registerModelCatalogProvider(registration.record, {
+			provider: registration.provider.id,
+			kinds: [registration.kind],
+			staticCatalog: () => synthesizeMediaGenerationCatalogEntries({
+				kind: registration.kind,
+				provider: registration.provider
+			})
+		});
+	};
+	return {
+		registerModelCatalogProvider,
+		registerSynthesizedTextModelCatalogProvider,
+		registerSynthesizedMediaModelCatalogProvider
+	};
+}
+//#endregion
+//#region src/plugins/provider-validation.ts
+const warnedDeprecatedDiscoveryProviders = /* @__PURE__ */ new Set();
+function normalizeTextList(values) {
+	const normalized = Array.from(new Set(normalizeTrimmedStringList(values)));
+	return normalized.length > 0 ? normalized : void 0;
+}
+function normalizeOnboardingScopes(values) {
+	const normalized = Array.from(new Set((values ?? []).filter((value) => value === "text-inference" || value === "image-generation")));
+	return normalized.length > 0 ? normalized : void 0;
+}
+function normalizeProviderOAuthProfileIdRepairs(values) {
+	if (!Array.isArray(values)) return;
+	const normalized = values.map((value) => {
+		const legacyProfileId = normalizeOptionalString(value?.legacyProfileId);
+		const promptLabel = normalizeOptionalString(value?.promptLabel);
+		if (!legacyProfileId && !promptLabel) return null;
+		return {
+			...legacyProfileId ? { legacyProfileId } : {},
+			...promptLabel ? { promptLabel } : {}
+		};
+	}).filter((value) => value !== null);
+	return normalized.length > 0 ? normalized : void 0;
+}
+function resolveWizardMethodId(params) {
+	if (!params.methodId) return;
+	if (params.auth.some((method) => method.id === params.methodId)) return params.methodId;
+	pushPluginValidationDiagnostic({
+		level: "warn",
+		pluginId: params.pluginId,
+		source: params.source,
+		message: `provider "${params.providerId}" ${params.metadataKind} method "${params.methodId}" not found; falling back to available methods`,
+		pushDiagnostic: params.pushDiagnostic
+	});
+}
+function buildNormalizedModelAllowlist(modelAllowlist) {
+	if (!modelAllowlist) return;
+	const allowedKeys = normalizeTextList(modelAllowlist.allowedKeys);
+	const initialSelections = normalizeTextList(modelAllowlist.initialSelections);
+	const loadCatalog = modelAllowlist.loadCatalog === true;
+	const message = normalizeOptionalString(modelAllowlist.message);
+	if (!allowedKeys && !initialSelections && !loadCatalog && !message) return;
+	return {
+		...allowedKeys ? { allowedKeys } : {},
+		...initialSelections ? { initialSelections } : {},
+		...loadCatalog ? { loadCatalog } : {},
+		...message ? { message } : {}
+	};
+}
+function buildNormalizedWizardSetup(params) {
+	const choiceId = normalizeOptionalString(params.setup.choiceId);
+	const choiceLabel = normalizeOptionalString(params.setup.choiceLabel);
+	const choiceHint = normalizeOptionalString(params.setup.choiceHint);
+	const groupId = normalizeOptionalString(params.setup.groupId);
+	const groupLabel = normalizeOptionalString(params.setup.groupLabel);
+	const groupHint = normalizeOptionalString(params.setup.groupHint);
+	const onboardingScopes = normalizeOnboardingScopes(params.setup.onboardingScopes);
+	const modelAllowlist = buildNormalizedModelAllowlist(params.setup.modelAllowlist);
+	return {
+		...choiceId ? { choiceId } : {},
+		...choiceLabel ? { choiceLabel } : {},
+		...choiceHint ? { choiceHint } : {},
+		...typeof params.setup.assistantPriority === "number" && Number.isFinite(params.setup.assistantPriority) ? { assistantPriority: params.setup.assistantPriority } : {},
+		...params.setup.assistantVisibility === "manual-only" || params.setup.assistantVisibility === "visible" ? { assistantVisibility: params.setup.assistantVisibility } : {},
+		...groupId ? { groupId } : {},
+		...groupLabel ? { groupLabel } : {},
+		...groupHint ? { groupHint } : {},
+		...params.methodId ? { methodId: params.methodId } : {},
+		...onboardingScopes ? { onboardingScopes } : {},
+		...modelAllowlist ? { modelAllowlist } : {}
+	};
+}
+function buildNormalizedModelPicker(modelPicker, methodId) {
+	const label = normalizeOptionalString(modelPicker.label);
+	const hint = normalizeOptionalString(modelPicker.hint);
+	return {
+		...label ? { label } : {},
+		...hint ? { hint } : {},
+		...methodId ? { methodId } : {}
+	};
+}
+function normalizeProviderWizardSetup(params) {
+	const hasAuthMethods = params.auth.length > 0;
+	if (!params.setup) return;
+	if (!hasAuthMethods) {
+		pushPluginValidationDiagnostic({
+			level: "warn",
+			pluginId: params.pluginId,
+			source: params.source,
+			message: `provider "${params.providerId}" setup metadata ignored because it has no auth methods`,
+			pushDiagnostic: params.pushDiagnostic
+		});
+		return;
+	}
+	const methodId = resolveWizardMethodId({
+		providerId: params.providerId,
+		pluginId: params.pluginId,
+		source: params.source,
+		auth: params.auth,
+		methodId: normalizeOptionalString(params.setup.methodId),
+		metadataKind: "setup",
+		pushDiagnostic: params.pushDiagnostic
+	});
+	return buildNormalizedWizardSetup({
+		setup: params.setup,
+		methodId
+	});
+}
+function normalizeProviderAuthMethods(params) {
+	const seenMethodIds = /* @__PURE__ */ new Set();
+	const normalized = [];
+	for (const method of params.auth) {
+		const methodId = normalizeOptionalString(method.id);
+		if (!methodId) {
+			pushPluginValidationDiagnostic({
+				level: "error",
+				pluginId: params.pluginId,
+				source: params.source,
+				message: `provider "${params.providerId}" auth method missing id`,
+				pushDiagnostic: params.pushDiagnostic
+			});
+			continue;
+		}
+		if (seenMethodIds.has(methodId)) {
+			pushPluginValidationDiagnostic({
+				level: "error",
+				pluginId: params.pluginId,
+				source: params.source,
+				message: `provider "${params.providerId}" auth method duplicated id "${methodId}"`,
+				pushDiagnostic: params.pushDiagnostic
+			});
+			continue;
+		}
+		seenMethodIds.add(methodId);
+		const wizardSetup = method.wizard;
+		const wizard = wizardSetup ? normalizeProviderWizardSetup({
+			providerId: params.providerId,
+			pluginId: params.pluginId,
+			source: params.source,
+			auth: [{
+				...method,
+				id: methodId
+			}],
+			setup: wizardSetup,
+			pushDiagnostic: params.pushDiagnostic
+		}) : void 0;
+		normalized.push({
+			...method,
+			id: methodId,
+			label: normalizeOptionalString(method.label) ?? methodId,
+			...normalizeOptionalString(method.hint) ? { hint: normalizeOptionalString(method.hint) } : {},
+			...wizard ? { wizard } : {}
+		});
+	}
+	return normalized;
+}
+function normalizeProviderWizard(params) {
+	if (!params.wizard) return;
+	const hasAuthMethods = params.auth.length > 0;
+	const normalizeSetup = () => {
+		const setup = params.wizard?.setup;
+		if (!setup) return;
+		return normalizeProviderWizardSetup({
+			providerId: params.providerId,
+			pluginId: params.pluginId,
+			source: params.source,
+			auth: params.auth,
+			setup,
+			pushDiagnostic: params.pushDiagnostic
+		});
+	};
+	const normalizeModelPicker = () => {
+		const modelPicker = params.wizard?.modelPicker;
+		if (!modelPicker) return;
+		if (!hasAuthMethods) {
+			pushPluginValidationDiagnostic({
+				level: "warn",
+				pluginId: params.pluginId,
+				source: params.source,
+				message: `provider "${params.providerId}" model-picker metadata ignored because it has no auth methods`,
+				pushDiagnostic: params.pushDiagnostic
+			});
+			return;
+		}
+		return buildNormalizedModelPicker(modelPicker, resolveWizardMethodId({
+			providerId: params.providerId,
+			pluginId: params.pluginId,
+			source: params.source,
+			auth: params.auth,
+			methodId: normalizeOptionalString(modelPicker.methodId),
+			metadataKind: "model-picker",
+			pushDiagnostic: params.pushDiagnostic
+		}));
+	};
+	const setup = normalizeSetup();
+	const modelPicker = normalizeModelPicker();
+	if (!setup && !modelPicker) return;
+	return {
+		...setup ? { setup } : {},
+		...modelPicker ? { modelPicker } : {}
+	};
+}
+function normalizeRegisteredProvider(params) {
+	const id = normalizeOptionalString(params.provider.id);
+	if (!id) {
+		pushPluginValidationDiagnostic({
+			level: "error",
+			pluginId: params.pluginId,
+			source: params.source,
+			message: "provider registration missing id",
+			pushDiagnostic: params.pushDiagnostic
+		});
+		return null;
+	}
+	const auth = normalizeProviderAuthMethods({
+		providerId: id,
+		pluginId: params.pluginId,
+		source: params.source,
+		auth: params.provider.auth ?? [],
+		pushDiagnostic: params.pushDiagnostic
+	});
+	const docsPath = normalizeOptionalString(params.provider.docsPath);
+	const aliases = normalizeTextList(params.provider.aliases);
+	const deprecatedProfileIds = normalizeTextList(params.provider.deprecatedProfileIds);
+	const oauthProfileIdRepairs = normalizeProviderOAuthProfileIdRepairs(params.provider.oauthProfileIdRepairs);
+	const envVars = normalizeTextList(params.provider.envVars);
+	const wizard = normalizeProviderWizard({
+		providerId: id,
+		pluginId: params.pluginId,
+		source: params.source,
+		auth,
+		wizard: params.provider.wizard,
+		pushDiagnostic: params.pushDiagnostic
+	});
+	const catalog = params.provider.catalog;
+	const discovery = params.provider.discovery;
+	if (catalog && discovery) pushPluginValidationDiagnostic({
+		level: "warn",
+		pluginId: params.pluginId,
+		source: params.source,
+		message: `provider "${id}" registered both catalog and discovery; using catalog`,
+		pushDiagnostic: params.pushDiagnostic
+	});
+	if (!catalog && discovery) {
+		const warningKey = `${params.pluginId}:${id}:discovery`;
+		if (!warnedDeprecatedDiscoveryProviders.has(warningKey)) {
+			warnedDeprecatedDiscoveryProviders.add(warningKey);
+			pushPluginValidationDiagnostic({
+				level: "warn",
+				pluginId: params.pluginId,
+				source: params.source,
+				message: `provider "${id}" uses deprecated discovery; use catalog`,
+				pushDiagnostic: params.pushDiagnostic
+			});
+		}
+	}
+	const { wizard: _ignoredWizard, docsPath: _ignoredDocsPath, aliases: _ignoredAliases, envVars: _ignoredEnvVars, catalog: _ignoredCatalog, discovery: _ignoredDiscovery, ...restProvider } = params.provider;
+	return {
+		...restProvider,
+		id,
+		label: normalizeOptionalString(params.provider.label) ?? id,
+		...docsPath ? { docsPath } : {},
+		...aliases ? { aliases } : {},
+		...deprecatedProfileIds ? { deprecatedProfileIds } : {},
+		...oauthProfileIdRepairs ? { oauthProfileIdRepairs } : {},
+		...envVars ? { envVars } : {},
+		auth,
+		...catalog ? { catalog } : {},
+		...!catalog && discovery ? { discovery } : {},
+		...wizard ? { wizard } : {}
+	};
+}
+//#endregion
+//#region src/plugins/registry.ts
+function normalizeHookTimeoutMs(value) {
+	if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) return;
+	return Math.floor(value);
+}
+function resolveTypedHookTimeoutMs(params) {
+	return normalizeHookTimeoutMs(params.policy?.timeouts?.[params.hookName]) ?? normalizeHookTimeoutMs(params.policy?.timeoutMs) ?? normalizeHookTimeoutMs(params.opts?.timeoutMs);
+}
+const constrainLegacyPromptInjectionHook = (handler) => {
+	return (event, ctx) => {
+		const result = handler(event, ctx);
+		if (result && typeof result === "object" && "then" in result) return Promise.resolve(result).then((resolved) => stripPromptMutationFieldsFromLegacyHookResult(resolved));
+		return stripPromptMutationFieldsFromLegacyHookResult(result);
+	};
+};
+function resolvePluginPath(input, rootDir) {
+	const trimmed = input.trim();
+	if (!trimmed || path.isAbsolute(trimmed) || trimmed.startsWith("~")) return resolveUserPath(input);
+	return rootDir ? path.resolve(rootDir, trimmed) : resolveUserPath(input);
+}
+function isOfficialCodexPluginRecord(record) {
+	if (record.id !== "codex") return false;
+	if (record.origin !== "global") return false;
+	if (record.packageName === "@openclaw/codex") return true;
+	return path.normalize(record.rootDir ?? record.source).split(path.sep).join("/").includes("/node_modules/@openclaw/codex");
+}
+function canClaimReservedCommandOwnership(record) {
+	return record.origin === "bundled" || isOfficialCodexPluginRecord(record);
+}
+const activePluginHookRegistrations = resolveGlobalSingleton(Symbol.for("openclaw.activePluginHookRegistrations"), () => /* @__PURE__ */ new Map());
+/**
+* Keep mode decoding centralized. PluginRegistrationMode is the public label;
+* registry code should consume these booleans instead of duplicating string
+* checks across individual registration handlers.
+*/
+function resolvePluginRegistrationCapabilities(mode) {
+	return {
+		capabilityHandlers: mode === "full" || mode === "discovery" || mode === "tool-discovery",
+		runtimeChannel: mode !== "setup-only" && mode !== "tool-discovery"
+	};
+}
+function createPluginRegistry(registryParams) {
+	const registry = createEmptyPluginRegistry();
+	const coreGatewayMethodNames = Array.from(new Set([...registryParams.coreGatewayMethodNames ?? [], ...Object.keys(registryParams.coreGatewayHandlers ?? {})])).toSorted();
+	registry.coreGatewayMethodNames = coreGatewayMethodNames;
+	const coreGatewayMethods = new Set(coreGatewayMethodNames);
+	const getHostCronService = () => registryParams.hostServices?.cron;
+	const pluginHookRollback = /* @__PURE__ */ new Map();
+	const pluginsWithChannelRegistrationConflict = /* @__PURE__ */ new Set();
+	const pluginSideEffectGuards = /* @__PURE__ */ new Map();
+	const pushDiagnostic = (diag) => {
+		registry.diagnostics.push(diag);
+	};
+	const { registerModelCatalogProvider, registerSynthesizedTextModelCatalogProvider, registerSynthesizedMediaModelCatalogProvider } = createModelCatalogRegistrationHandlers({
+		registry,
+		pushDiagnostic
+	});
+	const throwRegistrationError = (message) => {
+		throw new Error(message);
+	};
+	const requireRegistrationValue = (value, message) => {
+		if (!value) throw new Error(message);
+		return value;
+	};
+	const createPluginSideEffectGuard = (pluginId) => {
+		const guard = { active: true };
+		const guards = pluginSideEffectGuards.get(pluginId) ?? /* @__PURE__ */ new Set();
+		guards.add(guard);
+		pluginSideEffectGuards.set(pluginId, guards);
+		return guard;
+	};
+	const deactivatePluginSideEffectGuards = (pluginId) => {
+		const guards = pluginSideEffectGuards.get(pluginId);
+		if (!guards) return;
+		for (const guard of guards) guard.active = false;
+		pluginSideEffectGuards.delete(pluginId);
+	};
+	const registerCodexAppServerExtensionFactory = (record, factory) => {
+		if (record.origin !== "bundled") {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: "only bundled plugins can register Codex app-server extension factories"
+			});
+			return;
+		}
+		if (!(record.contracts?.embeddedExtensionFactories ?? []).includes("codex-app-server")) {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: "plugin must declare contracts.embeddedExtensionFactories: [\"codex-app-server\"] to register Codex app-server extension factories"
+			});
+			return;
+		}
+		if (typeof factory !== "function") {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: "codex app-server extension factory must be a function"
+			});
+			return;
+		}
+		if (registry.codexAppServerExtensionFactories.some((entry) => entry.pluginId === record.id && entry.rawFactory === factory)) return;
+		const safeFactory = async (codex) => {
+			try {
+				await factory(codex);
+			} catch (error) {
+				const detail = error instanceof Error ? error.message : String(error);
+				registryParams.logger.warn(`[plugins] codex app-server extension factory failed for ${record.id}: ${detail}`);
+			}
+		};
+		registry.codexAppServerExtensionFactories.push({
+			pluginId: record.id,
+			pluginName: record.name,
+			rawFactory: factory,
+			factory: safeFactory,
+			source: record.source,
+			rootDir: record.rootDir
+		});
+	};
+	const registerAgentToolResultMiddleware = (record, handler, options) => {
+		if (record.origin !== "bundled") {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: "only bundled plugins can register agent tool result middleware"
+			});
+			return;
+		}
+		if (typeof handler !== "function") {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: "agent tool result middleware must be a function"
+			});
+			return;
+		}
+		const runtimes = normalizeAgentToolResultMiddlewareRuntimes(options);
+		if (runtimes.length === 0) {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: "agent tool result middleware must target at least one supported runtime"
+			});
+			return;
+		}
+		const declared = normalizeAgentToolResultMiddlewareRuntimeIds(record.contracts?.agentToolResultMiddleware);
+		const missing = runtimes.filter((runtime) => !declared.includes(runtime));
+		if (missing.length > 0) {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: `plugin must declare contracts.agentToolResultMiddleware for: ${missing.join(", ")}`
+			});
+			return;
+		}
+		const existing = registry.agentToolResultMiddlewares.find((entry) => entry.pluginId === record.id && entry.rawHandler === handler);
+		if (existing) {
+			existing.runtimes = [...new Set([...existing.runtimes, ...runtimes])];
+			return;
+		}
+		const safeHandler = async (event, ctx) => {
+			try {
+				return await handler(event, ctx);
+			} catch (error) {
+				registryParams.logger.warn(`[plugins] agent tool result middleware failed for ${record.id}`);
+				throw error;
+			}
+		};
+		registry.agentToolResultMiddlewares.push({
+			pluginId: record.id,
+			pluginName: record.name,
+			rawHandler: handler,
+			handler: safeHandler,
+			runtimes,
+			source: record.source,
+			rootDir: record.rootDir
+		});
+	};
+	const registerTool = (record, tool, opts) => {
+		if (pluginsWithChannelRegistrationConflict.has(record.id)) return;
+		const declaredNames = normalizePluginToolContractNames(record.contracts);
+		if (declaredNames.length === 0) {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: "plugin must declare contracts.tools before registering agent tools"
+			});
+			return;
+		}
+		const names = [...opts?.names ?? [], ...opts?.name ? [opts.name] : []];
+		const optional = opts?.optional === true;
+		const factory = typeof tool === "function" ? tool : (_ctx) => tool;
+		if (typeof tool !== "function") names.push(tool.name);
+		const normalized = normalizePluginToolNames(names);
+		const undeclared = findUndeclaredPluginToolNames({
+			declaredNames,
+			toolNames: normalized
+		});
+		if (undeclared.length > 0) {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: `plugin must declare contracts.tools for: ${undeclared.join(", ")}`
+			});
+			return;
+		}
+		if (normalized.length > 0) record.toolNames.push(...normalized);
+		registry.tools.push({
+			pluginId: record.id,
+			pluginName: record.name,
+			factory,
+			names: normalized,
+			declaredNames,
+			optional,
+			source: record.source,
+			rootDir: record.rootDir
+		});
+	};
+	const registerHook = (record, events, handler, opts, config, pluginConfig) => {
+		const normalizedEvents = (Array.isArray(events) ? events : [events]).map((event) => event.trim()).filter(Boolean);
+		const entry = opts?.entry ?? null;
+		const hookName = requireRegistrationValue(entry?.hook.name ?? opts?.name?.trim(), "hook registration missing name");
+		const existingHook = registry.hooks.find((entry) => entry.entry.hook.name === hookName);
+		if (existingHook) {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: `hook already registered: ${hookName} (${existingHook.pluginId})`
+			});
+			return;
+		}
+		const description = entry?.hook.description ?? opts?.description ?? "";
+		const hookEntry = entry ? {
+			...entry,
+			hook: {
+				...entry.hook,
+				name: hookName,
+				description,
+				source: "openclaw-plugin",
+				pluginId: record.id
+			},
+			metadata: {
+				...entry.metadata,
+				events: normalizedEvents
+			}
+		} : {
+			hook: {
+				name: hookName,
+				description,
+				source: "openclaw-plugin",
+				pluginId: record.id,
+				filePath: record.source,
+				baseDir: path.dirname(record.source),
+				handlerPath: record.source
+			},
+			frontmatter: {},
+			metadata: { events: normalizedEvents },
+			invocation: { enabled: true }
+		};
+		record.hookNames.push(hookName);
+		registry.hooks.push({
+			pluginId: record.id,
+			entry: hookEntry,
+			events: normalizedEvents,
+			source: record.source
+		});
+		const hookSystemEnabled = config?.hooks?.internal?.enabled !== false;
+		if (!registryParams.activateGlobalSideEffects || !hookSystemEnabled || opts?.register === false) return;
+		const previousRegistrations = activePluginHookRegistrations.get(hookName) ?? [];
+		for (const registration of previousRegistrations) unregisterInternalHook(registration.event, registration.handler);
+		const nextRegistrations = [];
+		for (const event of normalizedEvents) {
+			const wrappedHandler = async (evt) => {
+				return handler({
+					...evt,
+					context: {
+						...evt.context,
+						pluginConfig
+					}
+				});
+			};
+			registerInternalHook(event, wrappedHandler);
+			nextRegistrations.push({
+				event,
+				handler: wrappedHandler
+			});
+		}
+		activePluginHookRegistrations.set(hookName, nextRegistrations);
+		const rollbackEntries = pluginHookRollback.get(record.id) ?? [];
+		rollbackEntries.push({
+			name: hookName,
+			previousRegistrations: [...previousRegistrations]
+		});
+		pluginHookRollback.set(record.id, rollbackEntries);
+	};
+	const registerGatewayMethod = (record, method, handler, opts) => {
+		const trimmed = method.trim();
+		if (!trimmed) return;
+		if (coreGatewayMethods.has(trimmed) || registry.gatewayHandlers[trimmed]) {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: `gateway method already registered: ${trimmed}`
+			});
+			return;
+		}
+		registry.gatewayHandlers[trimmed] = handler;
+		const normalizedScope = normalizePluginGatewayMethodScope(trimmed, opts?.scope);
+		if (normalizedScope.coercedToReservedAdmin) pushDiagnostic({
+			level: "warn",
+			pluginId: record.id,
+			source: record.source,
+			message: `gateway method scope coerced to operator.admin for reserved core namespace: ${trimmed}`
+		});
+		const effectiveScope = normalizedScope.scope;
+		if (effectiveScope) {
+			registry.gatewayMethodScopes ??= {};
+			registry.gatewayMethodScopes[trimmed] = effectiveScope;
+		}
+		record.gatewayMethods.push(trimmed);
+	};
+	const describeHttpRouteOwner = (entry) => {
+		return `${normalizeOptionalString(entry.pluginId) || "unknown-plugin"} (${normalizeOptionalString(entry.source) || "unknown-source"})`;
+	};
+	const registerHttpRoute = (record, params) => {
+		const normalizedPath = normalizePluginHttpPath(params.path);
+		if (!normalizedPath) {
+			pushDiagnostic({
+				level: "warn",
+				pluginId: record.id,
+				source: record.source,
+				message: "http route registration missing path"
+			});
+			return;
+		}
+		if (params.auth !== "gateway" && params.auth !== "plugin") {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: `http route registration missing or invalid auth: ${normalizedPath}`
+			});
+			return;
+		}
+		const match = params.match ?? "exact";
+		const overlappingRoute = findOverlappingPluginHttpRoute(registry.httpRoutes, {
+			path: normalizedPath,
+			match
+		});
+		if (overlappingRoute && overlappingRoute.auth !== params.auth) {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: `http route overlap rejected: ${normalizedPath} (${match}, ${params.auth}) overlaps ${overlappingRoute.path} (${overlappingRoute.match}, ${overlappingRoute.auth}) owned by ${describeHttpRouteOwner(overlappingRoute)}`
+			});
+			return;
+		}
+		const existingIndex = registry.httpRoutes.findIndex((entry) => entry.path === normalizedPath && entry.match === match);
+		if (existingIndex >= 0) {
+			const existing = registry.httpRoutes[existingIndex];
+			if (!existing) return;
+			if (!params.replaceExisting && existing.pluginId !== record.id) {
+				pushDiagnostic({
+					level: "error",
+					pluginId: record.id,
+					source: record.source,
+					message: `http route already registered: ${normalizedPath} (${match}) by ${describeHttpRouteOwner(existing)}`
+				});
+				return;
+			}
+			if (existing.pluginId && existing.pluginId !== record.id) {
+				pushDiagnostic({
+					level: "error",
+					pluginId: record.id,
+					source: record.source,
+					message: `http route replacement rejected: ${normalizedPath} (${match}) owned by ${describeHttpRouteOwner(existing)}`
+				});
+				return;
+			}
+			registry.httpRoutes[existingIndex] = {
+				pluginId: record.id,
+				path: normalizedPath,
+				handler: params.handler,
+				...params.handleUpgrade ? { handleUpgrade: params.handleUpgrade } : {},
+				auth: params.auth,
+				match,
+				...params.gatewayRuntimeScopeSurface ? { gatewayRuntimeScopeSurface: params.gatewayRuntimeScopeSurface } : {},
+				...params.nodeCapability ? { nodeCapability: { ...params.nodeCapability } } : {},
+				source: record.source
+			};
+			return;
+		}
+		record.httpRoutes += 1;
+		registry.httpRoutes.push({
+			pluginId: record.id,
+			path: normalizedPath,
+			handler: params.handler,
+			...params.handleUpgrade ? { handleUpgrade: params.handleUpgrade } : {},
+			auth: params.auth,
+			match,
+			...params.gatewayRuntimeScopeSurface ? { gatewayRuntimeScopeSurface: params.gatewayRuntimeScopeSurface } : {},
+			...params.nodeCapability ? { nodeCapability: { ...params.nodeCapability } } : {},
+			source: record.source
+		});
+	};
+	const registerHostedMediaResolver = (record, resolver) => {
+		if (typeof resolver !== "function") {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: "hosted media resolver registration missing resolver"
+			});
+			return;
+		}
+		(registry.hostedMediaResolvers ??= []).push({
+			pluginId: record.id,
+			pluginName: record.name,
+			resolver,
+			source: record.source,
+			rootDir: record.rootDir
+		});
+	};
+	const registerChannel = (record, registration, mode = "full") => {
+		const registrationCapabilities = resolvePluginRegistrationCapabilities(mode);
+		const normalized = typeof registration.plugin === "object" ? registration : { plugin: registration };
+		const plugin = normalizeRegisteredChannelPlugin({
+			pluginId: record.id,
+			source: record.source,
+			plugin: normalized.plugin,
+			pushDiagnostic
+		});
+		if (!plugin) return;
+		const id = plugin.id;
+		const existingRuntime = registry.channels.find((entry) => entry.plugin.id === id);
+		if (registrationCapabilities.runtimeChannel && existingRuntime) {
+			if (existingRuntime.pluginId === record.id) {
+				existingRuntime.plugin = plugin;
+				existingRuntime.pluginName = record.name;
+				existingRuntime.source = record.source;
+				existingRuntime.rootDir = record.rootDir;
+				const existingSetup = registry.channelSetups.find((entry) => entry.plugin.id === id);
+				if (existingSetup) {
+					existingSetup.plugin = plugin;
+					existingSetup.pluginName = record.name;
+					existingSetup.source = record.source;
+					existingSetup.enabled = record.enabled;
+					existingSetup.rootDir = record.rootDir;
+				}
+				return;
+			}
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: `channel already registered: ${id} (${existingRuntime.pluginId})`
+			});
+			pluginsWithChannelRegistrationConflict.add(record.id);
+			return;
+		}
+		const existingSetup = registry.channelSetups.find((entry) => entry.plugin.id === id);
+		if (existingSetup) {
+			if (existingSetup.pluginId === record.id) {
+				existingSetup.plugin = plugin;
+				existingSetup.pluginName = record.name;
+				existingSetup.source = record.source;
+				existingSetup.enabled = record.enabled;
+				existingSetup.rootDir = record.rootDir;
+				return;
+			}
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: `channel setup already registered: ${id} (${existingSetup.pluginId})`
+			});
+			pluginsWithChannelRegistrationConflict.add(record.id);
+			return;
+		}
+		if (!record.channelIds.includes(id)) record.channelIds.push(id);
+		registry.channelSetups.push({
+			pluginId: record.id,
+			pluginName: record.name,
+			plugin,
+			source: record.source,
+			enabled: record.enabled,
+			rootDir: record.rootDir
+		});
+		if (!registrationCapabilities.runtimeChannel) return;
+		registry.channels.push({
+			pluginId: record.id,
+			pluginName: record.name,
+			plugin,
+			source: record.source,
+			rootDir: record.rootDir
+		});
+	};
+	const registerProvider = (record, provider) => {
+		const normalizedProvider = normalizeRegisteredProvider({
+			pluginId: record.id,
+			source: record.source,
+			provider,
+			pushDiagnostic
+		});
+		if (!normalizedProvider) return;
+		const id = normalizedProvider.id;
+		const existing = registry.providers.find((entry) => entry.provider.id === id);
+		if (existing) {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: `provider already registered: ${id} (${existing.pluginId})`
+			});
+			return;
+		}
+		if (!record.providerIds.includes(id)) record.providerIds.push(id);
+		registry.providers.push({
+			pluginId: record.id,
+			pluginName: record.name,
+			provider: normalizedProvider,
+			source: record.source,
+			rootDir: record.rootDir
+		});
+		registerSynthesizedTextModelCatalogProvider({
+			record,
+			provider: normalizedProvider
+		});
+	};
+	const registerAgentHarness$1 = (record, harness) => {
+		const id = normalizeOptionalString(harness?.id) ?? "";
+		if (!id) {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: "agent harness registration missing id"
+			});
+			return;
+		}
+		if (typeof harness.supports !== "function" || typeof harness.runAttempt !== "function") {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: `agent harness "${id}" registration missing required runtime methods`
+			});
+			return;
+		}
+		const existing = registryParams.activateGlobalSideEffects === false ? registry.agentHarnesses.find((entry) => entry.harness.id === id) : getRegisteredAgentHarness(id);
+		if (existing) {
+			const ownerPluginId = "ownerPluginId" in existing ? existing.ownerPluginId : "pluginId" in existing ? existing.pluginId : void 0;
+			const ownerDetail = ownerPluginId ? ` (owner: ${ownerPluginId})` : "";
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: `agent harness already registered: ${id}${ownerDetail}`
+			});
+			return;
+		}
+		const normalizedHarness = {
+			...harness,
+			id,
+			pluginId: harness.pluginId ?? record.id
+		};
+		if (registryParams.activateGlobalSideEffects !== false) registerAgentHarness(normalizedHarness, { ownerPluginId: record.id });
+		record.agentHarnessIds.push(id);
+		registry.agentHarnesses.push({
+			pluginId: record.id,
+			pluginName: record.name,
+			harness: normalizedHarness,
+			source: record.source,
+			rootDir: record.rootDir
+		});
+	};
+	const registerCliBackend = (record, backend) => {
+		const id = backend.id.trim();
+		if (!id) {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: "cli backend registration missing id"
+			});
+			return;
+		}
+		const existing = (registry.cliBackends ?? []).find((entry) => entry.backend.id === id);
+		if (existing) {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: `cli backend already registered: ${id} (${existing.pluginId})`
+			});
+			return;
+		}
+		(registry.cliBackends ??= []).push({
+			pluginId: record.id,
+			pluginName: record.name,
+			backend: {
+				...backend,
+				id
+			},
+			source: record.source,
+			rootDir: record.rootDir
+		});
+		record.cliBackendIds.push(id);
+	};
+	const registerTextTransforms = (record, transforms) => {
+		if ((!transforms.input || transforms.input.length === 0) && (!transforms.output || transforms.output.length === 0)) {
+			pushDiagnostic({
+				level: "warn",
+				pluginId: record.id,
+				source: record.source,
+				message: "text transform registration has no input or output replacements"
+			});
+			return;
+		}
+		registry.textTransforms.push({
+			pluginId: record.id,
+			pluginName: record.name,
+			transforms,
+			source: record.source,
+			rootDir: record.rootDir
+		});
+	};
+	const registerUniqueProviderLike = (params) => {
+		const id = params.provider.id.trim();
+		const { record, kindLabel } = params;
+		const missingLabel = `${kindLabel} registration missing id`;
+		const duplicateLabel = `${kindLabel} already registered: ${id}`;
+		if (!id) {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: missingLabel
+			});
+			return false;
+		}
+		const existing = params.registrations.find((entry) => entry.provider.id === id);
+		if (existing) {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: `${duplicateLabel} (${existing.pluginId})`
+			});
+			return false;
+		}
+		if (!params.ownedIds.includes(id)) params.ownedIds.push(id);
+		params.registrations.push({
+			pluginId: record.id,
+			pluginName: record.name,
+			provider: params.provider,
+			source: record.source,
+			rootDir: record.rootDir
+		});
+		return true;
+	};
+	const registerSpeechProvider = (record, provider) => {
+		registerUniqueProviderLike({
+			record,
+			provider,
+			kindLabel: "speech provider",
+			registrations: registry.speechProviders,
+			ownedIds: record.speechProviderIds
+		});
+	};
+	const registerRealtimeTranscriptionProvider = (record, provider) => {
+		registerUniqueProviderLike({
+			record,
+			provider,
+			kindLabel: "realtime transcription provider",
+			registrations: registry.realtimeTranscriptionProviders,
+			ownedIds: record.realtimeTranscriptionProviderIds
+		});
+	};
+	const registerRealtimeVoiceProvider = (record, provider) => {
+		registerUniqueProviderLike({
+			record,
+			provider,
+			kindLabel: "realtime voice provider",
+			registrations: registry.realtimeVoiceProviders,
+			ownedIds: record.realtimeVoiceProviderIds
+		});
+	};
+	const registerMediaUnderstandingProvider = (record, provider) => {
+		registerUniqueProviderLike({
+			record,
+			provider,
+			kindLabel: "media provider",
+			registrations: registry.mediaUnderstandingProviders,
+			ownedIds: record.mediaUnderstandingProviderIds
+		});
+	};
+	const registerImageGenerationProvider = (record, provider) => {
+		if (registerUniqueProviderLike({
+			record,
+			provider,
+			kindLabel: "image-generation provider",
+			registrations: registry.imageGenerationProviders,
+			ownedIds: record.imageGenerationProviderIds
+		})) registerSynthesizedMediaModelCatalogProvider({
+			record,
+			kind: "image_generation",
+			provider
+		});
+	};
+	const registerVideoGenerationProvider = (record, provider) => {
+		if (registerUniqueProviderLike({
+			record,
+			provider,
+			kindLabel: "video-generation provider",
+			registrations: registry.videoGenerationProviders,
+			ownedIds: record.videoGenerationProviderIds
+		})) registerSynthesizedMediaModelCatalogProvider({
+			record,
+			kind: "video_generation",
+			provider
+		});
+	};
+	const registerMusicGenerationProvider = (record, provider) => {
+		if (registerUniqueProviderLike({
+			record,
+			provider,
+			kindLabel: "music-generation provider",
+			registrations: registry.musicGenerationProviders,
+			ownedIds: record.musicGenerationProviderIds
+		})) registerSynthesizedMediaModelCatalogProvider({
+			record,
+			kind: "music_generation",
+			provider
+		});
+	};
+	const registerWebFetchProvider = (record, provider) => {
+		registerUniqueProviderLike({
+			record,
+			provider,
+			kindLabel: "web fetch provider",
+			registrations: registry.webFetchProviders,
+			ownedIds: record.webFetchProviderIds
+		});
+	};
+	const registerWebSearchProvider = (record, provider) => {
+		registerUniqueProviderLike({
+			record,
+			provider,
+			kindLabel: "web search provider",
+			registrations: registry.webSearchProviders,
+			ownedIds: record.webSearchProviderIds
+		});
+	};
+	const registerMigrationProvider = (record, provider) => {
+		registerUniqueProviderLike({
+			record,
+			provider,
+			kindLabel: "migration provider",
+			registrations: registry.migrationProviders,
+			ownedIds: record.migrationProviderIds
+		});
+	};
+	const registerCli = (record, registrar, opts) => {
+		const normalizeCommandRoot = (raw, source) => {
+			const normalized = normalizeCommandDescriptorName(raw);
+			if (!normalized) pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: `invalid cli ${source} name: ${JSON.stringify(raw.trim())}`
+			});
+			return normalized;
+		};
+		const parentPath = (opts?.parentPath ?? []).map((segment) => normalizeCommandRoot(segment, "command"));
+		if (parentPath.some((segment) => segment === null)) return;
+		const normalizedParentPath = parentPath;
+		const descriptors = (opts?.descriptors ?? []).map((descriptor) => {
+			const name = normalizeCommandRoot(descriptor.name, "descriptor");
+			const description = sanitizeCommandDescriptorDescription(descriptor.description);
+			return name && description ? {
+				name,
+				description,
+				hasSubcommands: descriptor.hasSubcommands
+			} : null;
+		}).filter((descriptor) => descriptor !== null);
+		const commands = [...opts?.commands ?? [], ...descriptors.map((descriptor) => descriptor.name)].map((cmd) => normalizeCommandRoot(cmd, "command")).filter((command) => command !== null);
+		if (commands.length === 0) {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: "cli registration missing explicit commands metadata"
+			});
+			return;
+		}
+		const serializeCommandPath = (command) => [...normalizedParentPath, command].join(" ");
+		const commandPaths = commands.map(serializeCommandPath);
+		const commandPathSet = new Set(commandPaths);
+		const existing = registry.cliRegistrars.find((entry) => entry.commands.map((command) => [...entry.parentPath ?? [], command].join(" ")).some((commandPath) => commandPathSet.has(commandPath)));
+		if (existing) {
+			const existingCommandPaths = new Set(existing.commands.map((command) => [...existing.parentPath ?? [], command].join(" ")));
+			const overlap = commandPaths.find((commandPath) => existingCommandPaths.has(commandPath));
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: `cli command already registered: ${overlap ?? commands[0]} (${existing.pluginId})`
+			});
+			return;
+		}
+		record.cliCommands.push(...commandPaths);
+		registry.cliRegistrars.push({
+			pluginId: record.id,
+			pluginName: record.name,
+			register: registrar,
+			parentPath: normalizedParentPath,
+			commands,
+			descriptors,
+			source: record.source,
+			rootDir: record.rootDir
+		});
+	};
+	const reservedNodeHostCommands = new Set([
+		...NODE_SYSTEM_RUN_COMMANDS,
+		...NODE_EXEC_APPROVALS_COMMANDS,
+		NODE_SYSTEM_NOTIFY_COMMAND
+	]);
+	const registerReload = (record, registration) => {
+		const normalize = (values) => (values ?? []).map((value) => value.trim()).filter(Boolean);
+		const normalized = {
+			restartPrefixes: normalize(registration.restartPrefixes),
+			hotPrefixes: normalize(registration.hotPrefixes),
+			noopPrefixes: normalize(registration.noopPrefixes)
+		};
+		if ((normalized.restartPrefixes?.length ?? 0) === 0 && (normalized.hotPrefixes?.length ?? 0) === 0 && (normalized.noopPrefixes?.length ?? 0) === 0) {
+			pushDiagnostic({
+				level: "warn",
+				pluginId: record.id,
+				source: record.source,
+				message: "reload registration missing prefixes"
+			});
+			return;
+		}
+		registry.reloads ??= [];
+		registry.reloads.push({
+			pluginId: record.id,
+			pluginName: record.name,
+			registration: normalized,
+			source: record.source,
+			rootDir: record.rootDir
+		});
+	};
+	const registerNodeHostCommand = (record, nodeCommand) => {
+		const command = nodeCommand.command.trim();
+		if (!command) {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: "node host command registration missing command"
+			});
+			return;
+		}
+		if (reservedNodeHostCommands.has(command)) {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: `node host command reserved by core: ${command}`
+			});
+			return;
+		}
+		registry.nodeHostCommands ??= [];
+		const existing = registry.nodeHostCommands.find((entry) => entry.command.command === command);
+		if (existing) {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: `node host command already registered: ${command} (${existing.pluginId})`
+			});
+			return;
+		}
+		registry.nodeHostCommands.push({
+			pluginId: record.id,
+			pluginName: record.name,
+			command: {
+				...nodeCommand,
+				command,
+				cap: normalizeOptionalString(nodeCommand.cap)
+			},
+			source: record.source,
+			rootDir: record.rootDir
+		});
+	};
+	const registerNodeInvokePolicy = (record, policy, pluginConfig) => {
+		const commands = Array.isArray(policy.commands) ? policy.commands.map((command) => command.trim()).filter(Boolean) : [];
+		if (commands.length === 0) {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: "node invoke policy registration missing commands"
+			});
+			return;
+		}
+		if (typeof policy.handle !== "function") {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: `node invoke policy registration missing handler: ${commands.join(", ")}`
+			});
+			return;
+		}
+		registry.nodeInvokePolicies ??= [];
+		for (const command of commands) {
+			const existing = registry.nodeInvokePolicies.find((entry) => entry.policy.commands.includes(command));
+			if (existing) {
+				pushDiagnostic({
+					level: "error",
+					pluginId: record.id,
+					source: record.source,
+					message: `node invoke policy already registered for ${command} (${existing.pluginId})`
+				});
+				return;
+			}
+		}
+		registry.nodeInvokePolicies.push({
+			pluginId: record.id,
+			pluginName: record.name,
+			policy: {
+				...policy,
+				commands
+			},
+			pluginConfig,
+			source: record.source,
+			rootDir: record.rootDir
+		});
+	};
+	const registerSecurityAuditCollector = (record, collector) => {
+		registry.securityAuditCollectors ??= [];
+		registry.securityAuditCollectors.push({
+			pluginId: record.id,
+			pluginName: record.name,
+			collector,
+			source: record.source,
+			rootDir: record.rootDir
+		});
+	};
+	const registerService = (record, service) => {
+		const id = service.id.trim();
+		if (!id) return;
+		const existing = registry.services.find((entry) => entry.service.id === id);
+		if (existing) {
+			if (existing.pluginId === record.id) return;
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: `service already registered: ${id} (${existing.pluginId})`
+			});
+			return;
+		}
+		record.services.push(id);
+		registry.services.push({
+			pluginId: record.id,
+			pluginName: record.name,
+			service,
+			source: record.source,
+			origin: record.origin,
+			trustedOfficialInstall: record.trustedOfficialInstall,
+			rootDir: record.rootDir
+		});
+	};
+	const registerGatewayDiscoveryService = (record, service) => {
+		const id = service.id.trim();
+		if (!id) return;
+		const existing = registry.gatewayDiscoveryServices.find((entry) => entry.service.id === id);
+		if (existing) {
+			if (existing.pluginId === record.id) return;
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: `gateway discovery service already registered: ${id} (${existing.pluginId})`
+			});
+			return;
+		}
+		record.gatewayDiscoveryServiceIds.push(id);
+		registry.gatewayDiscoveryServices.push({
+			pluginId: record.id,
+			pluginName: record.name,
+			service,
+			source: record.source,
+			rootDir: record.rootDir
+		});
+	};
+	const registerCommand = (record, command) => {
+		const name = command.name.trim();
+		if (!name) {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: "command registration missing name"
+			});
+			return;
+		}
+		const allowReservedCommandNames = command.ownership === "reserved";
+		if (allowReservedCommandNames && !canClaimReservedCommandOwnership(record)) {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: `only bundled plugins can claim reserved command ownership: ${name}`
+			});
+			return;
+		}
+		if (allowReservedCommandNames && !isReservedCommandName(name)) {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: `reserved command ownership requires a reserved command name: ${name}`
+			});
+			return;
+		}
+		if (allowReservedCommandNames && record.id !== normalizeLowercaseStringOrEmpty(name)) {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: `command registration failed: Reserved command ownership requires plugin id "${record.id}" to match reserved command name "${normalizeLowercaseStringOrEmpty(name)}"`
+			});
+			return;
+		}
+		if (!registryParams.activateGlobalSideEffects) {
+			const validationError = validatePluginCommandDefinition(command, { allowReservedCommandNames });
+			if (validationError) {
+				pushDiagnostic({
+					level: "error",
+					pluginId: record.id,
+					source: record.source,
+					message: `command registration failed: ${validationError}`
+				});
+				return;
+			}
+		} else {
+			const { ownership: _ownership, ...commandForRegistration } = command;
+			const result = registerPluginCommand(record.id, allowReservedCommandNames ? commandForRegistration : command, {
+				pluginName: record.name,
+				pluginRoot: record.rootDir,
+				allowReservedCommandNames
+			});
+			if (!result.ok) {
+				pushDiagnostic({
+					level: "error",
+					pluginId: record.id,
+					source: record.source,
+					message: `command registration failed: ${result.error}`
+				});
+				return;
+			}
+			if (allowReservedCommandNames) {
+				const registeredCommand = pluginCommands.get(`/${name.toLowerCase()}`);
+				if (registeredCommand?.pluginId === record.id) registeredCommand.ownership = "reserved";
+			}
+		}
+		record.commands.push(name);
+		registry.commands.push({
+			pluginId: record.id,
+			pluginName: record.name,
+			command,
+			source: record.source,
+			rootDir: record.rootDir
+		});
+	};
+	const normalizeHostHookString = (value) => typeof value === "string" ? normalizePluginHostHookId(value) : "";
+	const normalizeOptionalHostHookString = (value) => {
+		if (value === void 0) return;
+		if (typeof value !== "string") return "";
+		return value.trim();
+	};
+	const normalizeHostHookStringList = (value) => {
+		if (value === void 0) return;
+		if (!Array.isArray(value)) return null;
+		const normalized = value.map((item) => normalizeOptionalHostHookString(item));
+		if (normalized.some((item) => !item)) return null;
+		return normalized;
+	};
+	const validateSessionActionSchema = (record, id, schema) => {
+		if (schema === void 0) return true;
+		if (!isPluginJsonValue(schema)) {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: `session action schema must be JSON-compatible: ${id}`
+			});
+			return false;
+		}
+		if (typeof schema !== "boolean" && (!schema || typeof schema !== "object" || Array.isArray(schema))) {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: `session action schema must be a JSON schema object or boolean: ${id}`
+			});
+			return false;
+		}
+		try {
+			validateJsonSchemaValue({
+				schema,
+				cacheKey: `plugin-session-action-registration:${record.id}:${id}`,
+				value: void 0
+			});
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: `session action schema is not valid JSON Schema: ${id}: ${message}`
+			});
+			return false;
+		}
+		return true;
+	};
+	const controlUiSurfaces = new Set([
+		"session",
+		"tool",
+		"run",
+		"settings",
+		"chat-message",
+		"chat-input-bar",
+		"chat-header-chip"
+	]);
+	const chatStreamSurfaces = new Set([
+		"chat-message",
+		"chat-input-bar",
+		"chat-header-chip"
+	]);
+	const registerSessionExtension = (record, extension) => {
+		const namespace = normalizeHostHookString(extension.namespace);
+		const description = normalizeHostHookString(extension.description);
+		const project = extension.project;
+		let normalizedSessionEntrySlotKey;
+		let invalidMessage;
+		if (!namespace || !description) invalidMessage = "session extension registration requires namespace and description";
+		else if (project !== void 0 && typeof project !== "function") invalidMessage = "session extension projector must be a function";
+		else if (project?.constructor?.name === "AsyncFunction") invalidMessage = "session extension projector must be synchronous";
+		else if (extension.cleanup !== void 0 && typeof extension.cleanup !== "function") invalidMessage = "session extension cleanup must be a function";
+		else if (extension.sessionEntrySlotKey !== void 0) {
+			const slotKey = normalizeSessionEntrySlotKey(extension.sessionEntrySlotKey);
+			if (!slotKey.ok) invalidMessage = slotKey.error;
+			else normalizedSessionEntrySlotKey = slotKey.key;
+		}
+		if (invalidMessage) {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: invalidMessage
+			});
+			return;
+		}
+		if ((registry.sessionExtensions ?? []).find((entry) => entry.pluginId === record.id && entry.extension.namespace === namespace)) {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: `session extension already registered: ${namespace}`
+			});
+			return;
+		}
+		if (normalizedSessionEntrySlotKey) {
+			if ((registry.sessionExtensions ?? []).find((entry) => {
+				const existingSlotKey = entry.extension.sessionEntrySlotKey;
+				if (existingSlotKey === void 0) return false;
+				const normalizedExistingSlotKey = normalizeSessionEntrySlotKey(existingSlotKey);
+				return normalizedExistingSlotKey.ok && normalizedExistingSlotKey.key === normalizedSessionEntrySlotKey;
+			})) {
+				pushDiagnostic({
+					level: "error",
+					pluginId: record.id,
+					source: record.source,
+					message: `sessionEntrySlotKey already registered: ${normalizedSessionEntrySlotKey}`
+				});
+				return;
+			}
+		}
+		(registry.sessionExtensions ??= []).push({
+			pluginId: record.id,
+			pluginName: record.name,
+			extension: {
+				...extension,
+				namespace,
+				description,
+				...normalizedSessionEntrySlotKey ? { sessionEntrySlotKey: normalizedSessionEntrySlotKey } : {}
+			},
+			source: record.source,
+			rootDir: record.rootDir
+		});
+	};
+	const registerTrustedToolPolicy = (record, policy) => {
+		if (record.origin !== "bundled") {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: "only bundled plugins can register trusted tool policies"
+			});
+			return;
+		}
+		const id = normalizeHostHookString(policy.id);
+		const description = normalizeHostHookString(policy.description);
+		if (!id || !description || typeof policy.evaluate !== "function") {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: "trusted tool policy registration requires id, description, and evaluate()"
+			});
+			return;
+		}
+		const existing = (registry.trustedToolPolicies ?? []).find((entry) => entry.policy.id === id);
+		if (existing) {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: `trusted tool policy already registered: ${id} (${existing.pluginId})`
+			});
+			return;
+		}
+		(registry.trustedToolPolicies ??= []).push({
+			pluginId: record.id,
+			pluginName: record.name,
+			policy: {
+				...policy,
+				id,
+				description
+			},
+			source: record.source,
+			rootDir: record.rootDir
+		});
+	};
+	const registerToolMetadata = (record, metadata) => {
+		const toolName = normalizeHostHookString(metadata.toolName);
+		if (!toolName) {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: "tool metadata registration missing toolName"
+			});
+			return;
+		}
+		const undeclared = findUndeclaredPluginToolNames({
+			declaredNames: normalizePluginToolContractNames(record.contracts),
+			toolNames: [toolName]
+		});
+		if (undeclared.length > 0) {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: `plugin must declare contracts.tools for tool metadata: ${undeclared.join(", ")}`
+			});
+			return;
+		}
+		const existing = (registry.toolMetadata ?? []).find((entry) => entry.pluginId === record.id && entry.metadata.toolName === toolName);
+		if (existing) {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: `tool metadata already registered: ${toolName} (${existing.pluginId})`
+			});
+			return;
+		}
+		const displayName = normalizeOptionalHostHookString(metadata.displayName);
+		const description = normalizeOptionalHostHookString(metadata.description);
+		const tags = normalizeHostHookStringList(metadata.tags);
+		if (displayName === "" || description === "" || tags === null || metadata.risk !== void 0 && ![
+			"low",
+			"medium",
+			"high"
+		].includes(metadata.risk)) {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: `tool metadata registration has invalid metadata: ${toolName}`
+			});
+			return;
+		}
+		(registry.toolMetadata ??= []).push({
+			pluginId: record.id,
+			pluginName: record.name,
+			metadata: {
+				...metadata,
+				toolName,
+				...displayName !== void 0 ? { displayName } : {},
+				...description !== void 0 ? { description } : {},
+				...tags !== void 0 ? { tags } : {}
+			},
+			source: record.source,
+			rootDir: record.rootDir
+		});
+	};
+	const registerControlUiDescriptor = (record, descriptor) => {
+		const id = normalizeHostHookString(descriptor.id);
+		const label = normalizeHostHookString(descriptor.label);
+		const description = normalizeOptionalHostHookString(descriptor.description);
+		const placement = normalizeOptionalHostHookString(descriptor.placement);
+		const requiredScopes = normalizeHostHookStringList(descriptor.requiredScopes);
+		const surface = typeof descriptor.surface === "string" ? descriptor.surface : "";
+		if (!id || !label || !controlUiSurfaces.has(surface) || description === "" || placement === "" || requiredScopes === null) {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: "control UI descriptor registration requires id, surface, label, and valid optional fields"
+			});
+			return;
+		}
+		if (requiredScopes !== void 0) {
+			const unknownScope = requiredScopes.find((scope) => !isOperatorScope(scope));
+			if (unknownScope !== void 0) {
+				pushDiagnostic({
+					level: "error",
+					pluginId: record.id,
+					source: record.source,
+					message: `control UI descriptor requiredScopes contains unknown operator scope: ${unknownScope}`
+				});
+				return;
+			}
+		}
+		if (descriptor.schema !== void 0 && !isPluginJsonValue(descriptor.schema)) {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: `control UI descriptor schema must be JSON-compatible: ${id}`
+			});
+			return;
+		}
+		let normalizedPriority;
+		if (descriptor.priority !== void 0) {
+			if (typeof descriptor.priority !== "number" || !Number.isFinite(descriptor.priority)) {
+				pushDiagnostic({
+					level: "error",
+					pluginId: record.id,
+					source: record.source,
+					message: `control UI descriptor priority must be a finite number: ${id}`
+				});
+				return;
+			}
+			normalizedPriority = descriptor.priority;
+		}
+		let normalizedActiveWhen;
+		if (descriptor.activeWhen !== void 0) {
+			if (!chatStreamSurfaces.has(surface)) {
+				pushDiagnostic({
+					level: "error",
+					pluginId: record.id,
+					source: record.source,
+					message: `control UI descriptor activeWhen only applies to chat-* surfaces: ${id}`
+				});
+				return;
+			}
+			if (descriptor.activeWhen === null || typeof descriptor.activeWhen !== "object" || Array.isArray(descriptor.activeWhen)) {
+				pushDiagnostic({
+					level: "error",
+					pluginId: record.id,
+					source: record.source,
+					message: `control UI descriptor activeWhen must be an object: ${id}`
+				});
+				return;
+			}
+			const namespace = normalizeHostHookString(descriptor.activeWhen.sessionExtensionNamespace);
+			const valuePath = normalizeOptionalHostHookString(descriptor.activeWhen.valuePath);
+			if (!namespace || valuePath === "") {
+				pushDiagnostic({
+					level: "error",
+					pluginId: record.id,
+					source: record.source,
+					message: `control UI descriptor activeWhen requires non-empty sessionExtensionNamespace: ${id}`
+				});
+				return;
+			}
+			if (descriptor.activeWhen.equals !== void 0 && !isPluginJsonValue(descriptor.activeWhen.equals)) {
+				pushDiagnostic({
+					level: "error",
+					pluginId: record.id,
+					source: record.source,
+					message: `control UI descriptor activeWhen.equals must be JSON-compatible: ${id}`
+				});
+				return;
+			}
+			normalizedActiveWhen = {
+				sessionExtensionNamespace: namespace,
+				...valuePath !== void 0 ? { valuePath } : {},
+				...descriptor.activeWhen.equals !== void 0 ? { equals: descriptor.activeWhen.equals } : {}
+			};
+		}
+		if ((registry.controlUiDescriptors ?? []).find((entry) => entry.pluginId === record.id && entry.descriptor.id === id)) {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: `control UI descriptor already registered: ${id}`
+			});
+			return;
+		}
+		(registry.controlUiDescriptors ??= []).push({
+			pluginId: record.id,
+			pluginName: record.name,
+			descriptor: {
+				...descriptor,
+				id,
+				surface,
+				label,
+				...description !== void 0 ? { description } : {},
+				...placement !== void 0 ? { placement } : {},
+				...requiredScopes !== void 0 ? { requiredScopes } : {},
+				...normalizedPriority !== void 0 ? { priority: normalizedPriority } : {},
+				...normalizedActiveWhen !== void 0 ? { activeWhen: normalizedActiveWhen } : {}
+			},
+			source: record.source,
+			rootDir: record.rootDir
+		});
+	};
+	const registerRuntimeLifecycle = (record, lifecycle) => {
+		const id = normalizePluginHostHookId(lifecycle.id);
+		if (!id) {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: "runtime lifecycle registration missing id"
+			});
+			return;
+		}
+		if ((registry.runtimeLifecycles ?? []).find((entry) => entry.pluginId === record.id && entry.lifecycle.id === id)) {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: `runtime lifecycle already registered: ${id}`
+			});
+			return;
+		}
+		if (lifecycle.cleanup !== void 0 && typeof lifecycle.cleanup !== "function") {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: `runtime lifecycle cleanup must be a function: ${id}`
+			});
+			return;
+		}
+		(registry.runtimeLifecycles ??= []).push({
+			pluginId: record.id,
+			pluginName: record.name,
+			lifecycle: {
+				...lifecycle,
+				id
+			},
+			source: record.source,
+			rootDir: record.rootDir
+		});
+	};
+	const registerAgentEventSubscription = (record, subscription) => {
+		const id = normalizePluginHostHookId(subscription.id);
+		if (!id || typeof subscription.handle !== "function") {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: "agent event subscription registration requires id and handle"
+			});
+			return;
+		}
+		const streams = normalizeHostHookStringList(subscription.streams);
+		if (streams === null) {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: `agent event subscription streams must be an array of strings: ${id}`
+			});
+			return;
+		}
+		if ((registry.agentEventSubscriptions ?? []).find((entry) => entry.pluginId === record.id && entry.subscription.id === id)) {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: `agent event subscription already registered: ${id}`
+			});
+			return;
+		}
+		(registry.agentEventSubscriptions ??= []).push({
+			pluginId: record.id,
+			pluginName: record.name,
+			subscription: {
+				...subscription,
+				id,
+				...streams !== void 0 ? { streams } : {}
+			},
+			source: record.source,
+			rootDir: record.rootDir
+		});
+	};
+	const registerSessionSchedulerJob = (record, job) => {
+		const jobId = normalizeHostHookString(job.id);
+		const sessionKey = normalizeHostHookString(job.sessionKey);
+		const kind = normalizeHostHookString(job.kind);
+		if (jobId && (registry.sessionSchedulerJobs ?? []).some((entry) => entry.pluginId === record.id && entry.job.id === jobId)) {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: `session scheduler job already registered: ${jobId}`
+			});
+			return;
+		}
+		if (!jobId || !sessionKey || !kind) {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: "session scheduler job registration requires unique id, sessionKey, and kind"
+			});
+			return;
+		}
+		if (job.cleanup !== void 0 && typeof job.cleanup !== "function") {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: `session scheduler job cleanup must be a function: ${jobId}`
+			});
+			return;
+		}
+		if (registryParams.activateGlobalSideEffects === false) {
+			(registry.sessionSchedulerJobs ??= []).push({
+				pluginId: record.id,
+				pluginName: record.name,
+				job: {
+					...job,
+					id: jobId,
+					sessionKey,
+					kind
+				},
+				source: record.source,
+				rootDir: record.rootDir
+			});
+			return {
+				id: jobId,
+				pluginId: record.id,
+				sessionKey,
+				kind
+			};
+		}
+		const handle = registerPluginSessionSchedulerJob({
+			pluginId: record.id,
+			pluginName: record.name,
+			ownerRegistry: registry,
+			job: {
+				...job,
+				id: jobId,
+				sessionKey,
+				kind
+			}
+		});
+		if (!handle) {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: "session scheduler job registration requires unique id, sessionKey, and kind"
+			});
+			return;
+		}
+		(registry.sessionSchedulerJobs ??= []).push({
+			pluginId: record.id,
+			pluginName: record.name,
+			job: {
+				...job,
+				id: handle.id,
+				sessionKey: handle.sessionKey,
+				kind: handle.kind
+			},
+			generation: getPluginSessionSchedulerJobGeneration({
+				pluginId: record.id,
+				jobId: handle.id,
+				sessionKey: handle.sessionKey
+			}),
+			source: record.source,
+			rootDir: record.rootDir
+		});
+		return handle;
+	};
+	const registerSessionAction = (record, action) => {
+		const id = normalizeHostHookString(action.id);
+		const description = normalizeOptionalHostHookString(action.description);
+		const requiredScopes = normalizeHostHookStringList(action.requiredScopes);
+		if (!id || description === "" || requiredScopes === null || typeof action.handler !== "function") {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: "session action registration requires id, handler, and valid optional fields"
+			});
+			return;
+		}
+		if (requiredScopes !== void 0) {
+			const unknownScope = requiredScopes.find((scope) => !isOperatorScope(scope));
+			if (unknownScope !== void 0) {
+				pushDiagnostic({
+					level: "error",
+					pluginId: record.id,
+					source: record.source,
+					message: `session action requiredScopes contains unknown operator scope: ${unknownScope}`
+				});
+				return;
+			}
+		}
+		if (!validateSessionActionSchema(record, id, action.schema)) return;
+		if ((registry.sessionActions ?? []).find((entry) => entry.pluginId === record.id && entry.action.id === id)) {
+			pushDiagnostic({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: `session action already registered: ${id}`
+			});
+			return;
+		}
+		(registry.sessionActions ??= []).push({
+			pluginId: record.id,
+			pluginName: record.name,
+			action: {
+				...action,
+				id,
+				...description !== void 0 ? { description } : {},
+				...requiredScopes !== void 0 ? { requiredScopes } : {}
+			},
+			source: record.source,
+			rootDir: record.rootDir
+		});
+	};
+	const registerTypedHook = (record, hookName, handler, opts, policy) => {
+		if (!isPluginHookName(hookName)) {
+			pushDiagnostic({
+				level: "warn",
+				pluginId: record.id,
+				source: record.source,
+				message: `unknown typed hook "${String(hookName)}" ignored`
+			});
+			return;
+		}
+		let effectiveHandler = handler;
+		if (policy?.allowPromptInjection === false && isPromptInjectionHookName(hookName)) {
+			if (hookName !== "before_agent_start") {
+				pushDiagnostic({
+					level: "warn",
+					pluginId: record.id,
+					source: record.source,
+					message: `typed hook "${hookName}" blocked by plugins.entries.${record.id}.hooks.allowPromptInjection=false`
+				});
+				return;
+			}
+			pushDiagnostic({
+				level: "warn",
+				pluginId: record.id,
+				source: record.source,
+				message: `typed hook "${hookName}" prompt fields constrained by plugins.entries.${record.id}.hooks.allowPromptInjection=false`
+			});
+			effectiveHandler = constrainLegacyPromptInjectionHook(handler);
+		}
+		if (isConversationHookName(hookName)) {
+			const explicitConversationAccess = policy?.allowConversationAccess;
+			if (record.origin !== "bundled" && explicitConversationAccess !== true) {
+				pushDiagnostic({
+					level: "warn",
+					pluginId: record.id,
+					source: record.source,
+					message: `typed hook "${hookName}" blocked because non-bundled plugins must set plugins.entries.${record.id}.hooks.allowConversationAccess=true`
+				});
+				return;
+			}
+			if (record.origin === "bundled" && explicitConversationAccess === false) {
+				pushDiagnostic({
+					level: "warn",
+					pluginId: record.id,
+					source: record.source,
+					message: `typed hook "${hookName}" blocked by plugins.entries.${record.id}.hooks.allowConversationAccess=false`
+				});
+				return;
+			}
+		}
+		const timeoutMs = resolveTypedHookTimeoutMs({
+			hookName,
+			opts,
+			policy
+		});
+		record.hookCount += 1;
+		registry.typedHooks.push({
+			pluginId: record.id,
+			hookName,
+			handler: effectiveHandler,
+			priority: opts?.priority,
+			...timeoutMs !== void 0 ? { timeoutMs } : {},
+			source: record.source
+		});
+	};
+	const registerConversationBindingResolvedHandler = (record, handler) => {
+		registry.conversationBindingResolvedHandlers.push({
+			pluginId: record.id,
+			pluginName: record.name,
+			pluginRoot: record.rootDir,
+			handler,
+			source: record.source,
+			rootDir: record.rootDir
+		});
+	};
+	const normalizeLogger = (logger) => ({
+		info: logger.info,
+		warn: logger.warn,
+		error: logger.error,
+		debug: logger.debug
+	});
+	const pluginRuntimeById = /* @__PURE__ */ new Map();
+	const pluginRuntimeRecordById = /* @__PURE__ */ new Map();
+	const resolvePluginRuntime = (pluginId) => {
+		const cached = pluginRuntimeById.get(pluginId);
+		if (cached) return cached;
+		const runtime = new Proxy(registryParams.runtime, { get(target, prop, receiver) {
+			if (prop === "state") return {
+				...Reflect.get(target, prop, receiver),
+				openKeyedStore: (options) => {
+					if ((pluginRuntimeRecordById.get(pluginId) ?? registry.plugins.find((entry) => entry.id === pluginId))?.origin !== "bundled") throw new Error("openKeyedStore is only available for bundled plugins in this release.");
+					return createPluginStateKeyedStore(pluginId, options);
+				}
+			};
+			if (prop === "llm") {
+				const llm = Reflect.get(target, prop, receiver);
+				return { complete: (params) => withPluginRuntimePluginIdScope(pluginId, () => llm.complete(params)) };
+			}
+			if (prop !== "subagent") return Reflect.get(target, prop, receiver);
+			const subagent = Reflect.get(target, prop, receiver);
+			return {
+				run: (params) => withPluginRuntimePluginIdScope(pluginId, () => subagent.run(params)),
+				waitForRun: (params) => withPluginRuntimePluginIdScope(pluginId, () => subagent.waitForRun(params)),
+				getSessionMessages: (params) => withPluginRuntimePluginIdScope(pluginId, () => subagent.getSessionMessages(params)),
+				getSession: (params) => withPluginRuntimePluginIdScope(pluginId, () => subagent.getSession(params)),
+				deleteSession: (params) => withPluginRuntimePluginIdScope(pluginId, () => subagent.deleteSession(params))
+			};
+		} });
+		pluginRuntimeById.set(pluginId, runtime);
+		return runtime;
+	};
+	const createApi = (record, params) => {
+		const registrationMode = params.registrationMode ?? "full";
+		const registrationCapabilities = resolvePluginRegistrationCapabilities(registrationMode);
+		pluginRuntimeRecordById.set(record.id, record);
+		const sideEffectGuard = createPluginSideEffectGuard(record.id);
+		const isLoadedRecordInRegistry = () => registry.plugins.some((plugin) => plugin.id === record.id && plugin.status === "loaded");
+		const isLoadedRecordInActiveRegistry = () => getActivePluginRegistry() === registry && isLoadedRecordInRegistry();
+		const isActivatingLoadedRecord = () => registryParams.activateGlobalSideEffects !== false && record.enabled && record.status === "loaded" && !registry.plugins.some((plugin) => plugin.id === record.id);
+		const shouldCommitWorkflowSideEffect = () => sideEffectGuard.active && !isPluginRegistryRetired(registry) && (isActivatingLoadedRecord() || isPluginRegistryActivated(registry) && isLoadedRecordInRegistry());
+		return buildPluginApi({
+			id: record.id,
+			name: record.name,
+			version: record.version,
+			description: record.description,
+			source: record.source,
+			rootDir: record.rootDir,
+			registrationMode,
+			config: params.config,
+			pluginConfig: params.pluginConfig,
+			runtime: resolvePluginRuntime(record.id),
+			logger: normalizeLogger(registryParams.logger),
+			resolvePath: (input) => resolvePluginPath(input, record.rootDir),
+			handlers: {
+				...registrationCapabilities.capabilityHandlers ? {
+					registerTool: (tool, opts) => registerTool(record, tool, opts),
+					registerHook: (events, handler, opts) => registerHook(record, events, handler, opts, params.config, params.pluginConfig),
+					registerHttpRoute: (routeParams) => registerHttpRoute(record, routeParams),
+					registerHostedMediaResolver: (resolver) => registerHostedMediaResolver(record, resolver),
+					registerProvider: (provider) => registerProvider(record, provider),
+					registerModelCatalogProvider: (provider) => registerModelCatalogProvider(record, provider),
+					registerAgentHarness: (harness) => registerAgentHarness$1(record, harness),
+					registerDetachedTaskRuntime: (runtime) => {
+						const existing = getDetachedTaskLifecycleRuntimeRegistration();
+						if (existing && existing.pluginId !== record.id) {
+							pushDiagnostic({
+								level: "error",
+								pluginId: record.id,
+								source: record.source,
+								message: `detached task runtime already registered by ${existing.pluginId}`
+							});
+							return;
+						}
+						registerDetachedTaskLifecycleRuntime(record.id, runtime);
+					},
+					registerSpeechProvider: (provider) => registerSpeechProvider(record, provider),
+					registerRealtimeTranscriptionProvider: (provider) => registerRealtimeTranscriptionProvider(record, provider),
+					registerRealtimeVoiceProvider: (provider) => registerRealtimeVoiceProvider(record, provider),
+					registerMediaUnderstandingProvider: (provider) => registerMediaUnderstandingProvider(record, provider),
+					registerImageGenerationProvider: (provider) => registerImageGenerationProvider(record, provider),
+					registerVideoGenerationProvider: (provider) => registerVideoGenerationProvider(record, provider),
+					registerMusicGenerationProvider: (provider) => registerMusicGenerationProvider(record, provider),
+					registerWebFetchProvider: (provider) => registerWebFetchProvider(record, provider),
+					registerWebSearchProvider: (provider) => registerWebSearchProvider(record, provider),
+					registerMigrationProvider: (provider) => registerMigrationProvider(record, provider),
+					registerGatewayMethod: (method, handler, opts) => registerGatewayMethod(record, method, handler, opts),
+					registerService: (service) => registerService(record, service),
+					registerGatewayDiscoveryService: (service) => registerGatewayDiscoveryService(record, service),
+					registerCliBackend: (backend) => registerCliBackend(record, backend),
+					registerTextTransforms: (transforms) => registerTextTransforms(record, transforms),
+					registerReload: (registration) => registerReload(record, registration),
+					registerNodeHostCommand: (command) => registerNodeHostCommand(record, command),
+					registerNodeInvokePolicy: (policy) => registerNodeInvokePolicy(record, policy, params.pluginConfig),
+					registerSecurityAuditCollector: (collector) => registerSecurityAuditCollector(record, collector),
+					registerInteractiveHandler: (registration) => {
+						const result = registerPluginInteractiveHandler(record.id, registration, {
+							pluginName: record.name,
+							pluginRoot: record.rootDir
+						});
+						if (!result.ok) pushDiagnostic({
+							level: "warn",
+							pluginId: record.id,
+							source: record.source,
+							message: result.error ?? "interactive handler registration failed"
+						});
+					},
+					onConversationBindingResolved: (handler) => registerConversationBindingResolvedHandler(record, handler),
+					registerCommand: (command) => registerCommand(record, command),
+					registerContextEngine: (id, factory) => {
+						const normalizedId = normalizeOptionalString(id) ?? "";
+						if (!normalizedId) {
+							pushDiagnostic({
+								level: "error",
+								pluginId: record.id,
+								source: record.source,
+								message: "context engine registration missing id"
+							});
+							return;
+						}
+						if (typeof factory !== "function") {
+							pushDiagnostic({
+								level: "error",
+								pluginId: record.id,
+								source: record.source,
+								message: `context engine "${normalizedId}" registration missing factory`
+							});
+							return;
+						}
+						if (normalizedId === defaultSlotIdForKey("contextEngine")) {
+							pushDiagnostic({
+								level: "error",
+								pluginId: record.id,
+								source: record.source,
+								message: `context engine id reserved by core: ${normalizedId}`
+							});
+							return;
+						}
+						const result = registerContextEngineForOwner(normalizedId, factory, `plugin:${record.id}`, { allowSameOwnerRefresh: true });
+						if (!result.ok) {
+							pushDiagnostic({
+								level: "error",
+								pluginId: record.id,
+								source: record.source,
+								message: `context engine already registered: ${normalizedId} (${result.existingOwner})`
+							});
+							return;
+						}
+						if (!record.contextEngineIds?.includes(normalizedId)) record.contextEngineIds = [...record.contextEngineIds ?? [], normalizedId];
+					},
+					registerCompactionProvider: (provider) => {
+						const id = normalizeOptionalString(provider?.id);
+						if (!id) {
+							pushDiagnostic({
+								level: "error",
+								pluginId: record.id,
+								source: record.source,
+								message: "compaction provider registration missing id"
+							});
+							return;
+						}
+						if (typeof provider?.summarize !== "function") {
+							pushDiagnostic({
+								level: "error",
+								pluginId: record.id,
+								source: record.source,
+								message: `compaction provider "${id}" registration missing summarize`
+							});
+							return;
+						}
+						const existing = getRegisteredCompactionProvider(id);
+						if (existing) {
+							const ownerDetail = existing.ownerPluginId ? ` (owner: ${existing.ownerPluginId})` : "";
+							pushDiagnostic({
+								level: "error",
+								pluginId: record.id,
+								source: record.source,
+								message: `compaction provider already registered: ${id}${ownerDetail}`
+							});
+							return;
+						}
+						registerCompactionProvider(provider, { ownerPluginId: record.id });
+					},
+					registerCodexAppServerExtensionFactory: (factory) => {
+						registerCodexAppServerExtensionFactory(record, factory);
+					},
+					registerAgentToolResultMiddleware: (handler, options) => {
+						registerAgentToolResultMiddleware(record, handler, options);
+					},
+					registerSessionExtension: (extension) => registerSessionExtension(record, extension),
+					enqueueNextTurnInjection: (injection) => {
+						if (params.hookPolicy?.allowPromptInjection === false) {
+							pushDiagnostic({
+								level: "warn",
+								pluginId: record.id,
+								source: record.source,
+								message: `next-turn injection blocked by plugins.entries.${record.id}.hooks.allowPromptInjection=false`
+							});
+							return Promise.resolve({
+								enqueued: false,
+								id: "",
+								sessionKey: injection.sessionKey
+							});
+						}
+						return enqueuePluginNextTurnInjection({
+							cfg: registryParams.runtime.config.current(),
+							pluginId: record.id,
+							pluginName: record.name,
+							injection
+						});
+					},
+					registerTrustedToolPolicy: (policy) => registerTrustedToolPolicy(record, policy),
+					registerToolMetadata: (metadata) => registerToolMetadata(record, metadata),
+					registerControlUiDescriptor: (descriptor) => registerControlUiDescriptor(record, descriptor),
+					registerRuntimeLifecycle: (lifecycle) => registerRuntimeLifecycle(record, lifecycle),
+					registerAgentEventSubscription: (subscription) => registerAgentEventSubscription(record, subscription),
+					emitAgentEvent: (event) => {
+						if (registryParams.activateGlobalSideEffects === false) return {
+							emitted: false,
+							reason: "global side effects disabled"
+						};
+						if (!shouldCommitWorkflowSideEffect()) return {
+							emitted: false,
+							reason: "plugin is not loaded"
+						};
+						return emitPluginAgentEvent({
+							pluginId: record.id,
+							pluginName: record.name,
+							origin: record.origin,
+							event
+						});
+					},
+					setRunContext: (patch) => registryParams.activateGlobalSideEffects !== false && shouldCommitWorkflowSideEffect() ? setPluginRunContext({
+						pluginId: record.id,
+						patch
+					}) : false,
+					getRunContext: (get) => getPluginRunContext({
+						pluginId: record.id,
+						get
+					}),
+					clearRunContext: (params) => {
+						if (registryParams.activateGlobalSideEffects === false || !shouldCommitWorkflowSideEffect()) return;
+						clearPluginRunContext({
+							pluginId: record.id,
+							runId: params.runId,
+							namespace: params.namespace
+						});
+					},
+					registerSessionSchedulerJob: (job) => registerSessionSchedulerJob(record, job),
+					registerSessionAction: (action) => registerSessionAction(record, action),
+					sendSessionAttachment: async (attachment) => {
+						if (registryParams.activateGlobalSideEffects === false) return {
+							ok: false,
+							error: "global side effects disabled"
+						};
+						try {
+							if (!isLoadedRecordInActiveRegistry()) return {
+								ok: false,
+								error: "plugin is not loaded"
+							};
+							const runtimeConfig = registryParams.runtime.config?.current?.() ?? params.config;
+							return await sendPluginSessionAttachment({
+								...attachment,
+								config: runtimeConfig,
+								origin: record.origin
+							});
+						} catch (error) {
+							return {
+								ok: false,
+								error: `attachment delivery setup failed: ${formatErrorMessage(error)}`
+							};
+						}
+					},
+					scheduleSessionTurn: async (schedule) => {
+						if (registryParams.activateGlobalSideEffects === false) return;
+						await Promise.resolve();
+						return schedulePluginSessionTurn({
+							pluginId: record.id,
+							pluginName: record.name,
+							origin: record.origin,
+							schedule,
+							cron: getHostCronService(),
+							shouldCommit: isLoadedRecordInActiveRegistry,
+							ownerRegistry: registry
+						});
+					},
+					unscheduleSessionTurnsByTag: async (request) => {
+						if (registryParams.activateGlobalSideEffects === false) return {
+							removed: 0,
+							failed: 0
+						};
+						await Promise.resolve();
+						if (!isLoadedRecordInActiveRegistry()) return {
+							removed: 0,
+							failed: 0
+						};
+						return unschedulePluginSessionTurnsByTag({
+							pluginId: record.id,
+							origin: record.origin,
+							cron: getHostCronService(),
+							request
+						});
+					},
+					registerMemoryCapability: (capability) => {
+						if (!hasKind(record.kind, "memory")) throwRegistrationError("only memory plugins can register a memory capability");
+						if (Array.isArray(record.kind) && record.kind.length > 1 && !record.memorySlotSelected) {
+							pushDiagnostic({
+								level: "warn",
+								pluginId: record.id,
+								source: record.source,
+								message: "dual-kind plugin not selected for memory slot; skipping memory capability registration"
+							});
+							return;
+						}
+						registerMemoryCapability(record.id, capability);
+					},
+					registerMemoryPromptSection: (builder) => {
+						if (!hasKind(record.kind, "memory")) throwRegistrationError("only memory plugins can register a memory prompt section");
+						if (Array.isArray(record.kind) && record.kind.length > 1 && !record.memorySlotSelected) {
+							pushDiagnostic({
+								level: "warn",
+								pluginId: record.id,
+								source: record.source,
+								message: "dual-kind plugin not selected for memory slot; skipping memory prompt section registration"
+							});
+							return;
+						}
+						registerMemoryPromptSectionForPlugin(record.id, builder);
+					},
+					registerMemoryPromptSupplement: (builder) => {
+						if (typeof builder !== "function") {
+							pushDiagnostic({
+								level: "error",
+								pluginId: record.id,
+								source: record.source,
+								message: "memory prompt supplement registration missing builder"
+							});
+							return;
+						}
+						registerMemoryPromptSupplement(record.id, builder);
+					},
+					registerMemoryCorpusSupplement: (supplement) => {
+						registerMemoryCorpusSupplement(record.id, supplement);
+					},
+					registerMemoryFlushPlan: (resolver) => {
+						if (!hasKind(record.kind, "memory")) throwRegistrationError("only memory plugins can register a memory flush plan");
+						if (Array.isArray(record.kind) && record.kind.length > 1 && !record.memorySlotSelected) {
+							pushDiagnostic({
+								level: "warn",
+								pluginId: record.id,
+								source: record.source,
+								message: "dual-kind plugin not selected for memory slot; skipping memory flush plan registration"
+							});
+							return;
+						}
+						registerMemoryFlushPlanResolverForPlugin(record.id, resolver);
+					},
+					registerMemoryRuntime: (runtime) => {
+						if (!hasKind(record.kind, "memory")) throwRegistrationError("only memory plugins can register a memory runtime");
+						if (Array.isArray(record.kind) && record.kind.length > 1 && !record.memorySlotSelected) {
+							pushDiagnostic({
+								level: "warn",
+								pluginId: record.id,
+								source: record.source,
+								message: "dual-kind plugin not selected for memory slot; skipping memory runtime registration"
+							});
+							return;
+						}
+						registerMemoryRuntimeForPlugin(record.id, runtime);
+					},
+					registerMemoryEmbeddingProvider: (adapter) => {
+						if (hasKind(record.kind, "memory")) {
+							if (Array.isArray(record.kind) && record.kind.length > 1 && !record.memorySlotSelected) {
+								pushDiagnostic({
+									level: "warn",
+									pluginId: record.id,
+									source: record.source,
+									message: "dual-kind plugin not selected for memory slot; skipping memory embedding provider registration"
+								});
+								return;
+							}
+						} else if (!(record.contracts?.memoryEmbeddingProviders ?? []).includes(adapter.id)) {
+							pushDiagnostic({
+								level: "error",
+								pluginId: record.id,
+								source: record.source,
+								message: `plugin must own memory slot or declare contracts.memoryEmbeddingProviders for adapter: ${adapter.id}`
+							});
+							return;
+						}
+						const existing = getRegisteredMemoryEmbeddingProvider(adapter.id);
+						if (existing) {
+							const ownerDetail = existing.ownerPluginId ? ` (owner: ${existing.ownerPluginId})` : "";
+							pushDiagnostic({
+								level: "error",
+								pluginId: record.id,
+								source: record.source,
+								message: `memory embedding provider already registered: ${adapter.id}${ownerDetail}`
+							});
+							return;
+						}
+						registerMemoryEmbeddingProvider(adapter, { ownerPluginId: record.id });
+						registry.memoryEmbeddingProviders.push({
+							pluginId: record.id,
+							pluginName: record.name,
+							provider: adapter,
+							source: record.source,
+							rootDir: record.rootDir
+						});
+					},
+					on: (hookName, handler, opts) => registerTypedHook(record, hookName, handler, opts, params.hookPolicy)
+				} : {},
+				registerCli: (registrar, opts) => registerCli(record, registrar, opts),
+				registerChannel: (registration) => registerChannel(record, registration, registrationMode)
+			}
+		});
+	};
+	const rollbackPluginGlobalSideEffects = (pluginId) => {
+		deactivatePluginSideEffectGuards(pluginId);
+		if (registryParams.activateGlobalSideEffects === false) return;
+		clearPluginCommandsForPlugin(pluginId);
+		clearPluginInteractiveHandlersForPlugin(pluginId);
+		clearContextEnginesForOwner(`plugin:${pluginId}`);
+		const hookRollbackEntries = pluginHookRollback.get(pluginId) ?? [];
+		for (const entry of hookRollbackEntries.toReversed()) {
+			const activeRegistrations = activePluginHookRegistrations.get(entry.name) ?? [];
+			for (const registration of activeRegistrations) unregisterInternalHook(registration.event, registration.handler);
+			if (entry.previousRegistrations.length === 0) {
+				activePluginHookRegistrations.delete(entry.name);
+				continue;
+			}
+			for (const registration of entry.previousRegistrations) registerInternalHook(registration.event, registration.handler);
+			activePluginHookRegistrations.set(entry.name, [...entry.previousRegistrations]);
+		}
+		pluginHookRollback.delete(pluginId);
+	};
+	return {
+		registry,
+		createApi,
+		rollbackPluginGlobalSideEffects,
+		pushDiagnostic,
+		registerTool,
+		registerChannel,
+		registerHostedMediaResolver,
+		registerProvider,
+		registerModelCatalogProvider,
+		registerAgentHarness: registerAgentHarness$1,
+		registerCliBackend,
+		registerTextTransforms,
+		registerSpeechProvider,
+		registerRealtimeTranscriptionProvider,
+		registerRealtimeVoiceProvider,
+		registerMediaUnderstandingProvider,
+		registerImageGenerationProvider,
+		registerVideoGenerationProvider,
+		registerMusicGenerationProvider,
+		registerWebSearchProvider,
+		registerMigrationProvider,
+		registerGatewayMethod,
+		registerCli,
+		registerReload,
+		registerNodeHostCommand,
+		registerSecurityAuditCollector,
+		registerService,
+		registerCommand,
+		registerSessionExtension,
+		registerTrustedToolPolicy,
+		registerToolMetadata,
+		registerControlUiDescriptor,
+		registerRuntimeLifecycle,
+		registerAgentEventSubscription,
+		registerSessionSchedulerJob,
+		registerSessionAction,
+		registerHook,
+		registerTypedHook
+	};
+}
+//#endregion
+//#region src/plugins/loader.ts
+const CLI_METADATA_ENTRY_BASENAMES = [
+	"cli-metadata.ts",
+	"cli-metadata.js",
+	"cli-metadata.mjs",
+	"cli-metadata.cjs"
+];
+function resolveDreamingSidecarEngineId(params) {
+	const normalizedMemorySlot = normalizeLowercaseStringOrEmpty(params.memorySlot);
+	if (!normalizedMemorySlot || normalizedMemorySlot === "none" || normalizedMemorySlot === "memory-core") return null;
+	return resolveMemoryDreamingConfig({
+		pluginConfig: resolveMemoryDreamingPluginConfig(params.cfg),
+		cfg: params.cfg
+	}).enabled ? DEFAULT_MEMORY_DREAMING_PLUGIN_ID : null;
+}
+var PluginLoadFailureError = class extends Error {
+	constructor(registry) {
+		const failedPlugins = registry.plugins.filter((entry) => entry.status === "error");
+		const summary = failedPlugins.map((entry) => `${entry.id}: ${entry.error ?? "unknown plugin load error"}`).join("; ");
+		super(`plugin load failed: ${summary}`);
+		this.name = "PluginLoadFailureError";
+		this.pluginIds = failedPlugins.map((entry) => entry.id);
+		this.registry = registry;
+	}
+};
+const MAX_PLUGIN_REGISTRY_CACHE_ENTRIES = 128;
+const pluginLoaderCacheState = new PluginLoaderCacheState(MAX_PLUGIN_REGISTRY_CACHE_ENTRIES);
+const fullWorkspacePluginLoaderCacheState = new PluginLoaderCacheState(MAX_PLUGIN_REGISTRY_CACHE_ENTRIES);
+const LAZY_RUNTIME_REFLECTION_KEYS = [
+	"version",
+	"config",
+	"agent",
+	"subagent",
+	"system",
+	"media",
+	"tts",
+	"stt",
+	"channel",
+	"events",
+	"logging",
+	"state",
+	"modelAuth"
+];
+function createPluginCandidatesFromManifestRegistry(manifestRegistry) {
+	return manifestRegistry.plugins.map((record) => ({
+		idHint: record.id,
+		rootDir: record.rootDir,
+		source: record.source,
+		...record.setupSource !== void 0 ? { setupSource: record.setupSource } : {},
+		origin: record.origin,
+		...record.workspaceDir !== void 0 ? { workspaceDir: record.workspaceDir } : {},
+		...record.format !== void 0 ? { format: record.format } : {},
+		...record.bundleFormat !== void 0 ? { bundleFormat: record.bundleFormat } : {}
+	}));
+}
+function clearPluginLoaderCache() {
+	pluginLoaderCacheState.clear();
+	fullWorkspacePluginLoaderCacheState.clear();
+	clearActivatedPluginRuntimeState();
+}
+function clearActivatedPluginRuntimeState() {
+	clearAgentHarnesses();
+	clearPluginCommands();
+	clearCompactionProviders();
+	clearDetachedTaskLifecycleRuntimeRegistration();
+	clearPluginInteractiveHandlers();
+	clearMemoryEmbeddingProviders();
+	clearMemoryPluginState();
+}
+function clearPluginRegistryLoadCache() {
+	pluginLoaderCacheState.clearCachedRegistries();
+	fullWorkspacePluginLoaderCacheState.clearCachedRegistries();
+}
+const defaultLogger = () => createSubsystemLogger("plugins");
+function isPromiseLike(value) {
+	return (typeof value === "object" || typeof value === "function") && value !== null && typeof value.then === "function";
+}
+function snapshotPluginRegistry(registry) {
+	return {
+		arrays: {
+			tools: [...registry.tools],
+			hooks: [...registry.hooks],
+			typedHooks: [...registry.typedHooks],
+			channels: [...registry.channels],
+			channelSetups: [...registry.channelSetups],
+			providers: [...registry.providers],
+			modelCatalogProviders: [...registry.modelCatalogProviders],
+			cliBackends: [...registry.cliBackends ?? []],
+			textTransforms: [...registry.textTransforms],
+			speechProviders: [...registry.speechProviders],
+			realtimeTranscriptionProviders: [...registry.realtimeTranscriptionProviders],
+			realtimeVoiceProviders: [...registry.realtimeVoiceProviders],
+			mediaUnderstandingProviders: [...registry.mediaUnderstandingProviders],
+			imageGenerationProviders: [...registry.imageGenerationProviders],
+			videoGenerationProviders: [...registry.videoGenerationProviders],
+			musicGenerationProviders: [...registry.musicGenerationProviders],
+			webFetchProviders: [...registry.webFetchProviders],
+			webSearchProviders: [...registry.webSearchProviders],
+			migrationProviders: [...registry.migrationProviders],
+			codexAppServerExtensionFactories: [...registry.codexAppServerExtensionFactories],
+			agentToolResultMiddlewares: [...registry.agentToolResultMiddlewares],
+			memoryEmbeddingProviders: [...registry.memoryEmbeddingProviders],
+			agentHarnesses: [...registry.agentHarnesses],
+			httpRoutes: [...registry.httpRoutes],
+			cliRegistrars: [...registry.cliRegistrars],
+			reloads: [...registry.reloads ?? []],
+			nodeHostCommands: [...registry.nodeHostCommands ?? []],
+			nodeInvokePolicies: [...registry.nodeInvokePolicies ?? []],
+			securityAuditCollectors: [...registry.securityAuditCollectors ?? []],
+			services: [...registry.services],
+			commands: [...registry.commands],
+			sessionActions: [...registry.sessionActions ?? []],
+			conversationBindingResolvedHandlers: [...registry.conversationBindingResolvedHandlers],
+			diagnostics: [...registry.diagnostics]
+		},
+		gatewayHandlers: { ...registry.gatewayHandlers },
+		gatewayMethodScopes: { ...registry.gatewayMethodScopes },
+		coreGatewayMethodNames: [...registry.coreGatewayMethodNames ?? []]
+	};
+}
+function restorePluginRegistry(registry, snapshot) {
+	registry.tools = snapshot.arrays.tools;
+	registry.hooks = snapshot.arrays.hooks;
+	registry.typedHooks = snapshot.arrays.typedHooks;
+	registry.channels = snapshot.arrays.channels;
+	registry.channelSetups = snapshot.arrays.channelSetups;
+	registry.providers = snapshot.arrays.providers;
+	registry.modelCatalogProviders = snapshot.arrays.modelCatalogProviders;
+	registry.cliBackends = snapshot.arrays.cliBackends;
+	registry.textTransforms = snapshot.arrays.textTransforms;
+	registry.speechProviders = snapshot.arrays.speechProviders;
+	registry.realtimeTranscriptionProviders = snapshot.arrays.realtimeTranscriptionProviders;
+	registry.realtimeVoiceProviders = snapshot.arrays.realtimeVoiceProviders;
+	registry.mediaUnderstandingProviders = snapshot.arrays.mediaUnderstandingProviders;
+	registry.imageGenerationProviders = snapshot.arrays.imageGenerationProviders;
+	registry.videoGenerationProviders = snapshot.arrays.videoGenerationProviders;
+	registry.musicGenerationProviders = snapshot.arrays.musicGenerationProviders;
+	registry.webFetchProviders = snapshot.arrays.webFetchProviders;
+	registry.webSearchProviders = snapshot.arrays.webSearchProviders;
+	registry.migrationProviders = snapshot.arrays.migrationProviders;
+	registry.codexAppServerExtensionFactories = snapshot.arrays.codexAppServerExtensionFactories;
+	registry.agentToolResultMiddlewares = snapshot.arrays.agentToolResultMiddlewares;
+	registry.memoryEmbeddingProviders = snapshot.arrays.memoryEmbeddingProviders;
+	registry.agentHarnesses = snapshot.arrays.agentHarnesses;
+	registry.httpRoutes = snapshot.arrays.httpRoutes;
+	registry.cliRegistrars = snapshot.arrays.cliRegistrars;
+	registry.reloads = snapshot.arrays.reloads;
+	registry.nodeHostCommands = snapshot.arrays.nodeHostCommands;
+	registry.nodeInvokePolicies = snapshot.arrays.nodeInvokePolicies;
+	registry.securityAuditCollectors = snapshot.arrays.securityAuditCollectors;
+	registry.services = snapshot.arrays.services;
+	registry.commands = snapshot.arrays.commands;
+	registry.sessionActions = snapshot.arrays.sessionActions;
+	registry.conversationBindingResolvedHandlers = snapshot.arrays.conversationBindingResolvedHandlers;
+	registry.diagnostics = snapshot.arrays.diagnostics;
+	registry.gatewayHandlers = snapshot.gatewayHandlers;
+	registry.gatewayMethodScopes = snapshot.gatewayMethodScopes;
+	registry.coreGatewayMethodNames = snapshot.coreGatewayMethodNames;
+}
+function createGuardedPluginRegistrationApi(api) {
+	let closed = false;
+	return {
+		api: attachPluginApiFacades(new Proxy(api, { get(target, prop, receiver) {
+			const value = Reflect.get(target, prop, receiver);
+			if (typeof value !== "function") return value;
+			if (typeof prop === "string" && isLateCallablePluginApiMethod(prop)) return (...args) => Reflect.apply(value, target, args);
+			return (...args) => {
+				const isLateCallableMethod = typeof prop === "string" && isLateCallablePluginApiMethod(prop);
+				if (closed && !isLateCallableMethod) return;
+				return Reflect.apply(value, target, args);
+			};
+		} })),
+		close: () => {
+			closed = true;
+		}
+	};
+}
+function runPluginRegisterSync(register, api) {
+	const guarded = createGuardedPluginRegistrationApi(api);
+	try {
+		const result = register(guarded.api);
+		if (isPromiseLike(result)) {
+			Promise.resolve(result).catch(() => {});
+			throw new Error("plugin register must be synchronous");
+		}
+	} finally {
+		guarded.close();
+	}
+}
+function createPluginModuleLoader(options) {
+	const moduleLoaders = createPluginModuleLoaderCache();
+	const createLoaderForModule = (modulePath) => {
+		return getCachedPluginModuleLoader({
+			cache: moduleLoaders,
+			modulePath,
+			importerUrl: import.meta.url,
+			loaderFilename: modulePath,
+			aliasMap: buildPluginLoaderAliasMap(modulePath, process.argv[1], import.meta.url, options.pluginSdkResolution),
+			pluginSdkResolution: options.pluginSdkResolution
+		});
+	};
+	return (modulePath) => createLoaderForModule(modulePath)(toSafeImportPath(modulePath));
+}
+function resolveCanonicalDistRuntimeSource(source) {
+	const marker = `${path.sep}dist-runtime${path.sep}extensions${path.sep}`;
+	const index = source.indexOf(marker);
+	if (index === -1) return source;
+	const candidate = `${source.slice(0, index)}${path.sep}dist${path.sep}extensions${path.sep}${source.slice(index + marker.length)}`;
+	return fs.existsSync(candidate) ? candidate : source;
+}
+function rewriteBundledRuntimeArtifactRelativePath(relativePath) {
+	return relativePath.replace(/\.[^.]+$/u, ".js");
+}
+function resolvePreferredBuiltBundledRuntimeArtifact(params) {
+	const rootDir = safeRealpathOrResolve(params.rootDir);
+	const source = safeRealpathOrResolve(params.source);
+	if (!params.preferBuiltPluginArtifacts || params.origin !== "bundled") return {
+		source,
+		rootDir
+	};
+	const extensionsDir = path.dirname(rootDir);
+	if (path.basename(extensionsDir) !== "extensions") return {
+		source,
+		rootDir
+	};
+	const packageRoot = path.dirname(extensionsDir);
+	if (path.basename(packageRoot) === "dist" || path.basename(packageRoot) === "dist-runtime") return {
+		source,
+		rootDir
+	};
+	const relativeSource = path.relative(rootDir, source);
+	if (relativeSource === "" || relativeSource.startsWith("..") || path.isAbsolute(relativeSource)) return {
+		source,
+		rootDir
+	};
+	const artifactRelativePath = rewriteBundledRuntimeArtifactRelativePath(relativeSource);
+	for (const artifactRootName of ["dist-runtime", "dist"]) {
+		const artifactRoot = path.join(packageRoot, artifactRootName, "extensions", path.basename(rootDir));
+		const artifactSource = path.join(artifactRoot, artifactRelativePath);
+		if (fs.existsSync(artifactSource)) return {
+			source: safeRealpathOrResolve(artifactSource),
+			rootDir: safeRealpathOrResolve(artifactRoot)
+		};
+	}
+	return {
+		source,
+		rootDir
+	};
+}
+const __testing = {
+	buildPluginLoaderJitiOptions,
+	buildPluginLoaderAliasMap,
+	listPluginSdkAliasCandidates,
+	listPluginSdkExportedSubpaths,
+	resolveExtensionApiAlias,
+	resolvePluginSdkScopedAliasMap,
+	resolvePluginSdkAliasCandidateOrder,
+	resolvePluginSdkAliasFile,
+	resolvePluginRuntimeModulePath,
+	ensureOpenClawPluginSdkAlias,
+	shouldLoadChannelPluginInSetupRuntime,
+	shouldPreferNativeModuleLoad,
+	toSafeImportPath,
+	createGuardedPluginRegistrationApi,
+	runPluginRegisterSync,
+	getCompatibleActivePluginRegistry,
+	resolvePluginLoadCacheContext,
+	get maxPluginRegistryCacheEntries() {
+		return pluginLoaderCacheState.maxEntries;
+	},
+	setMaxPluginRegistryCacheEntriesForTest(value) {
+		pluginLoaderCacheState.setMaxEntriesForTest(value);
+		fullWorkspacePluginLoaderCacheState.setMaxEntriesForTest(value);
+	}
+};
+function getPluginRegistryCache(onlyPluginIds) {
+	return onlyPluginIds ? pluginLoaderCacheState : fullWorkspacePluginLoaderCacheState;
+}
+function getCachedPluginRegistry(cacheKey, onlyPluginIds) {
+	return getPluginRegistryCache(onlyPluginIds).get(cacheKey);
+}
+function setCachedPluginRegistry(cacheKey, state, onlyPluginIds) {
+	getPluginRegistryCache(onlyPluginIds).set(cacheKey, state);
+}
+function getReusableCachedPluginRegistry(params) {
+	const exact = getCachedPluginRegistry(params.cacheKey, params.onlyPluginIds);
+	if (exact) return {
+		state: exact,
+		cacheKey: params.cacheKey,
+		runtimeSubagentMode: params.runtimeSubagentMode
+	};
+	if (params.runtimeSubagentMode !== "default") return;
+	const gatewayBindableContext = resolvePluginLoadCacheContext({
+		...params.options,
+		runtimeOptions: {
+			...params.options.runtimeOptions,
+			allowGatewaySubagentBinding: true
+		}
+	});
+	const gatewayBindable = getCachedPluginRegistry(gatewayBindableContext.cacheKey, gatewayBindableContext.onlyPluginIds);
+	if (!gatewayBindable) return;
+	return {
+		state: gatewayBindable,
+		cacheKey: gatewayBindableContext.cacheKey,
+		runtimeSubagentMode: gatewayBindableContext.runtimeSubagentMode
+	};
+}
+function resolveBundledPackageRootForCache(stockRoot) {
+	if (!stockRoot) return;
+	const resolved = path.resolve(stockRoot);
+	const parent = path.dirname(resolved);
+	if (path.basename(resolved) === "extensions" && (path.basename(parent) === "dist" || path.basename(parent) === "dist-runtime")) return path.dirname(parent);
+	const sourcePackageRoot = parent;
+	if (fs.existsSync(path.join(sourcePackageRoot, "package.json"))) return sourcePackageRoot;
+}
+function readPackageVersionForCache(packageJsonPath) {
+	const parsed = tryReadJsonSync(packageJsonPath);
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return "unknown";
+	const version = parsed.version;
+	return typeof version === "string" && version.trim() ? version.trim() : "unknown";
+}
+const bundledPackageCacheIdentityByStockRoot = /* @__PURE__ */ new Map();
+function resolveBundledPackageCacheIdentity(stockRoot) {
+	if (!stockRoot) return;
+	const packageRoot = resolveBundledPackageRootForCache(stockRoot);
+	if (!packageRoot) return;
+	const stockRootKey = path.resolve(stockRoot);
+	const cached = bundledPackageCacheIdentityByStockRoot.get(stockRootKey);
+	if (cached) return cached;
+	const packageJsonPath = path.join(packageRoot, "package.json");
+	try {
+		const stat = fs.statSync(packageJsonPath);
+		const identity = {
+			packageJson: safeRealpathOrResolve(packageJsonPath),
+			packageRoot: safeRealpathOrResolve(packageRoot),
+			packageVersion: readPackageVersionForCache(packageJsonPath),
+			size: stat.size,
+			mtimeMs: stat.mtimeMs
+		};
+		bundledPackageCacheIdentityByStockRoot.set(stockRootKey, identity);
+		return identity;
+	} catch {
+		const identity = {
+			packageJson: path.resolve(packageJsonPath),
+			packageRoot: safeRealpathOrResolve(packageRoot),
+			packageVersion: "missing",
+			size: -1,
+			mtimeMs: -1
+		};
+		bundledPackageCacheIdentityByStockRoot.set(stockRootKey, identity);
+		return identity;
+	}
+}
+function buildCacheKey(params) {
+	const discoveryContext = resolvePluginDiscoveryContext({
+		workspaceDir: params.workspaceDir,
+		loadPaths: params.plugins.loadPaths,
+		env: params.env
+	});
+	const { roots, loadPaths } = discoveryContext;
+	const bundledPackage = resolveBundledPackageCacheIdentity(roots.stock);
+	const installs = Object.fromEntries(Object.entries(params.installs ?? {}).map(([pluginId, install]) => [pluginId, {
+		...install,
+		installPath: typeof install.installPath === "string" ? resolveUserPath(install.installPath, params.env) : install.installPath,
+		sourcePath: typeof install.sourcePath === "string" ? resolveUserPath(install.sourcePath, params.env) : install.sourcePath
+	}]));
+	const scopeKey = serializePluginIdScope(params.onlyPluginIds);
+	const setupOnlyKey = params.includeSetupOnlyChannelPlugins === true ? "setup-only" : "runtime";
+	const setupOnlyModeKey = params.forceSetupOnlyChannelPlugins === true ? "force-setup" : "normal-setup";
+	const setupOnlyRequirementKey = params.requireSetupEntryForSetupOnlyChannelPlugins === true ? "require-setup-entry" : "allow-full-fallback";
+	const startupChannelMode = params.preferSetupRuntimeForChannelPlugins === true ? "prefer-setup" : "full";
+	const bundledArtifactMode = params.preferBuiltPluginArtifacts === true ? "prefer-built-artifacts" : "source-default";
+	const moduleLoadMode = params.loadModules === false ? "manifest-only" : "load-modules";
+	const discoveryMode = params.toolDiscovery === true ? "tool-discovery" : "default-discovery";
+	const runtimeSubagentMode = params.runtimeSubagentMode ?? "default";
+	const gatewayMethodsKey = JSON.stringify(params.coreGatewayMethodNames ?? []);
+	const activationMode = params.activate === false ? "snapshot" : "active";
+	return `${roots.workspace ?? ""}::${roots.global ?? ""}::${roots.stock ?? ""}::${JSON.stringify({
+		bundledPackage,
+		discoveryFingerprint: fingerprintPluginDiscoveryContext(discoveryContext),
+		...params.plugins,
+		installs,
+		loadPaths,
+		activationMetadataKey: params.activationMetadataKey ?? ""
+	})}::${scopeKey}::${setupOnlyKey}::${setupOnlyModeKey}::${setupOnlyRequirementKey}::${startupChannelMode}::${bundledArtifactMode}::${moduleLoadMode}::${discoveryMode}::${runtimeSubagentMode}::${params.pluginSdkResolution ?? "auto"}::${gatewayMethodsKey}::${activationMode}`;
+}
+function matchesScopedPluginRequest(params) {
+	const scopedIds = params.onlyPluginIdSet;
+	if (!scopedIds) return true;
+	return scopedIds.has(params.pluginId);
+}
+function resolveRuntimeSubagentMode(runtimeOptions) {
+	if (runtimeOptions?.allowGatewaySubagentBinding === true) return "gateway-bindable";
+	if (runtimeOptions?.subagent) return "explicit";
+	return "default";
+}
+function buildActivationMetadataHash(params) {
+	const enabledSourceChannels = Object.entries(params.activationSource.rootConfig?.channels ?? {}).filter(([, value]) => {
+		if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+		return value.enabled === true;
+	}).map(([channelId]) => channelId).toSorted((left, right) => left.localeCompare(right));
+	const pluginEntryStates = Object.entries(params.activationSource.plugins.entries).map(([pluginId, entry]) => [pluginId, entry?.enabled ?? null]).toSorted(([left], [right]) => left.localeCompare(right));
+	const autoEnableReasonEntries = Object.entries(params.autoEnabledReasons).map(([pluginId, reasons]) => [pluginId, [...reasons]]).toSorted(([left], [right]) => left.localeCompare(right));
+	return createHash("sha256").update(JSON.stringify({
+		enabled: params.activationSource.plugins.enabled,
+		allow: params.activationSource.plugins.allow,
+		deny: params.activationSource.plugins.deny,
+		memorySlot: params.activationSource.plugins.slots.memory,
+		entries: pluginEntryStates,
+		enabledChannels: enabledSourceChannels,
+		autoEnabledReasons: autoEnableReasonEntries
+	})).digest("hex");
+}
+function hasExplicitCompatibilityInputs(options) {
+	return options.config !== void 0 || options.activationSourceConfig !== void 0 || options.autoEnabledReasons !== void 0 || options.workspaceDir !== void 0 || options.env !== void 0 || hasExplicitPluginIdScope(options.onlyPluginIds) || options.runtimeOptions !== void 0 || options.pluginSdkResolution !== void 0 || options.coreGatewayHandlers !== void 0 || options.includeSetupOnlyChannelPlugins === true || options.forceSetupOnlyChannelPlugins === true || options.requireSetupEntryForSetupOnlyChannelPlugins === true || options.preferSetupRuntimeForChannelPlugins === true || options.preferBuiltPluginArtifacts === true || options.loadModules === false;
+}
+function resolveCoreGatewayMethodNames(options) {
+	const names = new Set(options.coreGatewayMethodNames ?? []);
+	for (const name of Object.keys(options.coreGatewayHandlers ?? {})) names.add(name);
+	return Array.from(names).toSorted();
+}
+function pluginLoadOptionsMatchCacheKey(options, expectedCacheKey) {
+	return resolvePluginLoadCacheContext(options).cacheKey === expectedCacheKey;
+}
+function pluginToolDiscoveryOptionsMatchActiveCacheKey(options, expectedCacheKey) {
+	if (options.toolDiscovery !== true) return false;
+	const fullRuntimeOptions = {
+		...options,
+		toolDiscovery: void 0
+	};
+	if (pluginLoadOptionsMatchCacheKey(fullRuntimeOptions, expectedCacheKey)) return true;
+	if (options.activate !== false) return false;
+	return pluginLoadOptionsMatchCacheKey({
+		...fullRuntimeOptions,
+		activate: true
+	}, expectedCacheKey);
+}
+function registryContainsPluginScope(registry, onlyPluginIds) {
+	if (!onlyPluginIds || onlyPluginIds.length === 0) return false;
+	const loadedPluginIds = new Set(registry.plugins.map((plugin) => plugin.id));
+	return onlyPluginIds.every((pluginId) => loadedPluginIds.has(pluginId));
+}
+function scopedPluginLoadOptionsMatchWiderActiveCacheKey(options, expectedCacheKey, activeRegistry) {
+	const { onlyPluginIds } = resolvePluginLoadCacheContext(options);
+	if (!registryContainsPluginScope(activeRegistry, onlyPluginIds)) return false;
+	return pluginLoadOptionsMatchCacheKey({
+		...options,
+		onlyPluginIds: void 0
+	}, expectedCacheKey);
+}
+/**
+* Convert loader intent into explicit behavior flags.
+*
+* Registration modes are plugin-facing labels; this plan is the internal source
+* of truth for which entrypoint to load and which activation-only policies run.
+*/
+function resolvePluginRegistrationPlan(params) {
+	if (params.canLoadScopedSetupOnlyChannelPlugin) return {
+		mode: "setup-only",
+		loadSetupEntry: true,
+		loadSetupRuntimeEntry: false,
+		runRuntimeCapabilityPolicy: false,
+		runFullActivationOnlyRegistrations: false
+	};
+	if (params.scopedSetupOnlyChannelPluginRequested && params.requireSetupEntryForSetupOnlyChannelPlugins) return null;
+	if (!params.enableStateEnabled) return null;
+	if (params.toolDiscovery) return {
+		mode: "tool-discovery",
+		loadSetupEntry: false,
+		loadSetupRuntimeEntry: false,
+		runRuntimeCapabilityPolicy: true,
+		runFullActivationOnlyRegistrations: false
+	};
+	if (params.shouldLoadModules && !params.validateOnly && shouldLoadChannelPluginInSetupRuntime({
+		manifestChannels: params.manifestRecord.channels,
+		setupSource: params.manifestRecord.setupSource,
+		startupDeferConfiguredChannelFullLoadUntilAfterListen: params.manifestRecord.startupDeferConfiguredChannelFullLoadUntilAfterListen,
+		cfg: params.cfg,
+		env: params.env,
+		preferSetupRuntimeForChannelPlugins: params.preferSetupRuntimeForChannelPlugins
+	})) return {
+		mode: "setup-runtime",
+		loadSetupEntry: true,
+		loadSetupRuntimeEntry: true,
+		runRuntimeCapabilityPolicy: false,
+		runFullActivationOnlyRegistrations: false
+	};
+	const mode = params.shouldActivate ? "full" : "discovery";
+	return {
+		mode,
+		loadSetupEntry: false,
+		loadSetupRuntimeEntry: false,
+		runRuntimeCapabilityPolicy: true,
+		runFullActivationOnlyRegistrations: mode === "full"
+	};
+}
+function applyManifestSnapshotMetadata(record, manifestRecord) {
+	record.channelIds = [...manifestRecord.channels ?? []];
+	record.providerIds = [...manifestRecord.providers ?? []];
+	record.cliBackendIds = [...manifestRecord.cliBackends ?? [], ...manifestRecord.setup?.cliBackends ?? []];
+	record.commands = (manifestRecord.commandAliases ?? []).map((alias) => alias.name);
+}
+function resolvePluginLoadCacheContext(options = {}) {
+	const env = options.env ?? process.env;
+	const cfg = applyTestPluginDefaults(options.config ?? {}, env);
+	const activationSourceConfig = resolvePluginActivationSourceConfig({
+		config: options.config,
+		activationSourceConfig: options.activationSourceConfig
+	});
+	const normalized = normalizePluginsConfig(cfg.plugins);
+	const activationSource = createPluginActivationSource({ config: activationSourceConfig });
+	const trustNormalized = mergeTrustPluginConfigFromActivationSource({
+		normalized,
+		activationSource
+	});
+	const onlyPluginIds = normalizePluginIdScope(options.onlyPluginIds);
+	const includeSetupOnlyChannelPlugins = options.includeSetupOnlyChannelPlugins === true;
+	const forceSetupOnlyChannelPlugins = options.forceSetupOnlyChannelPlugins === true;
+	const requireSetupEntryForSetupOnlyChannelPlugins = options.requireSetupEntryForSetupOnlyChannelPlugins === true;
+	const preferSetupRuntimeForChannelPlugins = options.preferSetupRuntimeForChannelPlugins === true;
+	const preferBuiltPluginArtifacts = options.preferBuiltPluginArtifacts === true;
+	const runtimeSubagentMode = resolveRuntimeSubagentMode(options.runtimeOptions);
+	const coreGatewayMethodNames = resolveCoreGatewayMethodNames(options);
+	const installRecords = {
+		...loadInstalledPluginIndexInstallRecordsSync({ env }),
+		...cfg.plugins?.installs
+	};
+	const cacheKey = buildCacheKey({
+		workspaceDir: options.workspaceDir,
+		plugins: trustNormalized,
+		activationMetadataKey: buildActivationMetadataHash({
+			activationSource,
+			autoEnabledReasons: options.autoEnabledReasons ?? {}
+		}),
+		installs: installRecords,
+		env,
+		onlyPluginIds,
+		includeSetupOnlyChannelPlugins,
+		forceSetupOnlyChannelPlugins,
+		requireSetupEntryForSetupOnlyChannelPlugins,
+		preferSetupRuntimeForChannelPlugins,
+		preferBuiltPluginArtifacts,
+		toolDiscovery: options.toolDiscovery,
+		loadModules: options.loadModules,
+		runtimeSubagentMode,
+		pluginSdkResolution: options.pluginSdkResolution,
+		...coreGatewayMethodNames !== void 0 && { coreGatewayMethodNames },
+		activate: options.activate
+	});
+	return {
+		env,
+		cfg,
+		normalized: trustNormalized,
+		activationSourceConfig,
+		activationSource,
+		autoEnabledReasons: options.autoEnabledReasons ?? {},
+		onlyPluginIds,
+		includeSetupOnlyChannelPlugins,
+		forceSetupOnlyChannelPlugins,
+		requireSetupEntryForSetupOnlyChannelPlugins,
+		preferSetupRuntimeForChannelPlugins,
+		preferBuiltPluginArtifacts,
+		shouldActivate: options.activate !== false,
+		shouldLoadModules: options.loadModules !== false,
+		runtimeSubagentMode,
+		installRecords,
+		cacheKey
+	};
+}
+function mergeTrustPluginConfigFromActivationSource(params) {
+	const source = params.activationSource.plugins;
+	const allow = mergePluginTrustList(params.normalized.allow, source.allow);
+	const deny = mergePluginTrustList(params.normalized.deny, source.deny);
+	const loadPaths = mergePluginTrustList(params.normalized.loadPaths, source.loadPaths);
+	if (allow === params.normalized.allow && deny === params.normalized.deny && loadPaths === params.normalized.loadPaths) return params.normalized;
+	return {
+		...params.normalized,
+		allow,
+		deny,
+		loadPaths
+	};
+}
+function mergePluginTrustList(runtimeList, sourceList) {
+	if (sourceList.length === 0) return runtimeList;
+	const merged = [...runtimeList];
+	const seen = new Set(merged);
+	for (const entry of sourceList) if (!seen.has(entry)) {
+		merged.push(entry);
+		seen.add(entry);
+	}
+	return merged.length === runtimeList.length ? runtimeList : merged;
+}
+function getCompatibleActivePluginRegistry(options = {}) {
+	const activeRegistry = getActivePluginRegistry() ?? void 0;
+	if (!activeRegistry) return;
+	if (!hasExplicitCompatibilityInputs(options)) return activeRegistry;
+	const activeCacheKey = getActivePluginRegistryKey();
+	if (!activeCacheKey) return;
+	const loadContext = resolvePluginLoadCacheContext(options);
+	const matchesActiveCacheKey = (candidate) => {
+		if (pluginLoadOptionsMatchCacheKey(candidate, activeCacheKey)) return true;
+		if (candidate.coreGatewayMethodNames !== void 0) return false;
+		return pluginLoadOptionsMatchCacheKey({
+			...candidate,
+			coreGatewayMethodNames: activeRegistry.coreGatewayMethodNames ?? []
+		}, activeCacheKey);
+	};
+	if (matchesActiveCacheKey(options)) return activeRegistry;
+	if (scopedPluginLoadOptionsMatchWiderActiveCacheKey(options, activeCacheKey, activeRegistry)) return activeRegistry;
+	if (!loadContext.shouldActivate) {
+		const activatingOptions = {
+			...options,
+			activate: true
+		};
+		if (matchesActiveCacheKey(activatingOptions)) return activeRegistry;
+		if (scopedPluginLoadOptionsMatchWiderActiveCacheKey(activatingOptions, activeCacheKey, activeRegistry)) return activeRegistry;
+	}
+	if (pluginToolDiscoveryOptionsMatchActiveCacheKey(options, activeCacheKey)) return activeRegistry;
+	if (loadContext.runtimeSubagentMode === "default" && getActivePluginRuntimeSubagentMode() === "gateway-bindable") {
+		const gatewayBindableOptions = {
+			...options,
+			runtimeOptions: {
+				...options.runtimeOptions,
+				allowGatewaySubagentBinding: true
+			}
+		};
+		if (matchesActiveCacheKey(gatewayBindableOptions)) return activeRegistry;
+		if (scopedPluginLoadOptionsMatchWiderActiveCacheKey(gatewayBindableOptions, activeCacheKey, activeRegistry)) return activeRegistry;
+		if (pluginToolDiscoveryOptionsMatchActiveCacheKey(gatewayBindableOptions, activeCacheKey)) return activeRegistry;
+		if (!loadContext.shouldActivate) {
+			const activatingGatewayBindableOptions = {
+				...options,
+				activate: true,
+				runtimeOptions: {
+					...options.runtimeOptions,
+					allowGatewaySubagentBinding: true
+				}
+			};
+			if (matchesActiveCacheKey(activatingGatewayBindableOptions)) return activeRegistry;
+			if (scopedPluginLoadOptionsMatchWiderActiveCacheKey(activatingGatewayBindableOptions, activeCacheKey, activeRegistry)) return activeRegistry;
+		}
+	}
+}
+function resolveRuntimePluginRegistry(options) {
+	if (!options || !hasExplicitCompatibilityInputs(options)) return getCompatibleActivePluginRegistry();
+	const compatible = getCompatibleActivePluginRegistry(options);
+	if (compatible) return compatible;
+	if (isPluginRegistryLoadInFlight(options)) return;
+	return loadOpenClawPlugins(options);
+}
+function getRuntimePluginRegistryForLoadOptions(options) {
+	return resolveRuntimePluginRegistry(options);
+}
+function resolvePluginRegistryLoadCacheKey(options = {}) {
+	return resolvePluginLoadCacheContext(options).cacheKey;
+}
+function isPluginRegistryLoadInFlight(options = {}) {
+	return pluginLoaderCacheState.isLoadInFlight(resolvePluginRegistryLoadCacheKey(options));
+}
+function resolveCompatibleRuntimePluginRegistry(options) {
+	return getCompatibleActivePluginRegistry(options);
+}
+function validatePluginConfig(params) {
+	const schema = params.schema;
+	if (!schema) return {
+		ok: true,
+		value: params.value
+	};
+	if (isEmptyPluginConfigJsonSchema(schema)) {
+		if (params.value === void 0 || params.value && typeof params.value === "object" && !Array.isArray(params.value) && Object.keys(params.value).length === 0) return {
+			ok: true,
+			value: {}
+		};
+		if (!params.value || typeof params.value !== "object" || Array.isArray(params.value)) return {
+			ok: false,
+			errors: ["<root>: must be object"]
+		};
+		return {
+			ok: false,
+			errors: ["<root>: config must be empty"]
+		};
+	}
+	const result = validateJsonSchemaValue({
+		schema,
+		cacheKey: params.cacheKey ?? JSON.stringify(schema),
+		value: params.value ?? {},
+		applyDefaults: true
+	});
+	if (result.ok) return {
+		ok: true,
+		value: result.value
+	};
+	return {
+		ok: false,
+		errors: result.errors.map((error) => error.text)
+	};
+}
+function isEmptyPluginConfigJsonSchema(schema) {
+	if (schema.type !== "object" || schema.additionalProperties !== false) return false;
+	const properties = schema.properties;
+	if (!properties || typeof properties !== "object" || Array.isArray(properties) || Object.keys(properties).length > 0) return false;
+	return !("required" in schema || "dependentRequired" in schema || "dependencies" in schema || "minProperties" in schema || "allOf" in schema || "anyOf" in schema || "oneOf" in schema || "not" in schema);
+}
+function resolvePluginModuleExport(moduleExport) {
+	const seen = /* @__PURE__ */ new Set();
+	const candidates = [unwrapDefaultModuleExport(moduleExport), moduleExport];
+	for (let index = 0; index < candidates.length && index < 12; index += 1) {
+		const resolved = candidates[index];
+		if (seen.has(resolved)) continue;
+		seen.add(resolved);
+		if (typeof resolved === "function") return { register: resolved };
+		if (resolved && typeof resolved === "object") {
+			const def = resolved;
+			const register = def.register ?? def.activate;
+			if (typeof register === "function") return {
+				definition: def,
+				register
+			};
+			for (const key of ["default", "module"]) if (key in def) candidates.push(def[key]);
+		}
+	}
+	const resolved = candidates[0];
+	if (typeof resolved === "function") return { register: resolved };
+	if (resolved && typeof resolved === "object") {
+		const def = resolved;
+		return {
+			definition: def,
+			register: def.register ?? def.activate
+		};
+	}
+	return {};
+}
+function pushDiagnostics(diagnostics, append) {
+	diagnostics.push(...append);
+}
+function maybeThrowOnPluginLoadError(registry, throwOnLoadError) {
+	if (!throwOnLoadError) return;
+	if (!registry.plugins.some((entry) => entry.status === "error")) return;
+	throw new PluginLoadFailureError(registry);
+}
+function activatePluginRegistry(registry, cacheKey, runtimeSubagentMode, workspaceDir) {
+	const preserveGatewayHookRunner = runtimeSubagentMode === "default" && getActivePluginRuntimeSubagentMode() === "gateway-bindable" && getGlobalHookRunner() !== null;
+	setActivePluginRegistry(registry, cacheKey, runtimeSubagentMode, workspaceDir);
+	if (!preserveGatewayHookRunner) initializeGlobalHookRunner(registry);
+}
+function loadOpenClawPlugins(options = {}) {
+	const requestedOnlyPluginIdSet = createPluginIdScopeSet(normalizePluginIdScope(options.onlyPluginIds));
+	if (requestedOnlyPluginIdSet && requestedOnlyPluginIdSet.size === 0) {
+		const emptyRegistry = createEmptyPluginRegistry();
+		if (options.activate !== false) {
+			clearActivatedPluginRuntimeState();
+			activatePluginRegistry(emptyRegistry, `empty-plugin-scope::${resolveRuntimeSubagentMode(options.runtimeOptions)}::${options.workspaceDir ?? ""}`, resolveRuntimeSubagentMode(options.runtimeOptions), options.workspaceDir);
+		}
+		return emptyRegistry;
+	}
+	const { env, cfg, normalized, activationSource, autoEnabledReasons, onlyPluginIds, includeSetupOnlyChannelPlugins, forceSetupOnlyChannelPlugins, requireSetupEntryForSetupOnlyChannelPlugins, preferSetupRuntimeForChannelPlugins, preferBuiltPluginArtifacts, shouldActivate, shouldLoadModules, cacheKey, runtimeSubagentMode, installRecords } = resolvePluginLoadCacheContext(options);
+	const logger = options.logger ?? defaultLogger();
+	const validateOnly = options.mode === "validate";
+	const onlyPluginIdSet = createPluginIdScopeSet(onlyPluginIds);
+	const cacheEnabled = options.cache !== false;
+	if (cacheEnabled) {
+		const cached = getReusableCachedPluginRegistry({
+			cacheKey,
+			onlyPluginIds,
+			runtimeSubagentMode,
+			options
+		});
+		if (cached) {
+			if (shouldActivate) {
+				restoreRegisteredAgentHarnesses(cached.state.agentHarnesses);
+				restorePluginCommands(cached.state.commands ?? []);
+				restoreRegisteredCompactionProviders(cached.state.compactionProviders);
+				restoreDetachedTaskLifecycleRuntimeRegistration(cached.state.detachedTaskRuntimeRegistration);
+				restorePluginInteractiveHandlers(cached.state.interactiveHandlers ?? []);
+				restoreRegisteredMemoryEmbeddingProviders(cached.state.memoryEmbeddingProviders);
+				restoreMemoryPluginState({
+					capability: cached.state.memoryCapability,
+					corpusSupplements: cached.state.memoryCorpusSupplements,
+					promptSupplements: cached.state.memoryPromptSupplements
+				});
+				activatePluginRegistry(cached.state.registry, cached.cacheKey, cached.runtimeSubagentMode, options.workspaceDir);
+			}
+			return cached.state.registry;
+		}
+	}
+	pluginLoaderCacheState.beginLoad(cacheKey);
+	try {
+		if (shouldActivate) clearActivatedPluginRuntimeState();
+		const loadPluginModule = createPluginModuleLoader(options);
+		let createPluginRuntimeFactory = null;
+		const resolveCreatePluginRuntime = () => {
+			if (createPluginRuntimeFactory) return createPluginRuntimeFactory;
+			const runtimeModulePath = resolvePluginRuntimeModulePath({ pluginSdkResolution: options.pluginSdkResolution });
+			if (!runtimeModulePath) throw new Error("Unable to resolve plugin runtime module");
+			const runtimeModule = withProfile({ source: runtimeModulePath }, "runtime-module", () => loadPluginModule(runtimeModulePath));
+			if (typeof runtimeModule.createPluginRuntime !== "function") throw new Error("Plugin runtime module missing createPluginRuntime export");
+			createPluginRuntimeFactory = runtimeModule.createPluginRuntime;
+			return createPluginRuntimeFactory;
+		};
+		let resolvedRuntime = null;
+		const resolveRuntime = () => {
+			resolvedRuntime ??= resolveCreatePluginRuntime()(options.runtimeOptions);
+			return resolvedRuntime;
+		};
+		const lazyRuntimeReflectionKeySet = new Set(LAZY_RUNTIME_REFLECTION_KEYS);
+		const resolveLazyRuntimeDescriptor = (prop) => {
+			if (!lazyRuntimeReflectionKeySet.has(prop)) return Reflect.getOwnPropertyDescriptor(resolveRuntime(), prop);
+			return {
+				configurable: true,
+				enumerable: true,
+				get() {
+					return Reflect.get(resolveRuntime(), prop);
+				},
+				set(value) {
+					Reflect.set(resolveRuntime(), prop, value);
+				}
+			};
+		};
+		const { registry, createApi, rollbackPluginGlobalSideEffects, registerReload, registerNodeHostCommand, registerSecurityAuditCollector } = createPluginRegistry({
+			logger,
+			runtime: new Proxy({}, {
+				get(_target, prop, receiver) {
+					return Reflect.get(resolveRuntime(), prop, receiver);
+				},
+				set(_target, prop, value, receiver) {
+					return Reflect.set(resolveRuntime(), prop, value, receiver);
+				},
+				has(_target, prop) {
+					return lazyRuntimeReflectionKeySet.has(prop) || Reflect.has(resolveRuntime(), prop);
+				},
+				ownKeys() {
+					return [...LAZY_RUNTIME_REFLECTION_KEYS];
+				},
+				getOwnPropertyDescriptor(_target, prop) {
+					return resolveLazyRuntimeDescriptor(prop);
+				},
+				defineProperty(_target, prop, attributes) {
+					return Reflect.defineProperty(resolveRuntime(), prop, attributes);
+				},
+				deleteProperty(_target, prop) {
+					return Reflect.deleteProperty(resolveRuntime(), prop);
+				},
+				getPrototypeOf() {
+					return Reflect.getPrototypeOf(resolveRuntime());
+				}
+			}),
+			coreGatewayHandlers: options.coreGatewayHandlers,
+			...options.coreGatewayMethodNames !== void 0 && { coreGatewayMethodNames: options.coreGatewayMethodNames },
+			...options.hostServices !== void 0 && { hostServices: options.hostServices },
+			activateGlobalSideEffects: shouldActivate
+		});
+		const suppliedManifestRegistry = options.manifestRegistry;
+		const discovery = suppliedManifestRegistry ? {
+			candidates: createPluginCandidatesFromManifestRegistry(suppliedManifestRegistry),
+			diagnostics: []
+		} : discoverOpenClawPlugins({
+			workspaceDir: options.workspaceDir,
+			extraPaths: normalized.loadPaths,
+			env,
+			installRecords
+		});
+		const manifestRegistry = suppliedManifestRegistry ?? loadPluginManifestRegistry({
+			config: cfg,
+			workspaceDir: options.workspaceDir,
+			env,
+			candidates: discovery.candidates,
+			diagnostics: discovery.diagnostics,
+			installRecords: Object.keys(installRecords).length > 0 ? installRecords : void 0
+		});
+		pushDiagnostics(registry.diagnostics, manifestRegistry.diagnostics);
+		warnWhenAllowlistIsOpen({
+			emitWarning: shouldActivate,
+			logger,
+			pluginsEnabled: normalized.enabled,
+			allow: normalized.allow,
+			warningCacheKey: cacheKey,
+			warningCache: pluginLoaderCacheState,
+			discoverablePlugins: manifestRegistry.plugins.filter((plugin) => !onlyPluginIdSet || onlyPluginIdSet.has(plugin.id)).map((plugin) => ({
+				id: plugin.id,
+				source: plugin.source,
+				origin: plugin.origin
+			}))
+		});
+		const provenance = buildProvenanceIndex({
+			normalizedLoadPaths: normalized.loadPaths,
+			env
+		});
+		const manifestByRoot = new Map(manifestRegistry.plugins.map((record) => [record.rootDir, record]));
+		const orderedCandidates = [...discovery.candidates].toSorted((left, right) => {
+			return compareDuplicateCandidateOrder({
+				left,
+				right,
+				manifestByRoot,
+				provenance,
+				env
+			});
+		});
+		const seenIds = /* @__PURE__ */ new Map();
+		const memorySlot = normalized.slots.memory;
+		let selectedMemoryPluginId = null;
+		let memorySlotMatched = false;
+		const dreamingEngineId = resolveDreamingSidecarEngineId({
+			cfg,
+			memorySlot
+		});
+		const pluginLoadStartMs = performance.now();
+		let pluginLoadAttemptCount = 0;
+		for (const candidate of orderedCandidates) {
+			const manifestRecord = manifestByRoot.get(candidate.rootDir);
+			if (!manifestRecord) continue;
+			const pluginId = manifestRecord.id;
+			if (!matchesScopedPluginRequest({
+				onlyPluginIdSet,
+				pluginId
+			})) continue;
+			const activationState = resolveEffectivePluginActivationState({
+				id: pluginId,
+				origin: candidate.origin,
+				config: normalized,
+				rootConfig: cfg,
+				enabledByDefault: isPluginEnabledByDefaultForPlatform(manifestRecord),
+				activationSource,
+				autoEnabledReason: formatAutoEnabledActivationReason(autoEnabledReasons[pluginId])
+			});
+			const existingOrigin = seenIds.get(pluginId);
+			if (existingOrigin) {
+				const record = createPluginRecord({
+					id: pluginId,
+					name: manifestRecord.name ?? pluginId,
+					description: manifestRecord.description,
+					version: manifestRecord.version,
+					packageName: manifestRecord.packageName,
+					format: manifestRecord.format,
+					bundleFormat: manifestRecord.bundleFormat,
+					bundleCapabilities: manifestRecord.bundleCapabilities,
+					source: candidate.source,
+					rootDir: candidate.rootDir,
+					origin: candidate.origin,
+					workspaceDir: candidate.workspaceDir,
+					trustedOfficialInstall: manifestRecord.trustedOfficialInstall,
+					enabled: false,
+					compat: collectPluginManifestCompatCodes(manifestRecord),
+					activationState,
+					syntheticAuthRefs: manifestRecord.syntheticAuthRefs,
+					channelIds: manifestRecord.channels,
+					providerIds: manifestRecord.providers,
+					configSchema: Boolean(manifestRecord.configSchema),
+					contracts: manifestRecord.contracts
+				});
+				record.status = "disabled";
+				record.error = `overridden by ${existingOrigin} plugin`;
+				markPluginActivationDisabled(record, record.error);
+				registry.plugins.push(record);
+				continue;
+			}
+			const enableState = resolveEffectiveEnableState({
+				id: pluginId,
+				origin: candidate.origin,
+				config: normalized,
+				rootConfig: cfg,
+				enabledByDefault: isPluginEnabledByDefaultForPlatform(manifestRecord),
+				activationSource
+			});
+			const entry = normalized.entries[pluginId];
+			const record = createPluginRecord({
+				id: pluginId,
+				name: manifestRecord.name ?? pluginId,
+				description: manifestRecord.description,
+				version: manifestRecord.version,
+				packageName: manifestRecord.packageName,
+				format: manifestRecord.format,
+				bundleFormat: manifestRecord.bundleFormat,
+				bundleCapabilities: manifestRecord.bundleCapabilities,
+				source: candidate.source,
+				rootDir: candidate.rootDir,
+				origin: candidate.origin,
+				workspaceDir: candidate.workspaceDir,
+				trustedOfficialInstall: manifestRecord.trustedOfficialInstall,
+				enabled: enableState.enabled,
+				compat: collectPluginManifestCompatCodes(manifestRecord),
+				activationState,
+				syntheticAuthRefs: manifestRecord.syntheticAuthRefs,
+				channelIds: manifestRecord.channels,
+				providerIds: manifestRecord.providers,
+				configSchema: Boolean(manifestRecord.configSchema),
+				contracts: manifestRecord.contracts
+			});
+			record.kind = manifestRecord.kind;
+			record.configUiHints = manifestRecord.configUiHints;
+			record.configJsonSchema = manifestRecord.configSchema;
+			const pushPluginLoadError = (message) => {
+				record.status = "error";
+				record.error = message;
+				record.failedAt = /* @__PURE__ */ new Date();
+				record.failurePhase = "validation";
+				registry.plugins.push(record);
+				seenIds.set(pluginId, candidate.origin);
+				registry.diagnostics.push({
+					level: "error",
+					pluginId: record.id,
+					source: record.source,
+					message: record.error
+				});
+			};
+			const pluginRoot = safeRealpathOrResolve(candidate.rootDir);
+			const runtimeCandidateEntry = resolvePreferredBuiltBundledRuntimeArtifact({
+				source: candidate.source,
+				rootDir: pluginRoot,
+				origin: candidate.origin,
+				preferBuiltPluginArtifacts
+			});
+			const runtimeSetupEntry = manifestRecord.setupSource ? resolvePreferredBuiltBundledRuntimeArtifact({
+				source: manifestRecord.setupSource,
+				rootDir: pluginRoot,
+				origin: candidate.origin,
+				preferBuiltPluginArtifacts
+			}) : void 0;
+			const scopedSetupOnlyChannelPluginRequested = includeSetupOnlyChannelPlugins && !validateOnly && Boolean(onlyPluginIdSet) && manifestRecord.channels.length > 0 && (!enableState.enabled || forceSetupOnlyChannelPlugins);
+			const registrationPlan = resolvePluginRegistrationPlan({
+				canLoadScopedSetupOnlyChannelPlugin: scopedSetupOnlyChannelPluginRequested && (!requireSetupEntryForSetupOnlyChannelPlugins || Boolean(manifestRecord.setupSource)),
+				scopedSetupOnlyChannelPluginRequested,
+				requireSetupEntryForSetupOnlyChannelPlugins,
+				enableStateEnabled: enableState.enabled,
+				shouldLoadModules,
+				validateOnly,
+				shouldActivate,
+				manifestRecord,
+				cfg,
+				env,
+				preferSetupRuntimeForChannelPlugins,
+				toolDiscovery: options.toolDiscovery === true
+			});
+			if (!registrationPlan) {
+				record.status = "disabled";
+				record.error = enableState.reason;
+				markPluginActivationDisabled(record, enableState.reason);
+				registry.plugins.push(record);
+				seenIds.set(pluginId, candidate.origin);
+				continue;
+			}
+			const registrationMode = registrationPlan.mode;
+			if (!enableState.enabled) {
+				record.status = "disabled";
+				record.error = enableState.reason;
+				markPluginActivationDisabled(record, enableState.reason);
+			}
+			if (record.format === "bundle") {
+				const unsupportedCapabilities = (record.bundleCapabilities ?? []).filter((capability) => capability !== "skills" && capability !== "mcpServers" && capability !== "settings" && !((capability === "commands" || capability === "agents" || capability === "outputStyles" || capability === "lspServers") && (record.bundleFormat === "claude" || record.bundleFormat === "cursor")) && !(capability === "hooks" && (record.bundleFormat === "codex" || record.bundleFormat === "claude")));
+				for (const capability of unsupportedCapabilities) registry.diagnostics.push({
+					level: "warn",
+					pluginId: record.id,
+					source: record.source,
+					message: `bundle capability detected but not wired into OpenClaw yet: ${capability}`
+				});
+				if (enableState.enabled && record.rootDir && record.bundleFormat && (record.bundleCapabilities ?? []).includes("mcpServers")) {
+					const runtimeSupport = inspectBundleMcpRuntimeSupport({
+						pluginId: record.id,
+						rootDir: record.rootDir,
+						bundleFormat: record.bundleFormat
+					});
+					for (const message of runtimeSupport.diagnostics) registry.diagnostics.push({
+						level: "warn",
+						pluginId: record.id,
+						source: record.source,
+						message
+					});
+					if (runtimeSupport.unsupportedServerNames.length > 0) registry.diagnostics.push({
+						level: "warn",
+						pluginId: record.id,
+						source: record.source,
+						message: `bundle MCP servers use unsupported transports or incomplete configs (stdio only today): ${runtimeSupport.unsupportedServerNames.join(", ")}`
+					});
+				}
+				registry.plugins.push(record);
+				seenIds.set(pluginId, candidate.origin);
+				continue;
+			}
+			if (registrationPlan.runRuntimeCapabilityPolicy && candidate.origin === "bundled" && hasKind(manifestRecord.kind, "memory")) {
+				if (pluginId !== dreamingEngineId) {
+					const earlyMemoryDecision = resolveMemorySlotDecision({
+						id: record.id,
+						kind: manifestRecord.kind,
+						slot: memorySlot,
+						selectedId: selectedMemoryPluginId
+					});
+					if (!earlyMemoryDecision.enabled) {
+						record.enabled = false;
+						record.status = "disabled";
+						record.error = earlyMemoryDecision.reason;
+						markPluginActivationDisabled(record, earlyMemoryDecision.reason);
+						registry.plugins.push(record);
+						seenIds.set(pluginId, candidate.origin);
+						continue;
+					}
+				}
+			}
+			if (!manifestRecord.configSchema) {
+				pushPluginLoadError("missing config schema");
+				continue;
+			}
+			if (!shouldLoadModules && registrationPlan.runRuntimeCapabilityPolicy) {
+				const memoryDecision = resolveMemorySlotDecision({
+					id: record.id,
+					kind: record.kind,
+					slot: memorySlot,
+					selectedId: selectedMemoryPluginId
+				});
+				if (!memoryDecision.enabled && pluginId !== dreamingEngineId) {
+					record.enabled = false;
+					record.status = "disabled";
+					record.error = memoryDecision.reason;
+					markPluginActivationDisabled(record, memoryDecision.reason);
+					registry.plugins.push(record);
+					seenIds.set(pluginId, candidate.origin);
+					continue;
+				}
+				if (memoryDecision.selected && hasKind(record.kind, "memory")) {
+					selectedMemoryPluginId = record.id;
+					memorySlotMatched = true;
+					record.memorySlotSelected = true;
+				}
+			}
+			const validatedConfig = validatePluginConfig({
+				schema: manifestRecord.configSchema,
+				cacheKey: manifestRecord.schemaCacheKey,
+				value: entry?.config
+			});
+			if (!validatedConfig.ok) {
+				logger.error(`[plugins] ${record.id} invalid config: ${validatedConfig.errors?.join(", ")}`);
+				pushPluginLoadError(`invalid config: ${validatedConfig.errors?.join(", ")}`);
+				continue;
+			}
+			if (!shouldLoadModules) {
+				applyManifestSnapshotMetadata(record, manifestRecord);
+				registry.plugins.push(record);
+				seenIds.set(pluginId, candidate.origin);
+				continue;
+			}
+			const loadEntry = registrationPlan.loadSetupEntry && runtimeSetupEntry ? runtimeSetupEntry : runtimeCandidateEntry;
+			const moduleLoadSource = resolveCanonicalDistRuntimeSource(loadEntry.source);
+			const moduleRoot = resolveCanonicalDistRuntimeSource(loadEntry.rootDir);
+			const rejectHardlinks = shouldRejectHardlinkedPluginFiles({
+				origin: candidate.origin,
+				rootDir: candidate.rootDir,
+				env
+			});
+			const opened = openRootFileSync({
+				absolutePath: moduleLoadSource,
+				rootPath: moduleRoot,
+				boundaryLabel: "plugin root",
+				rejectHardlinks,
+				skipLexicalRootCheck: true
+			});
+			if (!opened.ok) {
+				pushPluginLoadError("plugin entry path escapes plugin root or fails alias checks");
+				continue;
+			}
+			const safeSource = opened.path;
+			fs.closeSync(opened.fd);
+			let mod = null;
+			try {
+				recordImportedPluginId(record.id);
+				pluginLoadAttemptCount++;
+				logger.debug?.(`[plugins] loading ${record.id} from ${safeSource}`);
+				mod = withProfile({
+					pluginId: record.id,
+					source: safeSource
+				}, registrationMode, () => loadPluginModule(safeSource));
+			} catch (err) {
+				recordPluginError({
+					logger,
+					registry,
+					record,
+					seenIds,
+					pluginId,
+					origin: candidate.origin,
+					phase: "load",
+					error: err,
+					logPrefix: `[plugins] ${record.id} failed to load from ${record.source}: `,
+					diagnosticMessagePrefix: "failed to load plugin: "
+				});
+				continue;
+			}
+			if (registrationPlan.loadSetupEntry && manifestRecord.setupSource) {
+				const setupRegistration = resolveSetupChannelRegistration(mod);
+				if (setupRegistration.loadError) {
+					recordPluginError({
+						logger,
+						registry,
+						record,
+						seenIds,
+						pluginId,
+						origin: candidate.origin,
+						phase: "load",
+						error: setupRegistration.loadError,
+						logPrefix: `[plugins] ${record.id} failed to load setup entry from ${record.source}: `,
+						diagnosticMessagePrefix: "failed to load setup entry: "
+					});
+					continue;
+				}
+				if (setupRegistration.plugin) {
+					if (!channelPluginIdBelongsToManifest({
+						channelId: setupRegistration.plugin.id,
+						pluginId: record.id,
+						manifestChannels: manifestRecord.channels
+					})) {
+						pushPluginLoadError(`plugin id mismatch (config uses "${record.id}", setup export uses "${setupRegistration.plugin.id}")`);
+						continue;
+					}
+					const api = createApi(record, {
+						config: cfg,
+						pluginConfig: {},
+						hookPolicy: entry?.hooks,
+						registrationMode
+					});
+					let mergedSetupRegistration = setupRegistration;
+					let runtimeSetterApplied = false;
+					if (registrationPlan.loadSetupRuntimeEntry && setupRegistration.usesBundledSetupContract && resolveCanonicalDistRuntimeSource(runtimeCandidateEntry.source) !== safeSource) {
+						const runtimeOpened = openRootFileSync({
+							absolutePath: resolveCanonicalDistRuntimeSource(runtimeCandidateEntry.source),
+							rootPath: resolveCanonicalDistRuntimeSource(runtimeCandidateEntry.rootDir),
+							boundaryLabel: "plugin root",
+							rejectHardlinks,
+							skipLexicalRootCheck: true
+						});
+						if (!runtimeOpened.ok) {
+							pushPluginLoadError("plugin entry path escapes plugin root or fails alias checks");
+							continue;
+						}
+						const safeRuntimeSource = runtimeOpened.path;
+						fs.closeSync(runtimeOpened.fd);
+						let runtimeMod = null;
+						try {
+							runtimeMod = withProfile({
+								pluginId: record.id,
+								source: safeRuntimeSource
+							}, "load-setup-runtime-entry", () => loadPluginModule(safeRuntimeSource));
+						} catch (err) {
+							recordPluginError({
+								logger,
+								registry,
+								record,
+								seenIds,
+								pluginId,
+								origin: candidate.origin,
+								phase: "load",
+								error: err,
+								logPrefix: `[plugins] ${record.id} failed to load setup-runtime entry from ${record.source}: `,
+								diagnosticMessagePrefix: "failed to load setup-runtime entry: "
+							});
+							continue;
+						}
+						const runtimeRegistration = resolveBundledRuntimeChannelRegistration(runtimeMod);
+						if (runtimeRegistration.id && runtimeRegistration.id !== record.id) {
+							pushPluginLoadError(`plugin id mismatch (config uses "${record.id}", runtime entry uses "${runtimeRegistration.id}")`);
+							continue;
+						}
+						if (runtimeRegistration.setChannelRuntime) try {
+							runtimeRegistration.setChannelRuntime(api.runtime);
+							runtimeSetterApplied = true;
+						} catch (err) {
+							recordPluginError({
+								logger,
+								registry,
+								record,
+								seenIds,
+								pluginId,
+								origin: candidate.origin,
+								phase: "load",
+								error: err,
+								logPrefix: `[plugins] ${record.id} failed to apply setup-runtime channel runtime from ${record.source}: `,
+								diagnosticMessagePrefix: "failed to apply setup-runtime channel runtime: "
+							});
+							continue;
+						}
+						const runtimePluginRegistration = loadBundledRuntimeChannelPlugin({ registration: runtimeRegistration });
+						if (runtimePluginRegistration.loadError) {
+							recordPluginError({
+								logger,
+								registry,
+								record,
+								seenIds,
+								pluginId,
+								origin: candidate.origin,
+								phase: "load",
+								error: runtimePluginRegistration.loadError,
+								logPrefix: `[plugins] ${record.id} failed to load setup-runtime channel entry from ${record.source}: `,
+								diagnosticMessagePrefix: "failed to load setup-runtime channel entry: "
+							});
+							continue;
+						}
+						if (runtimePluginRegistration.plugin) {
+							if (runtimePluginRegistration.plugin.id && runtimePluginRegistration.plugin.id !== record.id) {
+								pushPluginLoadError(`plugin id mismatch (config uses "${record.id}", runtime export uses "${runtimePluginRegistration.plugin.id}")`);
+								continue;
+							}
+							mergedSetupRegistration = {
+								...setupRegistration,
+								plugin: mergeSetupRuntimeChannelPlugin(runtimePluginRegistration.plugin, setupRegistration.plugin),
+								setChannelRuntime: runtimeRegistration.setChannelRuntime ?? setupRegistration.setChannelRuntime
+							};
+						}
+					}
+					const mergedSetupPlugin = mergedSetupRegistration.plugin;
+					if (!mergedSetupPlugin) continue;
+					if (!channelPluginIdBelongsToManifest({
+						channelId: mergedSetupPlugin.id,
+						pluginId: record.id,
+						manifestChannels: manifestRecord.channels
+					})) {
+						pushPluginLoadError(`plugin id mismatch (config uses "${record.id}", setup export uses "${mergedSetupPlugin.id}")`);
+						continue;
+					}
+					if (!runtimeSetterApplied) try {
+						mergedSetupRegistration.setChannelRuntime?.(api.runtime);
+					} catch (err) {
+						recordPluginError({
+							logger,
+							registry,
+							record,
+							seenIds,
+							pluginId,
+							origin: candidate.origin,
+							phase: "load",
+							error: err,
+							logPrefix: `[plugins] ${record.id} failed to apply setup channel runtime from ${record.source}: `,
+							diagnosticMessagePrefix: "failed to apply setup channel runtime: "
+						});
+						continue;
+					}
+					api.registerChannel(mergedSetupPlugin);
+					registry.plugins.push(record);
+					seenIds.set(pluginId, candidate.origin);
+					continue;
+				}
+			}
+			const resolved = resolvePluginModuleExport(mod);
+			const definition = resolved.definition;
+			const register = resolved.register;
+			if (definition?.id && definition.id !== record.id) {
+				pushPluginLoadError(`plugin id mismatch (config uses "${record.id}", export uses "${definition.id}")`);
+				continue;
+			}
+			record.name = definition?.name ?? record.name;
+			record.description = definition?.description ?? record.description;
+			record.version = definition?.version ?? record.version;
+			const manifestKind = record.kind;
+			const exportKind = definition?.kind;
+			if (manifestKind && exportKind && !kindsEqual(manifestKind, exportKind)) registry.diagnostics.push({
+				level: "warn",
+				pluginId: record.id,
+				source: record.source,
+				message: `plugin kind mismatch (manifest uses "${String(manifestKind)}", export uses "${String(exportKind)}")`
+			});
+			record.kind = definition?.kind ?? record.kind;
+			if (hasKind(record.kind, "memory") && memorySlot === record.id) memorySlotMatched = true;
+			if (registrationPlan.runRuntimeCapabilityPolicy) {
+				if (pluginId !== dreamingEngineId) {
+					const memoryDecision = resolveMemorySlotDecision({
+						id: record.id,
+						kind: record.kind,
+						slot: memorySlot,
+						selectedId: selectedMemoryPluginId
+					});
+					if (!memoryDecision.enabled) {
+						record.enabled = false;
+						record.status = "disabled";
+						record.error = memoryDecision.reason;
+						markPluginActivationDisabled(record, memoryDecision.reason);
+						registry.plugins.push(record);
+						seenIds.set(pluginId, candidate.origin);
+						continue;
+					}
+					if (memoryDecision.selected && hasKind(record.kind, "memory")) {
+						selectedMemoryPluginId = record.id;
+						record.memorySlotSelected = true;
+					}
+				}
+			}
+			if (registrationPlan.runFullActivationOnlyRegistrations) {
+				if (definition?.reload) registerReload(record, definition.reload);
+				for (const nodeHostCommand of definition?.nodeHostCommands ?? []) registerNodeHostCommand(record, nodeHostCommand);
+				for (const collector of definition?.securityAuditCollectors ?? []) registerSecurityAuditCollector(record, collector);
+			}
+			if (validateOnly) {
+				registry.plugins.push(record);
+				seenIds.set(pluginId, candidate.origin);
+				continue;
+			}
+			if (typeof register !== "function") {
+				logger.error(`[plugins] ${record.id} missing register/activate export`);
+				pushPluginLoadError(formatMissingPluginRegisterError(mod, env));
+				continue;
+			}
+			const api = createApi(record, {
+				config: cfg,
+				pluginConfig: validatedConfig.value,
+				hookPolicy: entry?.hooks,
+				registrationMode
+			});
+			const registrySnapshot = snapshotPluginRegistry(registry);
+			const previousAgentHarnesses = listRegisteredAgentHarnesses();
+			const previousCompactionProviders = listRegisteredCompactionProviders();
+			const previousDetachedTaskRuntimeRegistration = getDetachedTaskLifecycleRuntimeRegistration();
+			const previousMemoryCapability = getMemoryCapabilityRegistration();
+			const previousMemoryEmbeddingProviders = listRegisteredMemoryEmbeddingProviders();
+			const previousMemoryCorpusSupplements = listMemoryCorpusSupplements();
+			const previousMemoryPromptSupplements = listMemoryPromptSupplements();
+			try {
+				withProfile({
+					pluginId: record.id,
+					source: record.source
+				}, `${registrationMode}:register`, () => runPluginRegisterSync(register, api));
+				if (!shouldActivate) {
+					restoreRegisteredAgentHarnesses(previousAgentHarnesses);
+					restoreRegisteredCompactionProviders(previousCompactionProviders);
+					restoreDetachedTaskLifecycleRuntimeRegistration(previousDetachedTaskRuntimeRegistration);
+					restoreRegisteredMemoryEmbeddingProviders(previousMemoryEmbeddingProviders);
+					restoreMemoryPluginState({
+						capability: previousMemoryCapability,
+						corpusSupplements: previousMemoryCorpusSupplements,
+						promptSupplements: previousMemoryPromptSupplements
+					});
+				}
+				registry.plugins.push(record);
+				seenIds.set(pluginId, candidate.origin);
+			} catch (err) {
+				rollbackPluginGlobalSideEffects(record.id);
+				restorePluginRegistry(registry, registrySnapshot);
+				restoreRegisteredAgentHarnesses(previousAgentHarnesses);
+				restoreRegisteredCompactionProviders(previousCompactionProviders);
+				restoreDetachedTaskLifecycleRuntimeRegistration(previousDetachedTaskRuntimeRegistration);
+				restoreRegisteredMemoryEmbeddingProviders(previousMemoryEmbeddingProviders);
+				restoreMemoryPluginState({
+					capability: previousMemoryCapability,
+					corpusSupplements: previousMemoryCorpusSupplements,
+					promptSupplements: previousMemoryPromptSupplements
+				});
+				recordPluginError({
+					logger,
+					registry,
+					record,
+					seenIds,
+					pluginId,
+					origin: candidate.origin,
+					phase: "register",
+					error: err,
+					logPrefix: `[plugins] ${record.id} failed during register from ${record.source}: `,
+					diagnosticMessagePrefix: "plugin failed during register: "
+				});
+			}
+		}
+		const pluginLoadElapsedMs = performance.now() - pluginLoadStartMs;
+		if (pluginLoadAttemptCount > 0) logger.debug?.(`[plugins] loaded ${registry.plugins.length} plugin(s) (${pluginLoadAttemptCount} attempted) in ${pluginLoadElapsedMs.toFixed(1)}ms`);
+		if (!onlyPluginIdSet && typeof memorySlot === "string" && !memorySlotMatched) registry.diagnostics.push({
+			level: "warn",
+			message: `memory slot plugin not found or not marked as memory: ${memorySlot}`
+		});
+		warnAboutUntrackedLoadedPlugins({
+			registry,
+			provenance,
+			allowlist: normalized.allow,
+			emitWarning: shouldActivate,
+			logger,
+			env
+		});
+		maybeThrowOnPluginLoadError(registry, options.throwOnLoadError);
+		if (shouldActivate && options.mode !== "validate") {
+			const failedPlugins = registry.plugins.filter((plugin) => plugin.failedAt != null);
+			if (failedPlugins.length > 0) logger.warn(`[plugins] ${failedPlugins.length} plugin(s) failed to initialize (${formatPluginFailureSummary(failedPlugins)}). Run 'openclaw plugins list' for details.`);
+		}
+		if (cacheEnabled) setCachedPluginRegistry(cacheKey, {
+			commands: listRegisteredPluginCommands(),
+			detachedTaskRuntimeRegistration: getDetachedTaskLifecycleRuntimeRegistration(),
+			interactiveHandlers: listPluginInteractiveHandlers(),
+			memoryCapability: getMemoryCapabilityRegistration(),
+			memoryCorpusSupplements: listMemoryCorpusSupplements(),
+			registry,
+			agentHarnesses: listRegisteredAgentHarnesses(),
+			compactionProviders: listRegisteredCompactionProviders(),
+			memoryEmbeddingProviders: listRegisteredMemoryEmbeddingProviders(),
+			memoryPromptSupplements: listMemoryPromptSupplements()
+		}, onlyPluginIds);
+		if (shouldActivate) activatePluginRegistry(registry, cacheKey, runtimeSubagentMode, options.workspaceDir);
+		return registry;
+	} finally {
+		pluginLoaderCacheState.finishLoad(cacheKey);
+	}
+}
+async function loadOpenClawPluginCliRegistry(options = {}) {
+	const { env, cfg, normalized, activationSource, autoEnabledReasons, onlyPluginIds, cacheKey, installRecords } = resolvePluginLoadCacheContext({
+		...options,
+		activate: false
+	});
+	const logger = options.logger ?? defaultLogger();
+	const onlyPluginIdSet = createPluginIdScopeSet(onlyPluginIds);
+	const loadPluginModule = createPluginModuleLoader(options);
+	const { registry, registerCli } = createPluginRegistry({
+		logger,
+		runtime: {},
+		coreGatewayHandlers: options.coreGatewayHandlers,
+		...options.coreGatewayMethodNames !== void 0 && { coreGatewayMethodNames: options.coreGatewayMethodNames },
+		activateGlobalSideEffects: false
+	});
+	const discovery = discoverOpenClawPlugins({
+		workspaceDir: options.workspaceDir,
+		extraPaths: normalized.loadPaths,
+		env,
+		installRecords
+	});
+	const manifestRegistry = loadPluginManifestRegistry({
+		config: cfg,
+		workspaceDir: options.workspaceDir,
+		env,
+		candidates: discovery.candidates,
+		diagnostics: discovery.diagnostics,
+		installRecords: Object.keys(installRecords).length > 0 ? installRecords : void 0
+	});
+	pushDiagnostics(registry.diagnostics, manifestRegistry.diagnostics);
+	warnWhenAllowlistIsOpen({
+		emitWarning: false,
+		logger,
+		pluginsEnabled: normalized.enabled,
+		allow: normalized.allow,
+		warningCacheKey: `${cacheKey}::cli-metadata`,
+		warningCache: pluginLoaderCacheState,
+		discoverablePlugins: manifestRegistry.plugins.filter((plugin) => !onlyPluginIdSet || onlyPluginIdSet.has(plugin.id)).map((plugin) => ({
+			id: plugin.id,
+			source: plugin.source,
+			origin: plugin.origin
+		}))
+	});
+	const provenance = buildProvenanceIndex({
+		normalizedLoadPaths: normalized.loadPaths,
+		env
+	});
+	const manifestByRoot = new Map(manifestRegistry.plugins.map((record) => [record.rootDir, record]));
+	const orderedCandidates = [...discovery.candidates].toSorted((left, right) => {
+		return compareDuplicateCandidateOrder({
+			left,
+			right,
+			manifestByRoot,
+			provenance,
+			env
+		});
+	});
+	const seenIds = /* @__PURE__ */ new Map();
+	const memorySlot = normalized.slots.memory;
+	let selectedMemoryPluginId = null;
+	const dreamingEngineId = resolveDreamingSidecarEngineId({
+		cfg,
+		memorySlot
+	});
+	for (const candidate of orderedCandidates) {
+		const manifestRecord = manifestByRoot.get(candidate.rootDir);
+		if (!manifestRecord) continue;
+		const pluginId = manifestRecord.id;
+		if (!matchesScopedPluginRequest({
+			onlyPluginIdSet,
+			pluginId
+		})) continue;
+		const activationState = resolveEffectivePluginActivationState({
+			id: pluginId,
+			origin: candidate.origin,
+			config: normalized,
+			rootConfig: cfg,
+			enabledByDefault: isPluginEnabledByDefaultForPlatform(manifestRecord),
+			activationSource,
+			autoEnabledReason: formatAutoEnabledActivationReason(autoEnabledReasons[pluginId])
+		});
+		const existingOrigin = seenIds.get(pluginId);
+		if (existingOrigin) {
+			const record = createPluginRecord({
+				id: pluginId,
+				name: manifestRecord.name ?? pluginId,
+				description: manifestRecord.description,
+				version: manifestRecord.version,
+				packageName: manifestRecord.packageName,
+				format: manifestRecord.format,
+				bundleFormat: manifestRecord.bundleFormat,
+				bundleCapabilities: manifestRecord.bundleCapabilities,
+				source: candidate.source,
+				rootDir: candidate.rootDir,
+				origin: candidate.origin,
+				workspaceDir: candidate.workspaceDir,
+				trustedOfficialInstall: manifestRecord.trustedOfficialInstall,
+				enabled: false,
+				compat: collectPluginManifestCompatCodes(manifestRecord),
+				activationState,
+				syntheticAuthRefs: manifestRecord.syntheticAuthRefs,
+				channelIds: manifestRecord.channels,
+				providerIds: manifestRecord.providers,
+				configSchema: Boolean(manifestRecord.configSchema),
+				contracts: manifestRecord.contracts
+			});
+			record.status = "disabled";
+			record.error = `overridden by ${existingOrigin} plugin`;
+			markPluginActivationDisabled(record, record.error);
+			registry.plugins.push(record);
+			continue;
+		}
+		const enableState = resolveEffectiveEnableState({
+			id: pluginId,
+			origin: candidate.origin,
+			config: normalized,
+			rootConfig: cfg,
+			enabledByDefault: isPluginEnabledByDefaultForPlatform(manifestRecord),
+			activationSource
+		});
+		const entry = normalized.entries[pluginId];
+		const record = createPluginRecord({
+			id: pluginId,
+			name: manifestRecord.name ?? pluginId,
+			description: manifestRecord.description,
+			version: manifestRecord.version,
+			packageName: manifestRecord.packageName,
+			format: manifestRecord.format,
+			bundleFormat: manifestRecord.bundleFormat,
+			bundleCapabilities: manifestRecord.bundleCapabilities,
+			source: candidate.source,
+			rootDir: candidate.rootDir,
+			origin: candidate.origin,
+			workspaceDir: candidate.workspaceDir,
+			trustedOfficialInstall: manifestRecord.trustedOfficialInstall,
+			enabled: enableState.enabled,
+			compat: collectPluginManifestCompatCodes(manifestRecord),
+			activationState,
+			syntheticAuthRefs: manifestRecord.syntheticAuthRefs,
+			channelIds: manifestRecord.channels,
+			providerIds: manifestRecord.providers,
+			configSchema: Boolean(manifestRecord.configSchema),
+			contracts: manifestRecord.contracts
+		});
+		record.kind = manifestRecord.kind;
+		record.configUiHints = manifestRecord.configUiHints;
+		record.configJsonSchema = manifestRecord.configSchema;
+		const pushPluginLoadError = (message) => {
+			record.status = "error";
+			record.error = message;
+			record.failedAt = /* @__PURE__ */ new Date();
+			record.failurePhase = "validation";
+			registry.plugins.push(record);
+			seenIds.set(pluginId, candidate.origin);
+			registry.diagnostics.push({
+				level: "error",
+				pluginId: record.id,
+				source: record.source,
+				message: record.error
+			});
+		};
+		if (!enableState.enabled) {
+			record.status = "disabled";
+			record.error = enableState.reason;
+			markPluginActivationDisabled(record, enableState.reason);
+			registry.plugins.push(record);
+			seenIds.set(pluginId, candidate.origin);
+			continue;
+		}
+		if (record.format === "bundle") {
+			registry.plugins.push(record);
+			seenIds.set(pluginId, candidate.origin);
+			continue;
+		}
+		if (!manifestRecord.configSchema) {
+			pushPluginLoadError("missing config schema");
+			continue;
+		}
+		const validatedConfig = validatePluginConfig({
+			schema: manifestRecord.configSchema,
+			cacheKey: manifestRecord.schemaCacheKey,
+			value: entry?.config
+		});
+		if (!validatedConfig.ok) {
+			logger.error(`[plugins] ${record.id} invalid config: ${validatedConfig.errors?.join(", ")}`);
+			pushPluginLoadError(`invalid config: ${validatedConfig.errors?.join(", ")}`);
+			continue;
+		}
+		const pluginRoot = safeRealpathOrResolve(candidate.rootDir);
+		const cliMetadataSource = resolveCliMetadataEntrySource(candidate.rootDir);
+		const sourceForCliMetadata = candidate.origin === "bundled" ? cliMetadataSource ? safeRealpathOrResolve(cliMetadataSource) : null : cliMetadataSource ?? candidate.source;
+		if (!sourceForCliMetadata) {
+			record.status = "loaded";
+			registry.plugins.push(record);
+			seenIds.set(pluginId, candidate.origin);
+			continue;
+		}
+		const opened = openRootFileSync({
+			absolutePath: sourceForCliMetadata,
+			rootPath: pluginRoot,
+			boundaryLabel: "plugin root",
+			rejectHardlinks: shouldRejectHardlinkedPluginFiles({
+				origin: candidate.origin,
+				rootDir: candidate.rootDir,
+				env
+			}),
+			skipLexicalRootCheck: true
+		});
+		if (!opened.ok) {
+			pushPluginLoadError("plugin entry path escapes plugin root or fails alias checks");
+			continue;
+		}
+		const safeSource = opened.path;
+		fs.closeSync(opened.fd);
+		let mod = null;
+		try {
+			mod = withProfile({
+				pluginId: record.id,
+				source: safeSource
+			}, "cli-metadata", () => loadPluginModule(safeSource));
+		} catch (err) {
+			recordPluginError({
+				logger,
+				registry,
+				record,
+				seenIds,
+				pluginId,
+				origin: candidate.origin,
+				phase: "load",
+				error: err,
+				logPrefix: `[plugins] ${record.id} failed to load from ${record.source}: `,
+				diagnosticMessagePrefix: "failed to load plugin: "
+			});
+			continue;
+		}
+		const resolved = resolvePluginModuleExport(mod);
+		const definition = resolved.definition;
+		const register = resolved.register;
+		if (definition?.id && definition.id !== record.id) {
+			pushPluginLoadError(`plugin id mismatch (config uses "${record.id}", export uses "${definition.id}")`);
+			continue;
+		}
+		record.name = definition?.name ?? record.name;
+		record.description = definition?.description ?? record.description;
+		record.version = definition?.version ?? record.version;
+		const manifestKind = record.kind;
+		const exportKind = definition?.kind;
+		if (manifestKind && exportKind && !kindsEqual(manifestKind, exportKind)) registry.diagnostics.push({
+			level: "warn",
+			pluginId: record.id,
+			source: record.source,
+			message: `plugin kind mismatch (manifest uses "${String(manifestKind)}", export uses "${String(exportKind)}")`
+		});
+		record.kind = definition?.kind ?? record.kind;
+		if (pluginId !== dreamingEngineId) {
+			const memoryDecision = resolveMemorySlotDecision({
+				id: record.id,
+				kind: record.kind,
+				slot: memorySlot,
+				selectedId: selectedMemoryPluginId
+			});
+			if (!memoryDecision.enabled) {
+				record.enabled = false;
+				record.status = "disabled";
+				record.error = memoryDecision.reason;
+				markPluginActivationDisabled(record, memoryDecision.reason);
+				registry.plugins.push(record);
+				seenIds.set(pluginId, candidate.origin);
+				continue;
+			}
+			if (memoryDecision.selected && hasKind(record.kind, "memory")) {
+				selectedMemoryPluginId = record.id;
+				record.memorySlotSelected = true;
+			}
+		}
+		if (typeof register !== "function") {
+			logger.error(`[plugins] ${record.id} missing register/activate export`);
+			pushPluginLoadError(formatMissingPluginRegisterError(mod, env));
+			continue;
+		}
+		const api = buildPluginApi({
+			id: record.id,
+			name: record.name,
+			version: record.version,
+			description: record.description,
+			source: record.source,
+			rootDir: record.rootDir,
+			registrationMode: "cli-metadata",
+			config: cfg,
+			pluginConfig: validatedConfig.value,
+			runtime: {},
+			logger,
+			resolvePath: (input) => resolveUserPath(input),
+			handlers: { registerCli: (registrar, opts) => registerCli(record, registrar, opts) }
+		});
+		const registrySnapshot = snapshotPluginRegistry(registry);
+		try {
+			withProfile({
+				pluginId: record.id,
+				source: record.source
+			}, "cli-metadata:register", () => runPluginRegisterSync(register, api));
+			registry.plugins.push(record);
+			seenIds.set(pluginId, candidate.origin);
+		} catch (err) {
+			restorePluginRegistry(registry, registrySnapshot);
+			recordPluginError({
+				logger,
+				registry,
+				record,
+				seenIds,
+				pluginId,
+				origin: candidate.origin,
+				phase: "register",
+				error: err,
+				logPrefix: `[plugins] ${record.id} failed during register from ${record.source}: `,
+				diagnosticMessagePrefix: "plugin failed during register: "
+			});
+		}
+	}
+	return registry;
+}
+function safeRealpathOrResolve(value) {
+	try {
+		return fs.realpathSync(value);
+	} catch {
+		return path.resolve(value);
+	}
+}
+function resolveCliMetadataEntrySource(rootDir) {
+	for (const basename of CLI_METADATA_ENTRY_BASENAMES) {
+		const candidate = path.join(rootDir, basename);
+		if (fs.existsSync(candidate)) return candidate;
+	}
+	return null;
+}
+//#endregion
+export { resolvePluginActivationSourceConfig as C, getCompactionProvider as S, getPluginSessionExtensionStateSync as _, clearPluginRegistryLoadCache as a, listCodexAppServerExtensionFactories as b, loadOpenClawPluginCliRegistry as c, resolvePluginRegistryLoadCacheKey as d, resolveRuntimePluginRegistry as f, drainPluginNextTurnInjectionContext as g, synthesizeMediaGenerationCatalogEntries as h, clearPluginLoaderCache as i, loadOpenClawPlugins as l, listMediaGenerationProviderModels as m, __testing as n, getRuntimePluginRegistryForLoadOptions as o, createPluginRegistry as p, clearActivatedPluginRuntimeState as r, isPluginRegistryLoadInFlight as s, PluginLoadFailureError as t, resolveCompatibleRuntimePluginRegistry as u, patchPluginSessionExtension as v, PluginLoadReentryError as x, projectPluginSessionExtensionsSync as y };

--- a/patches/openclaw-2026.5.10-beta.5/manifest.json
+++ b/patches/openclaw-2026.5.10-beta.5/manifest.json
@@ -1,0 +1,28 @@
+{
+  "_doc": "Chat-stream seam overlay manifest. Maps openclaw version → file replacements + expected SHAs. The patcher in scripts/install-chat-stream-seam.mjs reads this to apply, verify, or revert. Each version of openclaw needs its own entry — when openclaw bumps a beta, regenerate the overlay against the new baseline and add a new entry here.",
+  "openclawVersion": "2026.5.10-beta.5",
+  "seamSource": {
+    "upstreamPR": "https://github.com/openclaw/openclaw/pull/80982",
+    "branch": "feat/plugin-sdk-chat-stream-renderer",
+    "commits": [
+      "e873855d5de feat(plugin-sdk): add chat-stream Control UI surfaces for plugin-owned inline UI",
+      "a114083ae85 fix: drop unused import + regenerate Swift protocol bindings",
+      "e23f6af81ae fix(contracts-test): drop unused oxlint-disable directive"
+    ],
+    "buildHEAD": "fb9af69ea2b (cherry-picked onto v2026.5.10-beta.5 = 1ba689376ac, built 2026-05-12)"
+  },
+  "files": [
+    {
+      "relativePath": "dist/loader-DdN5GTsW.js",
+      "baselineSha256": "6261d5bfb3985b930ca4b6fd70da2ded6541ba62939fe4678b6ae22d77e875b3",
+      "patchedSha256": "c7b2020399c53934a8fa1f27cd132ce43039f8d5537b2216d0d500f906174a29",
+      "description": "Plugin loader bundle. Adds chatStreamSurfaces set + activeWhen validation + priority parsing (~70 LOC of new code inside ~6000-line bundle)."
+    },
+    {
+      "relativePath": "dist/protocol-BBwaRnfZ.js",
+      "baselineSha256": "2d22a827ff37d6194b1116a6f5c4eddc0b5e30832fd4008f962f9b6921e6dc42",
+      "patchedSha256": "178b3f4786e6f4712b87041a55ebc88b740eebd646b84fbe03477e8f15456754",
+      "description": "Gateway wire-protocol schema bundle. Adds PluginControlUiActiveWhenSchema + 3 new surface Literals + priority/activeWhen optional fields (~10 LOC of new code)."
+    }
+  ]
+}

--- a/patches/openclaw-2026.5.10-beta.5/protocol-BBwaRnfZ.js
+++ b/patches/openclaw-2026.5.10-beta.5/protocol-BBwaRnfZ.js
@@ -1,0 +1,3105 @@
+import { n as ENV_SECRET_REF_ID_RE } from "./types.secrets-YqPIGGsa.js";
+import { i as SINGLE_VALUE_FILE_REF_ID, n as FILE_SECRET_REF_ID_INVALID_ESCAPE_JSON_SCHEMA_PATTERN, r as SECRET_PROVIDER_ALIAS_PATTERN, t as EXEC_SECRET_REF_ID_JSON_SCHEMA_PATTERN } from "./ref-contract-XV11eA9X.js";
+import { n as GATEWAY_CLIENT_IDS, r as GATEWAY_CLIENT_MODES } from "./client-info-BShRboip.js";
+import { t as INPUT_PROVENANCE_KIND_VALUES } from "./input-provenance-AodV2BqQ.js";
+import { r as MAX_PLUGIN_APPROVAL_TIMEOUT_MS } from "./plugin-approvals-BR_o6fIN.js";
+import AjvPkg from "ajv";
+import { Type } from "typebox";
+//#region src/agents/internal-event-contract.ts
+const AGENT_INTERNAL_EVENT_TYPE_TASK_COMPLETION = "task_completion";
+const AGENT_INTERNAL_EVENT_SOURCES = [
+	"subagent",
+	"cron",
+	"video_generation",
+	"music_generation"
+];
+const AGENT_INTERNAL_EVENT_STATUSES = [
+	"ok",
+	"timeout",
+	"error",
+	"unknown"
+];
+function parseSessionLabel(raw) {
+	if (typeof raw !== "string") return {
+		ok: false,
+		error: "invalid label: must be a string"
+	};
+	const trimmed = raw.trim();
+	if (!trimmed) return {
+		ok: false,
+		error: "invalid label: empty"
+	};
+	if (trimmed.length > 512) return {
+		ok: false,
+		error: `invalid label: too long (max 512)`
+	};
+	return {
+		ok: true,
+		label: trimmed
+	};
+}
+//#endregion
+//#region src/gateway/protocol/schema/primitives.ts
+const NonEmptyString = Type.String({ minLength: 1 });
+const ChatSendSessionKeyString = Type.String({
+	minLength: 1,
+	maxLength: 512
+});
+const SessionLabelString = Type.String({
+	minLength: 1,
+	maxLength: 512
+});
+const InputProvenanceSchema = Type.Object({
+	kind: Type.String({ enum: [...INPUT_PROVENANCE_KIND_VALUES] }),
+	originSessionId: Type.Optional(Type.String()),
+	sourceSessionKey: Type.Optional(Type.String()),
+	sourceChannel: Type.Optional(Type.String()),
+	sourceTool: Type.Optional(Type.String())
+}, { additionalProperties: false });
+const GatewayClientIdSchema = Type.Enum(GATEWAY_CLIENT_IDS);
+const GatewayClientModeSchema = Type.Enum(GATEWAY_CLIENT_MODES);
+Type.Union([
+	Type.Literal("env"),
+	Type.Literal("file"),
+	Type.Literal("exec")
+]);
+const SecretProviderAliasString = Type.String({ pattern: SECRET_PROVIDER_ALIAS_PATTERN.source });
+const EnvSecretRefSchema = Type.Object({
+	source: Type.Literal("env"),
+	provider: SecretProviderAliasString,
+	id: Type.String({ pattern: ENV_SECRET_REF_ID_RE.source })
+}, { additionalProperties: false });
+const FileSecretRefIdSchema = Type.Unsafe({
+	type: "string",
+	anyOf: [{ const: SINGLE_VALUE_FILE_REF_ID }, { allOf: [{ pattern: "^/" }, { not: { pattern: FILE_SECRET_REF_ID_INVALID_ESCAPE_JSON_SCHEMA_PATTERN } }] }]
+});
+const FileSecretRefSchema = Type.Object({
+	source: Type.Literal("file"),
+	provider: SecretProviderAliasString,
+	id: FileSecretRefIdSchema
+}, { additionalProperties: false });
+const ExecSecretRefSchema = Type.Object({
+	source: Type.Literal("exec"),
+	provider: SecretProviderAliasString,
+	id: Type.String({ pattern: EXEC_SECRET_REF_ID_JSON_SCHEMA_PATTERN })
+}, { additionalProperties: false });
+const SecretRefSchema = Type.Union([
+	EnvSecretRefSchema,
+	FileSecretRefSchema,
+	ExecSecretRefSchema
+]);
+const SecretInputSchema = Type.Union([Type.String(), SecretRefSchema]);
+//#endregion
+//#region src/gateway/protocol/schema/agent.ts
+const AgentInternalEventSchema = Type.Object({
+	type: Type.Literal(AGENT_INTERNAL_EVENT_TYPE_TASK_COMPLETION),
+	source: Type.String({ enum: [...AGENT_INTERNAL_EVENT_SOURCES] }),
+	childSessionKey: Type.String(),
+	childSessionId: Type.Optional(Type.String()),
+	announceType: Type.String(),
+	taskLabel: Type.String(),
+	status: Type.String({ enum: [...AGENT_INTERNAL_EVENT_STATUSES] }),
+	statusLabel: Type.String(),
+	result: Type.String(),
+	mediaUrls: Type.Optional(Type.Array(Type.String())),
+	statsLine: Type.Optional(Type.String()),
+	replyInstruction: Type.String()
+}, { additionalProperties: false });
+const AgentEventSchema = Type.Object({
+	runId: NonEmptyString,
+	seq: Type.Integer({ minimum: 0 }),
+	stream: NonEmptyString,
+	ts: Type.Integer({ minimum: 0 }),
+	spawnedBy: Type.Optional(NonEmptyString),
+	data: Type.Record(Type.String(), Type.Unknown())
+}, { additionalProperties: false });
+const MessageActionToolContextSchema = Type.Object({
+	currentChannelId: Type.Optional(Type.String()),
+	currentGraphChannelId: Type.Optional(Type.String()),
+	currentChannelProvider: Type.Optional(Type.String()),
+	currentThreadTs: Type.Optional(Type.String()),
+	currentMessageId: Type.Optional(Type.Union([Type.String(), Type.Number()])),
+	replyToMode: Type.Optional(Type.Union([
+		Type.Literal("off"),
+		Type.Literal("first"),
+		Type.Literal("all"),
+		Type.Literal("batched")
+	])),
+	hasRepliedRef: Type.Optional(Type.Object({ value: Type.Boolean() }, { additionalProperties: false })),
+	skipCrossContextDecoration: Type.Optional(Type.Boolean())
+}, { additionalProperties: false });
+const MessageActionParamsSchema = Type.Object({
+	channel: NonEmptyString,
+	action: NonEmptyString,
+	params: Type.Record(Type.String(), Type.Unknown()),
+	accountId: Type.Optional(Type.String()),
+	requesterSenderId: Type.Optional(Type.String()),
+	senderIsOwner: Type.Optional(Type.Boolean()),
+	sessionKey: Type.Optional(Type.String()),
+	sessionId: Type.Optional(Type.String()),
+	agentId: Type.Optional(Type.String()),
+	toolContext: Type.Optional(MessageActionToolContextSchema),
+	idempotencyKey: NonEmptyString
+}, { additionalProperties: false });
+const SendParamsSchema = Type.Object({
+	to: NonEmptyString,
+	message: Type.Optional(Type.String()),
+	mediaUrl: Type.Optional(Type.String()),
+	mediaUrls: Type.Optional(Type.Array(Type.String())),
+	asVoice: Type.Optional(Type.Boolean()),
+	gifPlayback: Type.Optional(Type.Boolean()),
+	channel: Type.Optional(Type.String()),
+	accountId: Type.Optional(Type.String()),
+	/** Optional agent id for per-agent media root resolution on gateway sends. */
+	agentId: Type.Optional(Type.String()),
+	/** Reply target message id for native quoted/threaded sends where supported. */
+	replyToId: Type.Optional(Type.String()),
+	/** Thread id (channel-specific meaning, e.g. Telegram forum topic id). */
+	threadId: Type.Optional(Type.String()),
+	/** Force document-style media sends where supported. */
+	forceDocument: Type.Optional(Type.Boolean()),
+	/** Send silently (no notification) where supported. */
+	silent: Type.Optional(Type.Boolean()),
+	/** Channel-specific parse mode for formatted text. */
+	parseMode: Type.Optional(Type.Literal("HTML")),
+	/** Optional session key for mirroring delivered output back into the transcript. */
+	sessionKey: Type.Optional(Type.String()),
+	idempotencyKey: NonEmptyString
+}, { additionalProperties: false });
+const PollParamsSchema = Type.Object({
+	to: NonEmptyString,
+	question: NonEmptyString,
+	options: Type.Array(NonEmptyString, {
+		minItems: 2,
+		maxItems: 12
+	}),
+	maxSelections: Type.Optional(Type.Integer({
+		minimum: 1,
+		maximum: 12
+	})),
+	/** Poll duration in seconds (channel-specific limits may apply). */
+	durationSeconds: Type.Optional(Type.Integer({
+		minimum: 1,
+		maximum: 604800
+	})),
+	durationHours: Type.Optional(Type.Integer({ minimum: 1 })),
+	/** Send silently (no notification) where supported. */
+	silent: Type.Optional(Type.Boolean()),
+	/** Poll anonymity where supported (e.g. Telegram polls default to anonymous). */
+	isAnonymous: Type.Optional(Type.Boolean()),
+	/** Thread id (channel-specific meaning, e.g. Telegram forum topic id). */
+	threadId: Type.Optional(Type.String()),
+	channel: Type.Optional(Type.String()),
+	accountId: Type.Optional(Type.String()),
+	idempotencyKey: NonEmptyString
+}, { additionalProperties: false });
+const AgentParamsSchema = Type.Object({
+	message: NonEmptyString,
+	agentId: Type.Optional(NonEmptyString),
+	provider: Type.Optional(Type.String()),
+	model: Type.Optional(Type.String()),
+	to: Type.Optional(Type.String()),
+	replyTo: Type.Optional(Type.String()),
+	sessionId: Type.Optional(Type.String()),
+	sessionKey: Type.Optional(Type.String()),
+	thinking: Type.Optional(Type.String()),
+	deliver: Type.Optional(Type.Boolean()),
+	attachments: Type.Optional(Type.Array(Type.Unknown())),
+	channel: Type.Optional(Type.String()),
+	replyChannel: Type.Optional(Type.String()),
+	accountId: Type.Optional(Type.String()),
+	replyAccountId: Type.Optional(Type.String()),
+	threadId: Type.Optional(Type.String()),
+	groupId: Type.Optional(Type.String()),
+	groupChannel: Type.Optional(Type.String()),
+	groupSpace: Type.Optional(Type.String()),
+	timeout: Type.Optional(Type.Integer({ minimum: 0 })),
+	bestEffortDeliver: Type.Optional(Type.Boolean()),
+	lane: Type.Optional(Type.String()),
+	cleanupBundleMcpOnRunEnd: Type.Optional(Type.Boolean()),
+	modelRun: Type.Optional(Type.Boolean()),
+	promptMode: Type.Optional(Type.Union([
+		Type.Literal("full"),
+		Type.Literal("minimal"),
+		Type.Literal("none")
+	])),
+	extraSystemPrompt: Type.Optional(Type.String()),
+	bootstrapContextMode: Type.Optional(Type.Union([Type.Literal("full"), Type.Literal("lightweight")])),
+	bootstrapContextRunKind: Type.Optional(Type.Union([
+		Type.Literal("default"),
+		Type.Literal("heartbeat"),
+		Type.Literal("cron")
+	])),
+	acpTurnSource: Type.Optional(Type.Literal("manual_spawn")),
+	internalRuntimeHandoffId: Type.Optional(NonEmptyString),
+	internalEvents: Type.Optional(Type.Array(AgentInternalEventSchema)),
+	inputProvenance: Type.Optional(InputProvenanceSchema),
+	voiceWakeTrigger: Type.Optional(Type.String()),
+	idempotencyKey: NonEmptyString,
+	label: Type.Optional(SessionLabelString)
+}, { additionalProperties: false });
+const AgentIdentityParamsSchema = Type.Object({
+	agentId: Type.Optional(NonEmptyString),
+	sessionKey: Type.Optional(Type.String())
+}, { additionalProperties: false });
+const AgentIdentityResultSchema = Type.Object({
+	agentId: NonEmptyString,
+	name: Type.Optional(NonEmptyString),
+	avatar: Type.Optional(NonEmptyString),
+	avatarSource: Type.Optional(NonEmptyString),
+	avatarStatus: Type.Optional(Type.String({ enum: [
+		"none",
+		"local",
+		"remote",
+		"data"
+	] })),
+	avatarReason: Type.Optional(NonEmptyString),
+	emoji: Type.Optional(NonEmptyString)
+}, { additionalProperties: false });
+const AgentWaitParamsSchema = Type.Object({
+	runId: NonEmptyString,
+	timeoutMs: Type.Optional(Type.Integer({ minimum: 0 }))
+}, { additionalProperties: false });
+const WakeParamsSchema = Type.Object({
+	mode: Type.Union([Type.Literal("now"), Type.Literal("next-heartbeat")]),
+	text: NonEmptyString
+}, { additionalProperties: true });
+//#endregion
+//#region src/gateway/protocol/schema/agents-models-skills.ts
+const ModelChoiceSchema = Type.Object({
+	id: NonEmptyString,
+	name: NonEmptyString,
+	provider: NonEmptyString,
+	alias: Type.Optional(NonEmptyString),
+	contextWindow: Type.Optional(Type.Integer({ minimum: 1 })),
+	reasoning: Type.Optional(Type.Boolean())
+}, { additionalProperties: false });
+const AgentSummarySchema = Type.Object({
+	id: NonEmptyString,
+	name: Type.Optional(NonEmptyString),
+	identity: Type.Optional(Type.Object({
+		name: Type.Optional(NonEmptyString),
+		theme: Type.Optional(NonEmptyString),
+		emoji: Type.Optional(NonEmptyString),
+		avatar: Type.Optional(NonEmptyString),
+		avatarUrl: Type.Optional(NonEmptyString)
+	}, { additionalProperties: false })),
+	workspace: Type.Optional(NonEmptyString),
+	model: Type.Optional(Type.Object({
+		primary: Type.Optional(NonEmptyString),
+		fallbacks: Type.Optional(Type.Array(NonEmptyString))
+	}, { additionalProperties: false })),
+	agentRuntime: Type.Optional(Type.Object({
+		id: NonEmptyString,
+		fallback: Type.Optional(Type.Union([Type.Literal("pi"), Type.Literal("none")])),
+		source: Type.Union([
+			Type.Literal("env"),
+			Type.Literal("agent"),
+			Type.Literal("defaults"),
+			Type.Literal("model"),
+			Type.Literal("provider"),
+			Type.Literal("implicit")
+		])
+	}, { additionalProperties: false }))
+}, { additionalProperties: false });
+const AgentsListParamsSchema = Type.Object({}, { additionalProperties: false });
+const AgentsListResultSchema = Type.Object({
+	defaultId: NonEmptyString,
+	mainKey: NonEmptyString,
+	scope: Type.Union([Type.Literal("per-sender"), Type.Literal("global")]),
+	agents: Type.Array(AgentSummarySchema)
+}, { additionalProperties: false });
+const AgentsCreateParamsSchema = Type.Object({
+	name: NonEmptyString,
+	workspace: NonEmptyString,
+	model: Type.Optional(NonEmptyString),
+	emoji: Type.Optional(Type.String()),
+	avatar: Type.Optional(Type.String())
+}, { additionalProperties: false });
+const AgentsCreateResultSchema = Type.Object({
+	ok: Type.Literal(true),
+	agentId: NonEmptyString,
+	name: NonEmptyString,
+	workspace: NonEmptyString,
+	model: Type.Optional(NonEmptyString)
+}, { additionalProperties: false });
+const AgentsUpdateParamsSchema = Type.Object({
+	agentId: NonEmptyString,
+	name: Type.Optional(NonEmptyString),
+	workspace: Type.Optional(NonEmptyString),
+	model: Type.Optional(NonEmptyString),
+	emoji: Type.Optional(Type.String()),
+	avatar: Type.Optional(Type.String())
+}, { additionalProperties: false });
+const AgentsUpdateResultSchema = Type.Object({
+	ok: Type.Literal(true),
+	agentId: NonEmptyString
+}, { additionalProperties: false });
+const AgentsDeleteParamsSchema = Type.Object({
+	agentId: NonEmptyString,
+	deleteFiles: Type.Optional(Type.Boolean())
+}, { additionalProperties: false });
+const AgentsDeleteResultSchema = Type.Object({
+	ok: Type.Literal(true),
+	agentId: NonEmptyString,
+	removedBindings: Type.Integer({ minimum: 0 })
+}, { additionalProperties: false });
+const AgentsFileEntrySchema = Type.Object({
+	name: NonEmptyString,
+	path: NonEmptyString,
+	missing: Type.Boolean(),
+	size: Type.Optional(Type.Integer({ minimum: 0 })),
+	updatedAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+	content: Type.Optional(Type.String())
+}, { additionalProperties: false });
+const AgentsFilesListParamsSchema = Type.Object({ agentId: NonEmptyString }, { additionalProperties: false });
+const AgentsFilesListResultSchema = Type.Object({
+	agentId: NonEmptyString,
+	workspace: NonEmptyString,
+	files: Type.Array(AgentsFileEntrySchema)
+}, { additionalProperties: false });
+const AgentsFilesGetParamsSchema = Type.Object({
+	agentId: NonEmptyString,
+	name: NonEmptyString
+}, { additionalProperties: false });
+const AgentsFilesGetResultSchema = Type.Object({
+	agentId: NonEmptyString,
+	workspace: NonEmptyString,
+	file: AgentsFileEntrySchema
+}, { additionalProperties: false });
+const AgentsFilesSetParamsSchema = Type.Object({
+	agentId: NonEmptyString,
+	name: NonEmptyString,
+	content: Type.String()
+}, { additionalProperties: false });
+const AgentsFilesSetResultSchema = Type.Object({
+	ok: Type.Literal(true),
+	agentId: NonEmptyString,
+	workspace: NonEmptyString,
+	file: AgentsFileEntrySchema
+}, { additionalProperties: false });
+const ModelsListParamsSchema = Type.Object({ view: Type.Optional(Type.Union([
+	Type.Literal("default"),
+	Type.Literal("configured"),
+	Type.Literal("all")
+])) }, { additionalProperties: false });
+const ModelsListResultSchema = Type.Object({ models: Type.Array(ModelChoiceSchema) }, { additionalProperties: false });
+const SkillsStatusParamsSchema = Type.Object({ agentId: Type.Optional(NonEmptyString) }, { additionalProperties: false });
+const SkillsBinsParamsSchema = Type.Object({}, { additionalProperties: false });
+const SkillsBinsResultSchema = Type.Object({ bins: Type.Array(NonEmptyString) }, { additionalProperties: false });
+const Sha256String = Type.String({
+	minLength: 64,
+	maxLength: 64,
+	pattern: "^[a-fA-F0-9]{64}$"
+});
+const SkillUploadIdempotencyKeyString = Type.String({
+	minLength: 1,
+	maxLength: 2048
+});
+const SkillUploadDataBase64String = Type.String({
+	minLength: 1,
+	maxLength: 5592408
+});
+const SkillsUploadBeginParamsSchema = Type.Object({
+	kind: Type.Literal("skill-archive"),
+	slug: NonEmptyString,
+	sizeBytes: Type.Integer({ minimum: 1 }),
+	sha256: Type.Optional(Sha256String),
+	force: Type.Optional(Type.Boolean()),
+	idempotencyKey: Type.Optional(SkillUploadIdempotencyKeyString)
+}, { additionalProperties: false });
+const SkillsUploadChunkParamsSchema = Type.Object({
+	uploadId: NonEmptyString,
+	offset: Type.Integer({ minimum: 0 }),
+	dataBase64: SkillUploadDataBase64String
+}, { additionalProperties: false });
+const SkillsUploadCommitParamsSchema = Type.Object({
+	uploadId: NonEmptyString,
+	sha256: Type.Optional(Sha256String)
+}, { additionalProperties: false });
+const SkillsInstallParamsSchema = Type.Union([
+	Type.Object({
+		name: NonEmptyString,
+		installId: NonEmptyString,
+		dangerouslyForceUnsafeInstall: Type.Optional(Type.Boolean()),
+		timeoutMs: Type.Optional(Type.Integer({ minimum: 1e3 }))
+	}, { additionalProperties: false }),
+	Type.Object({
+		source: Type.Literal("clawhub"),
+		slug: NonEmptyString,
+		version: Type.Optional(NonEmptyString),
+		force: Type.Optional(Type.Boolean()),
+		timeoutMs: Type.Optional(Type.Integer({ minimum: 1e3 }))
+	}, { additionalProperties: false }),
+	Type.Object({
+		source: Type.Literal("upload"),
+		uploadId: NonEmptyString,
+		slug: NonEmptyString,
+		force: Type.Optional(Type.Boolean()),
+		sha256: Type.Optional(Sha256String),
+		timeoutMs: Type.Optional(Type.Integer({ minimum: 1e3 }))
+	}, { additionalProperties: false })
+]);
+const SkillsUpdateParamsSchema = Type.Union([Type.Object({
+	skillKey: NonEmptyString,
+	enabled: Type.Optional(Type.Boolean()),
+	apiKey: Type.Optional(Type.String()),
+	env: Type.Optional(Type.Record(NonEmptyString, Type.String()))
+}, { additionalProperties: false }), Type.Object({
+	source: Type.Literal("clawhub"),
+	slug: Type.Optional(NonEmptyString),
+	all: Type.Optional(Type.Boolean())
+}, { additionalProperties: false })]);
+const SkillsSearchParamsSchema = Type.Object({
+	query: Type.Optional(NonEmptyString),
+	limit: Type.Optional(Type.Integer({
+		minimum: 1,
+		maximum: 100
+	}))
+}, { additionalProperties: false });
+const SkillsSearchResultSchema = Type.Object({ results: Type.Array(Type.Object({
+	score: Type.Number(),
+	slug: NonEmptyString,
+	displayName: NonEmptyString,
+	summary: Type.Optional(Type.String()),
+	version: Type.Optional(NonEmptyString),
+	updatedAt: Type.Optional(Type.Integer())
+}, { additionalProperties: false })) }, { additionalProperties: false });
+const SkillsDetailParamsSchema = Type.Object({ slug: NonEmptyString }, { additionalProperties: false });
+const SkillsDetailResultSchema = Type.Object({
+	skill: Type.Union([Type.Object({
+		slug: NonEmptyString,
+		displayName: NonEmptyString,
+		summary: Type.Optional(Type.String()),
+		tags: Type.Optional(Type.Record(NonEmptyString, Type.String())),
+		createdAt: Type.Integer(),
+		updatedAt: Type.Integer()
+	}, { additionalProperties: false }), Type.Null()]),
+	latestVersion: Type.Optional(Type.Union([Type.Object({
+		version: NonEmptyString,
+		createdAt: Type.Integer(),
+		changelog: Type.Optional(Type.String())
+	}, { additionalProperties: false }), Type.Null()])),
+	metadata: Type.Optional(Type.Union([Type.Object({
+		os: Type.Optional(Type.Union([Type.Array(Type.String()), Type.Null()])),
+		systems: Type.Optional(Type.Union([Type.Array(Type.String()), Type.Null()]))
+	}, { additionalProperties: false }), Type.Null()])),
+	owner: Type.Optional(Type.Union([Type.Object({
+		handle: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+		displayName: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+		image: Type.Optional(Type.Union([Type.String(), Type.Null()]))
+	}, { additionalProperties: false }), Type.Null()]))
+}, { additionalProperties: false });
+const ToolsCatalogParamsSchema = Type.Object({
+	agentId: Type.Optional(NonEmptyString),
+	includePlugins: Type.Optional(Type.Boolean())
+}, { additionalProperties: false });
+const ToolsEffectiveParamsSchema = Type.Object({
+	agentId: Type.Optional(NonEmptyString),
+	sessionKey: NonEmptyString
+}, { additionalProperties: false });
+const ToolsInvokeParamsSchema = Type.Object({
+	name: NonEmptyString,
+	args: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+	sessionKey: Type.Optional(NonEmptyString),
+	agentId: Type.Optional(NonEmptyString),
+	confirm: Type.Optional(Type.Boolean()),
+	idempotencyKey: Type.Optional(NonEmptyString)
+}, { additionalProperties: false });
+const ToolCatalogProfileSchema = Type.Object({
+	id: Type.Union([
+		Type.Literal("minimal"),
+		Type.Literal("coding"),
+		Type.Literal("messaging"),
+		Type.Literal("full")
+	]),
+	label: NonEmptyString
+}, { additionalProperties: false });
+const ToolCatalogEntrySchema = Type.Object({
+	id: NonEmptyString,
+	label: NonEmptyString,
+	description: Type.String(),
+	source: Type.Union([Type.Literal("core"), Type.Literal("plugin")]),
+	pluginId: Type.Optional(NonEmptyString),
+	optional: Type.Optional(Type.Boolean()),
+	risk: Type.Optional(Type.Union([
+		Type.Literal("low"),
+		Type.Literal("medium"),
+		Type.Literal("high")
+	])),
+	tags: Type.Optional(Type.Array(NonEmptyString)),
+	defaultProfiles: Type.Array(Type.Union([
+		Type.Literal("minimal"),
+		Type.Literal("coding"),
+		Type.Literal("messaging"),
+		Type.Literal("full")
+	]))
+}, { additionalProperties: false });
+const ToolCatalogGroupSchema = Type.Object({
+	id: NonEmptyString,
+	label: NonEmptyString,
+	source: Type.Union([Type.Literal("core"), Type.Literal("plugin")]),
+	pluginId: Type.Optional(NonEmptyString),
+	tools: Type.Array(ToolCatalogEntrySchema)
+}, { additionalProperties: false });
+const ToolsCatalogResultSchema = Type.Object({
+	agentId: NonEmptyString,
+	profiles: Type.Array(ToolCatalogProfileSchema),
+	groups: Type.Array(ToolCatalogGroupSchema)
+}, { additionalProperties: false });
+const ToolsEffectiveEntrySchema = Type.Object({
+	id: NonEmptyString,
+	label: NonEmptyString,
+	description: Type.String(),
+	rawDescription: Type.String(),
+	source: Type.Union([
+		Type.Literal("core"),
+		Type.Literal("plugin"),
+		Type.Literal("channel")
+	]),
+	pluginId: Type.Optional(NonEmptyString),
+	channelId: Type.Optional(NonEmptyString),
+	risk: Type.Optional(Type.Union([
+		Type.Literal("low"),
+		Type.Literal("medium"),
+		Type.Literal("high")
+	])),
+	tags: Type.Optional(Type.Array(NonEmptyString))
+}, { additionalProperties: false });
+const ToolsEffectiveGroupSchema = Type.Object({
+	id: Type.Union([
+		Type.Literal("core"),
+		Type.Literal("plugin"),
+		Type.Literal("channel")
+	]),
+	label: NonEmptyString,
+	source: Type.Union([
+		Type.Literal("core"),
+		Type.Literal("plugin"),
+		Type.Literal("channel")
+	]),
+	tools: Type.Array(ToolsEffectiveEntrySchema)
+}, { additionalProperties: false });
+const ToolsEffectiveResultSchema = Type.Object({
+	agentId: NonEmptyString,
+	profile: NonEmptyString,
+	groups: Type.Array(ToolsEffectiveGroupSchema)
+}, { additionalProperties: false });
+const ToolsInvokeErrorSchema = Type.Object({
+	code: NonEmptyString,
+	message: NonEmptyString,
+	details: Type.Optional(Type.Unknown())
+}, { additionalProperties: false });
+const ToolsInvokeResultSchema = Type.Object({
+	ok: Type.Boolean(),
+	toolName: NonEmptyString,
+	output: Type.Optional(Type.Unknown()),
+	requiresApproval: Type.Optional(Type.Boolean()),
+	approvalId: Type.Optional(NonEmptyString),
+	source: Type.Optional(Type.Union([
+		Type.Literal("core"),
+		Type.Literal("plugin"),
+		Type.Literal("mcp"),
+		Type.Literal("channel"),
+		Type.String()
+	])),
+	error: Type.Optional(ToolsInvokeErrorSchema)
+}, { additionalProperties: false });
+//#endregion
+//#region src/gateway/protocol/schema/artifacts.ts
+const ArtifactQueryParamsProperties = {
+	sessionKey: Type.Optional(NonEmptyString),
+	runId: Type.Optional(NonEmptyString),
+	taskId: Type.Optional(NonEmptyString)
+};
+const ArtifactQueryParamsSchema = Type.Object(ArtifactQueryParamsProperties, { additionalProperties: false });
+const ArtifactGetParamsSchema = Type.Object({
+	...ArtifactQueryParamsProperties,
+	artifactId: NonEmptyString
+}, { additionalProperties: false });
+const ArtifactSummarySchema = Type.Object({
+	id: NonEmptyString,
+	type: NonEmptyString,
+	title: NonEmptyString,
+	mimeType: Type.Optional(NonEmptyString),
+	sizeBytes: Type.Optional(Type.Integer({ minimum: 0 })),
+	sessionKey: Type.Optional(NonEmptyString),
+	runId: Type.Optional(NonEmptyString),
+	taskId: Type.Optional(NonEmptyString),
+	messageSeq: Type.Optional(Type.Integer({ minimum: 1 })),
+	source: Type.Optional(NonEmptyString),
+	download: Type.Object({ mode: Type.Union([
+		Type.Literal("bytes"),
+		Type.Literal("url"),
+		Type.Literal("unsupported")
+	]) }, { additionalProperties: false })
+}, { additionalProperties: false });
+const ArtifactsListParamsSchema = ArtifactQueryParamsSchema;
+const ArtifactsListResultSchema = Type.Object({ artifacts: Type.Array(ArtifactSummarySchema) }, { additionalProperties: false });
+const ArtifactsGetParamsSchema = ArtifactGetParamsSchema;
+const ArtifactsGetResultSchema = Type.Object({ artifact: ArtifactSummarySchema }, { additionalProperties: false });
+const ArtifactsDownloadParamsSchema = ArtifactGetParamsSchema;
+const ArtifactsDownloadResultSchema = Type.Object({
+	artifact: ArtifactSummarySchema,
+	encoding: Type.Optional(Type.Literal("base64")),
+	data: Type.Optional(Type.String()),
+	url: Type.Optional(NonEmptyString)
+}, { additionalProperties: false });
+//#endregion
+//#region src/gateway/protocol/schema/channels.ts
+const TalkModeParamsSchema = Type.Object({
+	enabled: Type.Boolean(),
+	phase: Type.Optional(Type.String())
+}, { additionalProperties: false });
+const TalkConfigParamsSchema = Type.Object({ includeSecrets: Type.Optional(Type.Boolean()) }, { additionalProperties: false });
+const TalkSpeakParamsSchema = Type.Object({
+	text: NonEmptyString,
+	voiceId: Type.Optional(Type.String()),
+	modelId: Type.Optional(Type.String()),
+	outputFormat: Type.Optional(Type.String()),
+	speed: Type.Optional(Type.Number()),
+	rateWpm: Type.Optional(Type.Integer({ minimum: 1 })),
+	stability: Type.Optional(Type.Number()),
+	similarity: Type.Optional(Type.Number()),
+	style: Type.Optional(Type.Number()),
+	speakerBoost: Type.Optional(Type.Boolean()),
+	seed: Type.Optional(Type.Integer({ minimum: 0 })),
+	normalize: Type.Optional(Type.String()),
+	language: Type.Optional(Type.String()),
+	latencyTier: Type.Optional(Type.Integer({ minimum: 0 }))
+}, { additionalProperties: false });
+const TalkModeSchema = Type.Union([
+	Type.Literal("realtime"),
+	Type.Literal("stt-tts"),
+	Type.Literal("transcription")
+]);
+const TalkTransportSchema = Type.Union([
+	Type.Literal("webrtc"),
+	Type.Literal("provider-websocket"),
+	Type.Literal("gateway-relay"),
+	Type.Literal("managed-room")
+]);
+const TalkBrainSchema = Type.Union([
+	Type.Literal("agent-consult"),
+	Type.Literal("direct-tools"),
+	Type.Literal("none")
+]);
+const TalkEventTypeSchema = Type.Union([
+	Type.Literal("session.started"),
+	Type.Literal("session.ready"),
+	Type.Literal("session.closed"),
+	Type.Literal("session.error"),
+	Type.Literal("session.replaced"),
+	Type.Literal("turn.started"),
+	Type.Literal("turn.ended"),
+	Type.Literal("turn.cancelled"),
+	Type.Literal("capture.started"),
+	Type.Literal("capture.stopped"),
+	Type.Literal("capture.cancelled"),
+	Type.Literal("capture.once"),
+	Type.Literal("input.audio.delta"),
+	Type.Literal("input.audio.committed"),
+	Type.Literal("transcript.delta"),
+	Type.Literal("transcript.done"),
+	Type.Literal("output.text.delta"),
+	Type.Literal("output.text.done"),
+	Type.Literal("output.audio.started"),
+	Type.Literal("output.audio.delta"),
+	Type.Literal("output.audio.done"),
+	Type.Literal("tool.call"),
+	Type.Literal("tool.progress"),
+	Type.Literal("tool.result"),
+	Type.Literal("tool.error"),
+	Type.Literal("usage.metrics"),
+	Type.Literal("latency.metrics"),
+	Type.Literal("health.changed")
+]);
+const TURN_SCOPED_TALK_EVENT_TYPES = [
+	"turn.started",
+	"turn.ended",
+	"turn.cancelled",
+	"input.audio.delta",
+	"input.audio.committed",
+	"transcript.delta",
+	"transcript.done",
+	"output.text.delta",
+	"output.text.done",
+	"output.audio.started",
+	"output.audio.delta",
+	"output.audio.done",
+	"tool.call",
+	"tool.progress",
+	"tool.result",
+	"tool.error"
+];
+const CAPTURE_SCOPED_TALK_EVENT_TYPES = [
+	"capture.started",
+	"capture.stopped",
+	"capture.cancelled",
+	"capture.once"
+];
+function requireJsonSchemaProperties(properties) {
+	const conditionalRequirementKey = ["th", "en"].join("");
+	return Object.fromEntries([[conditionalRequirementKey, { required: properties }]]);
+}
+const TalkEventSchema = Type.Object({
+	id: NonEmptyString,
+	type: TalkEventTypeSchema,
+	sessionId: NonEmptyString,
+	turnId: Type.Optional(Type.String()),
+	captureId: Type.Optional(Type.String()),
+	seq: Type.Integer({ minimum: 1 }),
+	timestamp: NonEmptyString,
+	mode: TalkModeSchema,
+	transport: TalkTransportSchema,
+	brain: TalkBrainSchema,
+	provider: Type.Optional(Type.String()),
+	final: Type.Optional(Type.Boolean()),
+	callId: Type.Optional(Type.String()),
+	itemId: Type.Optional(Type.String()),
+	parentId: Type.Optional(Type.String()),
+	payload: Type.Unknown()
+}, {
+	additionalProperties: false,
+	allOf: [{
+		if: {
+			properties: { type: { enum: TURN_SCOPED_TALK_EVENT_TYPES } },
+			required: ["type"]
+		},
+		...requireJsonSchemaProperties(["turnId"])
+	}, {
+		if: {
+			properties: { type: { enum: CAPTURE_SCOPED_TALK_EVENT_TYPES } },
+			required: ["type"]
+		},
+		...requireJsonSchemaProperties(["captureId"])
+	}]
+});
+const TalkClientCreateParamsSchema = Type.Object({
+	sessionKey: Type.Optional(Type.String()),
+	provider: Type.Optional(Type.String()),
+	model: Type.Optional(Type.String()),
+	voice: Type.Optional(Type.String()),
+	vadThreshold: Type.Optional(Type.Number()),
+	silenceDurationMs: Type.Optional(Type.Integer({ minimum: 1 })),
+	prefixPaddingMs: Type.Optional(Type.Integer({ minimum: 0 })),
+	reasoningEffort: Type.Optional(Type.String()),
+	mode: Type.Optional(TalkModeSchema),
+	transport: Type.Optional(TalkTransportSchema),
+	brain: Type.Optional(TalkBrainSchema)
+}, { additionalProperties: false });
+const TalkClientToolCallParamsSchema = Type.Object({
+	sessionKey: NonEmptyString,
+	callId: NonEmptyString,
+	name: NonEmptyString,
+	args: Type.Optional(Type.Unknown()),
+	relaySessionId: Type.Optional(NonEmptyString)
+}, { additionalProperties: false });
+const TalkClientToolCallResultSchema = Type.Object({
+	runId: NonEmptyString,
+	idempotencyKey: NonEmptyString
+}, { additionalProperties: false });
+const TalkSessionJoinParamsSchema = Type.Object({
+	sessionId: NonEmptyString,
+	token: NonEmptyString
+}, { additionalProperties: false });
+const TalkSessionCreateParamsSchema = Type.Object({
+	sessionKey: Type.Optional(Type.String()),
+	provider: Type.Optional(Type.String()),
+	model: Type.Optional(Type.String()),
+	voice: Type.Optional(Type.String()),
+	vadThreshold: Type.Optional(Type.Number()),
+	silenceDurationMs: Type.Optional(Type.Integer({ minimum: 1 })),
+	prefixPaddingMs: Type.Optional(Type.Integer({ minimum: 0 })),
+	reasoningEffort: Type.Optional(Type.String()),
+	mode: Type.Optional(TalkModeSchema),
+	transport: Type.Optional(TalkTransportSchema),
+	brain: Type.Optional(TalkBrainSchema),
+	ttlMs: Type.Optional(Type.Integer({
+		minimum: 1e3,
+		maximum: 36e5
+	}))
+}, { additionalProperties: false });
+const TalkSessionAppendAudioParamsSchema = Type.Object({
+	sessionId: NonEmptyString,
+	audioBase64: NonEmptyString,
+	timestamp: Type.Optional(Type.Number())
+}, { additionalProperties: false });
+const TalkSessionTurnParamsSchema = Type.Object({
+	sessionId: NonEmptyString,
+	turnId: Type.Optional(Type.String())
+}, { additionalProperties: false });
+const TalkSessionCancelTurnParamsSchema = Type.Object({
+	sessionId: NonEmptyString,
+	turnId: Type.Optional(Type.String()),
+	reason: Type.Optional(Type.String())
+}, { additionalProperties: false });
+const TalkSessionCancelOutputParamsSchema = Type.Object({
+	sessionId: NonEmptyString,
+	turnId: Type.Optional(Type.String()),
+	reason: Type.Optional(Type.String())
+}, { additionalProperties: false });
+const TalkSessionSubmitToolResultParamsSchema = Type.Object({
+	sessionId: NonEmptyString,
+	callId: NonEmptyString,
+	result: Type.Unknown(),
+	options: Type.Optional(Type.Object({
+		suppressResponse: Type.Optional(Type.Boolean()),
+		willContinue: Type.Optional(Type.Boolean())
+	}, { additionalProperties: false }))
+}, { additionalProperties: false });
+const TalkSessionCloseParamsSchema = Type.Object({ sessionId: NonEmptyString }, { additionalProperties: false });
+const TalkSessionManagedRoomStateSchema = Type.Object({
+	activeClientId: Type.Optional(Type.String()),
+	activeTurnId: Type.Optional(Type.String()),
+	recentTalkEvents: Type.Array(TalkEventSchema)
+}, { additionalProperties: false });
+const TalkSessionManagedRoomRecordSchema = Type.Object({
+	id: NonEmptyString,
+	roomId: NonEmptyString,
+	roomUrl: NonEmptyString,
+	sessionKey: NonEmptyString,
+	sessionId: Type.Optional(Type.String()),
+	channel: Type.Optional(Type.String()),
+	target: Type.Optional(Type.String()),
+	provider: Type.Optional(Type.String()),
+	model: Type.Optional(Type.String()),
+	voice: Type.Optional(Type.String()),
+	mode: TalkModeSchema,
+	transport: TalkTransportSchema,
+	brain: TalkBrainSchema,
+	createdAt: Type.Number(),
+	expiresAt: Type.Number(),
+	room: TalkSessionManagedRoomStateSchema
+}, { additionalProperties: false });
+const TalkCatalogParamsSchema = Type.Object({}, { additionalProperties: false });
+const TalkCatalogProviderSchema = Type.Object({
+	id: NonEmptyString,
+	label: NonEmptyString,
+	configured: Type.Boolean(),
+	models: Type.Optional(Type.Array(Type.String())),
+	voices: Type.Optional(Type.Array(Type.String())),
+	defaultModel: Type.Optional(Type.String()),
+	modes: Type.Optional(Type.Array(TalkModeSchema)),
+	transports: Type.Optional(Type.Array(TalkTransportSchema)),
+	brains: Type.Optional(Type.Array(TalkBrainSchema)),
+	inputAudioFormats: Type.Optional(Type.Array(Type.Object({
+		encoding: Type.Union([Type.Literal("pcm16"), Type.Literal("g711_ulaw")]),
+		sampleRateHz: Type.Integer({ minimum: 1 }),
+		channels: Type.Integer({ minimum: 1 })
+	}, { additionalProperties: false }))),
+	outputAudioFormats: Type.Optional(Type.Array(Type.Object({
+		encoding: Type.Union([Type.Literal("pcm16"), Type.Literal("g711_ulaw")]),
+		sampleRateHz: Type.Integer({ minimum: 1 }),
+		channels: Type.Integer({ minimum: 1 })
+	}, { additionalProperties: false }))),
+	supportsBrowserSession: Type.Optional(Type.Boolean()),
+	supportsBargeIn: Type.Optional(Type.Boolean()),
+	supportsToolCalls: Type.Optional(Type.Boolean()),
+	supportsVideoFrames: Type.Optional(Type.Boolean()),
+	supportsSessionResumption: Type.Optional(Type.Boolean())
+}, { additionalProperties: false });
+const TalkCatalogProviderGroupSchema = Type.Object({
+	activeProvider: Type.Optional(Type.String()),
+	providers: Type.Array(TalkCatalogProviderSchema)
+}, { additionalProperties: false });
+const TalkCatalogResultSchema = Type.Object({
+	modes: Type.Array(TalkModeSchema),
+	transports: Type.Array(TalkTransportSchema),
+	brains: Type.Array(TalkBrainSchema),
+	speech: TalkCatalogProviderGroupSchema,
+	transcription: TalkCatalogProviderGroupSchema,
+	realtime: TalkCatalogProviderGroupSchema
+}, { additionalProperties: false });
+const BrowserRealtimeAudioContractSchema = Type.Object({
+	inputEncoding: Type.Union([Type.Literal("pcm16"), Type.Literal("g711_ulaw")]),
+	inputSampleRateHz: Type.Integer({ minimum: 1 }),
+	outputEncoding: Type.Union([Type.Literal("pcm16"), Type.Literal("g711_ulaw")]),
+	outputSampleRateHz: Type.Integer({ minimum: 1 })
+}, { additionalProperties: false });
+const TalkSessionCreateResultSchema = Type.Object({
+	sessionId: NonEmptyString,
+	provider: Type.Optional(Type.String()),
+	mode: TalkModeSchema,
+	transport: TalkTransportSchema,
+	brain: TalkBrainSchema,
+	relaySessionId: Type.Optional(NonEmptyString),
+	transcriptionSessionId: Type.Optional(NonEmptyString),
+	handoffId: Type.Optional(NonEmptyString),
+	roomId: Type.Optional(NonEmptyString),
+	roomUrl: Type.Optional(NonEmptyString),
+	token: Type.Optional(NonEmptyString),
+	audio: Type.Optional(Type.Unknown()),
+	model: Type.Optional(Type.String()),
+	voice: Type.Optional(Type.String()),
+	expiresAt: Type.Optional(Type.Number())
+}, { additionalProperties: false });
+const TalkSessionTurnResultSchema = Type.Object({
+	ok: Type.Boolean(),
+	turnId: Type.Optional(Type.String()),
+	events: Type.Optional(Type.Array(TalkEventSchema))
+}, { additionalProperties: false });
+const TalkSessionJoinResultSchema = TalkSessionManagedRoomRecordSchema;
+const TalkSessionOkResultSchema = Type.Object({ ok: Type.Boolean() }, { additionalProperties: false });
+const BrowserRealtimeWebRtcSdpSessionSchema = Type.Object({
+	provider: NonEmptyString,
+	transport: Type.Literal("webrtc"),
+	clientSecret: NonEmptyString,
+	offerUrl: Type.Optional(Type.String()),
+	offerHeaders: Type.Optional(Type.Record(Type.String(), Type.String())),
+	model: Type.Optional(Type.String()),
+	voice: Type.Optional(Type.String()),
+	expiresAt: Type.Optional(Type.Number())
+}, { additionalProperties: false });
+const BrowserRealtimeJsonPcmWebSocketSessionSchema = Type.Object({
+	provider: NonEmptyString,
+	transport: Type.Literal("provider-websocket"),
+	protocol: NonEmptyString,
+	clientSecret: NonEmptyString,
+	websocketUrl: NonEmptyString,
+	audio: BrowserRealtimeAudioContractSchema,
+	initialMessage: Type.Optional(Type.Unknown()),
+	model: Type.Optional(Type.String()),
+	voice: Type.Optional(Type.String()),
+	expiresAt: Type.Optional(Type.Number())
+}, { additionalProperties: false });
+const BrowserRealtimeGatewayRelaySessionSchema = Type.Object({
+	provider: NonEmptyString,
+	transport: Type.Literal("gateway-relay"),
+	relaySessionId: NonEmptyString,
+	audio: BrowserRealtimeAudioContractSchema,
+	model: Type.Optional(Type.String()),
+	voice: Type.Optional(Type.String()),
+	expiresAt: Type.Optional(Type.Number())
+}, { additionalProperties: false });
+const BrowserRealtimeManagedRoomSessionSchema = Type.Object({
+	provider: NonEmptyString,
+	transport: Type.Literal("managed-room"),
+	roomUrl: NonEmptyString,
+	token: Type.Optional(Type.String()),
+	model: Type.Optional(Type.String()),
+	voice: Type.Optional(Type.String()),
+	expiresAt: Type.Optional(Type.Number())
+}, { additionalProperties: false });
+const TalkClientCreateResultSchema = Type.Union([
+	BrowserRealtimeWebRtcSdpSessionSchema,
+	BrowserRealtimeJsonPcmWebSocketSessionSchema,
+	BrowserRealtimeGatewayRelaySessionSchema,
+	BrowserRealtimeManagedRoomSessionSchema
+]);
+const talkProviderFieldSchemas = { apiKey: Type.Optional(SecretInputSchema) };
+const TalkProviderConfigSchema = Type.Object(talkProviderFieldSchemas, { additionalProperties: true });
+const TalkRealtimeConfigSchema = Type.Object({
+	provider: Type.Optional(Type.String()),
+	providers: Type.Optional(Type.Record(Type.String(), TalkProviderConfigSchema)),
+	model: Type.Optional(Type.String()),
+	voice: Type.Optional(Type.String()),
+	instructions: Type.Optional(Type.String()),
+	mode: Type.Optional(TalkModeSchema),
+	transport: Type.Optional(TalkTransportSchema),
+	brain: Type.Optional(TalkBrainSchema)
+}, { additionalProperties: false });
+const ResolvedTalkConfigSchema = Type.Object({
+	provider: Type.String(),
+	config: TalkProviderConfigSchema
+}, { additionalProperties: false });
+const TalkConfigSchema = Type.Object({
+	provider: Type.Optional(Type.String()),
+	providers: Type.Optional(Type.Record(Type.String(), TalkProviderConfigSchema)),
+	realtime: Type.Optional(TalkRealtimeConfigSchema),
+	resolved: Type.Optional(ResolvedTalkConfigSchema),
+	consultThinkingLevel: Type.Optional(Type.String()),
+	consultFastMode: Type.Optional(Type.Boolean()),
+	speechLocale: Type.Optional(Type.String()),
+	interruptOnSpeech: Type.Optional(Type.Boolean()),
+	silenceTimeoutMs: Type.Optional(Type.Integer({ minimum: 1 }))
+}, { additionalProperties: false });
+const TalkConfigResultSchema = Type.Object({ config: Type.Object({
+	talk: Type.Optional(TalkConfigSchema),
+	session: Type.Optional(Type.Object({ mainKey: Type.Optional(Type.String()) }, { additionalProperties: false })),
+	ui: Type.Optional(Type.Object({ seamColor: Type.Optional(Type.String()) }, { additionalProperties: false }))
+}, { additionalProperties: false }) }, { additionalProperties: false });
+const TalkSpeakResultSchema = Type.Object({
+	audioBase64: NonEmptyString,
+	provider: NonEmptyString,
+	outputFormat: Type.Optional(Type.String()),
+	voiceCompatible: Type.Optional(Type.Boolean()),
+	mimeType: Type.Optional(Type.String()),
+	fileExtension: Type.Optional(Type.String())
+}, { additionalProperties: false });
+const ChannelsStatusParamsSchema = Type.Object({
+	probe: Type.Optional(Type.Boolean()),
+	timeoutMs: Type.Optional(Type.Integer({ minimum: 0 }))
+}, { additionalProperties: false });
+const ChannelAccountSnapshotSchema = Type.Object({
+	accountId: NonEmptyString,
+	name: Type.Optional(Type.String()),
+	enabled: Type.Optional(Type.Boolean()),
+	configured: Type.Optional(Type.Boolean()),
+	linked: Type.Optional(Type.Boolean()),
+	running: Type.Optional(Type.Boolean()),
+	connected: Type.Optional(Type.Boolean()),
+	reconnectAttempts: Type.Optional(Type.Integer({ minimum: 0 })),
+	lastConnectedAt: Type.Optional(Type.Integer({ minimum: 0 })),
+	lastError: Type.Optional(Type.String()),
+	healthState: Type.Optional(Type.String()),
+	lastStartAt: Type.Optional(Type.Integer({ minimum: 0 })),
+	lastStopAt: Type.Optional(Type.Integer({ minimum: 0 })),
+	lastInboundAt: Type.Optional(Type.Integer({ minimum: 0 })),
+	lastOutboundAt: Type.Optional(Type.Integer({ minimum: 0 })),
+	lastTransportActivityAt: Type.Optional(Type.Integer({ minimum: 0 })),
+	busy: Type.Optional(Type.Boolean()),
+	activeRuns: Type.Optional(Type.Integer({ minimum: 0 })),
+	lastRunActivityAt: Type.Optional(Type.Integer({ minimum: 0 })),
+	lastProbeAt: Type.Optional(Type.Integer({ minimum: 0 })),
+	mode: Type.Optional(Type.String()),
+	dmPolicy: Type.Optional(Type.String()),
+	allowFrom: Type.Optional(Type.Array(Type.String())),
+	tokenSource: Type.Optional(Type.String()),
+	botTokenSource: Type.Optional(Type.String()),
+	appTokenSource: Type.Optional(Type.String()),
+	baseUrl: Type.Optional(Type.String()),
+	allowUnmentionedGroups: Type.Optional(Type.Boolean()),
+	cliPath: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+	dbPath: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+	port: Type.Optional(Type.Union([Type.Integer({ minimum: 0 }), Type.Null()])),
+	probe: Type.Optional(Type.Unknown()),
+	audit: Type.Optional(Type.Unknown()),
+	application: Type.Optional(Type.Unknown())
+}, { additionalProperties: true });
+const ChannelUiMetaSchema = Type.Object({
+	id: NonEmptyString,
+	label: NonEmptyString,
+	detailLabel: NonEmptyString,
+	systemImage: Type.Optional(Type.String())
+}, { additionalProperties: false });
+const ChannelEventLoopHealthSchema = Type.Object({
+	degraded: Type.Boolean(),
+	reasons: Type.Array(Type.Union([
+		Type.Literal("event_loop_delay"),
+		Type.Literal("event_loop_utilization"),
+		Type.Literal("cpu")
+	])),
+	intervalMs: Type.Integer({ minimum: 0 }),
+	delayP99Ms: Type.Number({ minimum: 0 }),
+	delayMaxMs: Type.Number({ minimum: 0 }),
+	utilization: Type.Number({ minimum: 0 }),
+	cpuCoreRatio: Type.Number({ minimum: 0 })
+}, { additionalProperties: false });
+const ChannelsStatusResultSchema = Type.Object({
+	ts: Type.Integer({ minimum: 0 }),
+	channelOrder: Type.Array(NonEmptyString),
+	channelLabels: Type.Record(NonEmptyString, NonEmptyString),
+	channelDetailLabels: Type.Optional(Type.Record(NonEmptyString, NonEmptyString)),
+	channelSystemImages: Type.Optional(Type.Record(NonEmptyString, NonEmptyString)),
+	channelMeta: Type.Optional(Type.Array(ChannelUiMetaSchema)),
+	channels: Type.Record(NonEmptyString, Type.Unknown()),
+	channelAccounts: Type.Record(NonEmptyString, Type.Array(ChannelAccountSnapshotSchema)),
+	channelDefaultAccountId: Type.Record(NonEmptyString, NonEmptyString),
+	eventLoop: Type.Optional(ChannelEventLoopHealthSchema),
+	partial: Type.Optional(Type.Boolean()),
+	warnings: Type.Optional(Type.Array(Type.String()))
+}, { additionalProperties: false });
+const ChannelsLogoutParamsSchema = Type.Object({
+	channel: NonEmptyString,
+	accountId: Type.Optional(Type.String())
+}, { additionalProperties: false });
+const ChannelsStopParamsSchema = Type.Object({
+	channel: NonEmptyString,
+	accountId: Type.Optional(Type.String())
+}, { additionalProperties: false });
+const ChannelsStartParamsSchema = Type.Object({
+	channel: NonEmptyString,
+	accountId: Type.Optional(Type.String())
+}, { additionalProperties: false });
+const WebLoginStartParamsSchema = Type.Object({
+	force: Type.Optional(Type.Boolean()),
+	timeoutMs: Type.Optional(Type.Integer({ minimum: 0 })),
+	verbose: Type.Optional(Type.Boolean()),
+	accountId: Type.Optional(Type.String())
+}, { additionalProperties: false });
+const QrDataUrlSchema = Type.String({
+	maxLength: 16384,
+	pattern: "^data:image/png;base64,"
+});
+const WebLoginWaitParamsSchema = Type.Object({
+	timeoutMs: Type.Optional(Type.Integer({ minimum: 0 })),
+	accountId: Type.Optional(Type.String()),
+	currentQrDataUrl: Type.Optional(QrDataUrlSchema)
+}, { additionalProperties: false });
+const COMMAND_DESCRIPTION_MAX_LENGTH = 2e3;
+const BoundedNonEmptyString = (maxLength) => Type.String({
+	minLength: 1,
+	maxLength
+});
+const CommandSourceSchema = Type.Union([
+	Type.Literal("native"),
+	Type.Literal("skill"),
+	Type.Literal("plugin")
+]);
+const CommandScopeSchema = Type.Union([
+	Type.Literal("text"),
+	Type.Literal("native"),
+	Type.Literal("both")
+]);
+const CommandCategorySchema = Type.Union([
+	Type.Literal("session"),
+	Type.Literal("options"),
+	Type.Literal("status"),
+	Type.Literal("management"),
+	Type.Literal("media"),
+	Type.Literal("tools"),
+	Type.Literal("docks")
+]);
+const CommandArgChoiceSchema = Type.Object({
+	value: Type.String({ maxLength: 200 }),
+	label: Type.String({ maxLength: 200 })
+}, { additionalProperties: false });
+const CommandArgSchema = Type.Object({
+	name: BoundedNonEmptyString(200),
+	description: Type.String({ maxLength: 500 }),
+	type: Type.Union([
+		Type.Literal("string"),
+		Type.Literal("number"),
+		Type.Literal("boolean")
+	]),
+	required: Type.Optional(Type.Boolean()),
+	choices: Type.Optional(Type.Array(CommandArgChoiceSchema, { maxItems: 50 })),
+	dynamic: Type.Optional(Type.Boolean())
+}, { additionalProperties: false });
+const CommandEntrySchema = Type.Object({
+	name: BoundedNonEmptyString(200),
+	nativeName: Type.Optional(BoundedNonEmptyString(200)),
+	textAliases: Type.Optional(Type.Array(BoundedNonEmptyString(200), { maxItems: 20 })),
+	description: Type.String({ maxLength: COMMAND_DESCRIPTION_MAX_LENGTH }),
+	category: Type.Optional(CommandCategorySchema),
+	source: CommandSourceSchema,
+	scope: CommandScopeSchema,
+	acceptsArgs: Type.Boolean(),
+	args: Type.Optional(Type.Array(CommandArgSchema, { maxItems: 20 }))
+}, { additionalProperties: false });
+const CommandsListParamsSchema = Type.Object({
+	agentId: Type.Optional(NonEmptyString),
+	provider: Type.Optional(NonEmptyString),
+	scope: Type.Optional(CommandScopeSchema),
+	includeArgs: Type.Optional(Type.Boolean())
+}, { additionalProperties: false });
+const CommandsListResultSchema = Type.Object({ commands: Type.Array(CommandEntrySchema, { maxItems: 500 }) }, { additionalProperties: false });
+//#endregion
+//#region src/gateway/protocol/schema/config.ts
+const ConfigSchemaLookupPathString = Type.String({
+	minLength: 1,
+	maxLength: 1024,
+	pattern: "^[A-Za-z0-9_./\\[\\]\\-*]+$"
+});
+const ConfigDeliveryContextSchema = Type.Object({
+	channel: Type.Optional(Type.String()),
+	to: Type.Optional(Type.String()),
+	accountId: Type.Optional(Type.String()),
+	threadId: Type.Optional(Type.Union([Type.String(), Type.Number()]))
+}, { additionalProperties: false });
+const ConfigGetParamsSchema = Type.Object({}, { additionalProperties: false });
+const ConfigSetParamsSchema = Type.Object({
+	raw: NonEmptyString,
+	baseHash: Type.Optional(NonEmptyString)
+}, { additionalProperties: false });
+const ConfigApplyLikeParamsSchema = Type.Object({
+	raw: NonEmptyString,
+	baseHash: Type.Optional(NonEmptyString),
+	sessionKey: Type.Optional(Type.String()),
+	deliveryContext: Type.Optional(ConfigDeliveryContextSchema),
+	note: Type.Optional(Type.String()),
+	restartDelayMs: Type.Optional(Type.Integer({ minimum: 0 }))
+}, { additionalProperties: false });
+const ConfigApplyParamsSchema = ConfigApplyLikeParamsSchema;
+const ConfigPatchParamsSchema = ConfigApplyLikeParamsSchema;
+const ConfigSchemaParamsSchema = Type.Object({}, { additionalProperties: false });
+const ConfigSchemaLookupParamsSchema = Type.Object({ path: ConfigSchemaLookupPathString }, { additionalProperties: false });
+const UpdateStatusParamsSchema = Type.Object({}, { additionalProperties: false });
+const UpdateRunParamsSchema = Type.Object({
+	sessionKey: Type.Optional(Type.String()),
+	deliveryContext: Type.Optional(ConfigDeliveryContextSchema),
+	note: Type.Optional(Type.String()),
+	continuationMessage: Type.Optional(Type.String()),
+	restartDelayMs: Type.Optional(Type.Integer({ minimum: 0 })),
+	timeoutMs: Type.Optional(Type.Integer({ minimum: 1 }))
+}, { additionalProperties: false });
+const ConfigUiHintSchema = Type.Object({
+	label: Type.Optional(Type.String()),
+	help: Type.Optional(Type.String()),
+	tags: Type.Optional(Type.Array(Type.String())),
+	group: Type.Optional(Type.String()),
+	order: Type.Optional(Type.Integer()),
+	advanced: Type.Optional(Type.Boolean()),
+	sensitive: Type.Optional(Type.Boolean()),
+	placeholder: Type.Optional(Type.String()),
+	itemTemplate: Type.Optional(Type.Unknown())
+}, { additionalProperties: false });
+const ConfigSchemaResponseSchema = Type.Object({
+	schema: Type.Unknown(),
+	uiHints: Type.Record(Type.String(), ConfigUiHintSchema),
+	version: NonEmptyString,
+	generatedAt: NonEmptyString
+}, { additionalProperties: false });
+const ConfigSchemaLookupChildSchema = Type.Object({
+	key: NonEmptyString,
+	path: NonEmptyString,
+	type: Type.Optional(Type.Union([Type.String(), Type.Array(Type.String())])),
+	required: Type.Boolean(),
+	hasChildren: Type.Boolean(),
+	hint: Type.Optional(ConfigUiHintSchema),
+	hintPath: Type.Optional(Type.String())
+}, { additionalProperties: false });
+const ConfigSchemaLookupResultSchema = Type.Object({
+	path: NonEmptyString,
+	schema: Type.Unknown(),
+	hint: Type.Optional(ConfigUiHintSchema),
+	hintPath: Type.Optional(Type.String()),
+	children: Type.Array(ConfigSchemaLookupChildSchema)
+}, { additionalProperties: false });
+//#endregion
+//#region src/gateway/protocol/schema/cron.ts
+function cronAgentTurnPayloadSchema(params) {
+	return Type.Object({
+		kind: Type.Literal("agentTurn"),
+		message: params.message,
+		model: Type.Optional(Type.String()),
+		fallbacks: Type.Optional(Type.Array(Type.String())),
+		thinking: Type.Optional(Type.String()),
+		timeoutSeconds: Type.Optional(Type.Number({ minimum: 0 })),
+		allowUnsafeExternalContent: Type.Optional(Type.Boolean()),
+		lightContext: Type.Optional(Type.Boolean()),
+		toolsAllow: Type.Optional(params.toolsAllow)
+	}, { additionalProperties: false });
+}
+const CronSessionTargetSchema = Type.Union([
+	Type.Literal("main"),
+	Type.Literal("isolated"),
+	Type.Literal("current"),
+	Type.String({ pattern: "^session:.+" })
+]);
+const CronWakeModeSchema = Type.Union([Type.Literal("next-heartbeat"), Type.Literal("now")]);
+function cronRunStatusSchema(options = {}) {
+	return Type.Union([
+		Type.Literal("ok"),
+		Type.Literal("error"),
+		Type.Literal("skipped")
+	], options);
+}
+const CronRunStatusSchema = cronRunStatusSchema();
+const DeprecatedCronRunStatusSchema = cronRunStatusSchema({
+	deprecated: true,
+	description: "Deprecated alias for lastRunStatus."
+});
+const CronSortDirSchema = Type.Union([Type.Literal("asc"), Type.Literal("desc")]);
+const CronJobsEnabledFilterSchema = Type.Union([
+	Type.Literal("all"),
+	Type.Literal("enabled"),
+	Type.Literal("disabled")
+]);
+const CronJobsSortBySchema = Type.Union([
+	Type.Literal("nextRunAtMs"),
+	Type.Literal("updatedAtMs"),
+	Type.Literal("name")
+]);
+const CronRunsStatusFilterSchema = Type.Union([
+	Type.Literal("all"),
+	Type.Literal("ok"),
+	Type.Literal("error"),
+	Type.Literal("skipped")
+]);
+const CronRunsStatusValueSchema = Type.Union([
+	Type.Literal("ok"),
+	Type.Literal("error"),
+	Type.Literal("skipped")
+]);
+const CronDeliveryStatusSchema = Type.Union([
+	Type.Literal("delivered"),
+	Type.Literal("not-delivered"),
+	Type.Literal("unknown"),
+	Type.Literal("not-requested")
+]);
+const CronFailoverReasonSchema = Type.Union([
+	Type.Literal("auth"),
+	Type.Literal("format"),
+	Type.Literal("rate_limit"),
+	Type.Literal("billing"),
+	Type.Literal("server_error"),
+	Type.Literal("timeout"),
+	Type.Literal("model_not_found"),
+	Type.Literal("empty_response"),
+	Type.Literal("no_error_details"),
+	Type.Literal("unclassified"),
+	Type.Literal("unknown")
+]);
+const CronRunDiagnosticSeveritySchema = Type.Union([
+	Type.Literal("info"),
+	Type.Literal("warn"),
+	Type.Literal("error")
+]);
+const CronRunDiagnosticSourceSchema = Type.Union([
+	Type.Literal("cron-preflight"),
+	Type.Literal("cron-setup"),
+	Type.Literal("model-preflight"),
+	Type.Literal("agent-run"),
+	Type.Literal("tool"),
+	Type.Literal("exec"),
+	Type.Literal("delivery")
+]);
+const CronRunDiagnosticSchema = Type.Object({
+	ts: Type.Integer({ minimum: 0 }),
+	source: CronRunDiagnosticSourceSchema,
+	severity: CronRunDiagnosticSeveritySchema,
+	message: Type.String(),
+	toolName: Type.Optional(Type.String()),
+	exitCode: Type.Optional(Type.Union([Type.Number(), Type.Null()])),
+	truncated: Type.Optional(Type.Boolean())
+}, { additionalProperties: false });
+const CronRunDiagnosticsSchema = Type.Object({
+	summary: Type.Optional(Type.String()),
+	entries: Type.Array(CronRunDiagnosticSchema)
+}, { additionalProperties: false });
+const CronCommonOptionalFields = {
+	agentId: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+	sessionKey: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+	description: Type.Optional(Type.String()),
+	enabled: Type.Optional(Type.Boolean()),
+	deleteAfterRun: Type.Optional(Type.Boolean())
+};
+function cronIdOrJobIdParams(extraFields) {
+	return Type.Union([Type.Object({
+		id: NonEmptyString,
+		...extraFields
+	}, { additionalProperties: false }), Type.Object({
+		jobId: NonEmptyString,
+		...extraFields
+	}, { additionalProperties: false })]);
+}
+const CronRunLogJobIdSchema = Type.String({
+	minLength: 1,
+	pattern: "^[^/\\\\]+$"
+});
+const CronScheduleSchema = Type.Union([
+	Type.Object({
+		kind: Type.Literal("at"),
+		at: NonEmptyString
+	}, { additionalProperties: false }),
+	Type.Object({
+		kind: Type.Literal("every"),
+		everyMs: Type.Integer({ minimum: 1 }),
+		anchorMs: Type.Optional(Type.Integer({ minimum: 0 }))
+	}, { additionalProperties: false }),
+	Type.Object({
+		kind: Type.Literal("cron"),
+		expr: NonEmptyString,
+		tz: Type.Optional(Type.String()),
+		staggerMs: Type.Optional(Type.Integer({ minimum: 0 }))
+	}, { additionalProperties: false })
+]);
+const CronPayloadSchema = Type.Union([Type.Object({
+	kind: Type.Literal("systemEvent"),
+	text: NonEmptyString
+}, { additionalProperties: false }), cronAgentTurnPayloadSchema({
+	message: NonEmptyString,
+	toolsAllow: Type.Array(Type.String())
+})]);
+const CronPayloadPatchSchema = Type.Union([Type.Object({
+	kind: Type.Literal("systemEvent"),
+	text: Type.Optional(NonEmptyString)
+}, { additionalProperties: false }), cronAgentTurnPayloadSchema({
+	message: Type.Optional(NonEmptyString),
+	toolsAllow: Type.Union([Type.Array(Type.String()), Type.Null()])
+})]);
+const CronFailureAlertSchema = Type.Object({
+	after: Type.Optional(Type.Integer({ minimum: 1 })),
+	channel: Type.Optional(Type.Union([Type.Literal("last"), NonEmptyString])),
+	to: Type.Optional(Type.String()),
+	cooldownMs: Type.Optional(Type.Integer({ minimum: 0 })),
+	includeSkipped: Type.Optional(Type.Boolean()),
+	mode: Type.Optional(Type.Union([Type.Literal("announce"), Type.Literal("webhook")])),
+	accountId: Type.Optional(NonEmptyString)
+}, { additionalProperties: false });
+const CronFailureDestinationSchema = Type.Object({
+	channel: Type.Optional(Type.Union([Type.Literal("last"), NonEmptyString])),
+	to: Type.Optional(Type.String()),
+	accountId: Type.Optional(NonEmptyString),
+	mode: Type.Optional(Type.Union([Type.Literal("announce"), Type.Literal("webhook")]))
+}, { additionalProperties: false });
+const CronDeliverySharedProperties = {
+	channel: Type.Optional(Type.Union([Type.Literal("last"), NonEmptyString])),
+	threadId: Type.Optional(Type.Union([Type.String(), Type.Number()])),
+	accountId: Type.Optional(NonEmptyString),
+	bestEffort: Type.Optional(Type.Boolean()),
+	failureDestination: Type.Optional(CronFailureDestinationSchema)
+};
+const CronDeliveryNoopSchema = Type.Object({
+	mode: Type.Literal("none"),
+	...CronDeliverySharedProperties,
+	to: Type.Optional(Type.String())
+}, { additionalProperties: false });
+const CronDeliveryAnnounceSchema = Type.Object({
+	mode: Type.Literal("announce"),
+	...CronDeliverySharedProperties,
+	to: Type.Optional(Type.String())
+}, { additionalProperties: false });
+const CronDeliveryWebhookSchema = Type.Object({
+	mode: Type.Literal("webhook"),
+	...CronDeliverySharedProperties,
+	to: NonEmptyString
+}, { additionalProperties: false });
+const CronDeliverySchema = Type.Union([
+	CronDeliveryNoopSchema,
+	CronDeliveryAnnounceSchema,
+	CronDeliveryWebhookSchema
+]);
+const CronDeliveryPatchSchema = Type.Object({
+	mode: Type.Optional(Type.Union([
+		Type.Literal("none"),
+		Type.Literal("announce"),
+		Type.Literal("webhook")
+	])),
+	...CronDeliverySharedProperties,
+	to: Type.Optional(Type.String())
+}, { additionalProperties: false });
+const CronJobStateSchema = Type.Object({
+	nextRunAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+	runningAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+	lastRunAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+	lastRunStatus: Type.Optional(CronRunStatusSchema),
+	lastStatus: Type.Optional(DeprecatedCronRunStatusSchema),
+	lastError: Type.Optional(Type.String()),
+	lastDiagnostics: Type.Optional(CronRunDiagnosticsSchema),
+	lastDiagnosticSummary: Type.Optional(Type.String()),
+	lastErrorReason: Type.Optional(CronFailoverReasonSchema),
+	lastDurationMs: Type.Optional(Type.Integer({ minimum: 0 })),
+	consecutiveErrors: Type.Optional(Type.Integer({ minimum: 0 })),
+	consecutiveSkipped: Type.Optional(Type.Integer({ minimum: 0 })),
+	lastDelivered: Type.Optional(Type.Boolean()),
+	lastDeliveryStatus: Type.Optional(CronDeliveryStatusSchema),
+	lastDeliveryError: Type.Optional(Type.String()),
+	lastFailureAlertAtMs: Type.Optional(Type.Integer({ minimum: 0 }))
+}, { additionalProperties: false });
+const CronJobStatePatchSchema = Type.Object({
+	nextRunAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+	runningAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+	lastRunAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+	lastRunStatus: Type.Optional(CronRunStatusSchema),
+	lastStatus: Type.Optional(DeprecatedCronRunStatusSchema),
+	lastError: Type.Optional(Type.String()),
+	lastErrorReason: Type.Optional(CronFailoverReasonSchema),
+	lastDurationMs: Type.Optional(Type.Integer({ minimum: 0 })),
+	consecutiveErrors: Type.Optional(Type.Integer({ minimum: 0 })),
+	consecutiveSkipped: Type.Optional(Type.Integer({ minimum: 0 })),
+	lastDelivered: Type.Optional(Type.Boolean()),
+	lastDeliveryStatus: Type.Optional(CronDeliveryStatusSchema),
+	lastDeliveryError: Type.Optional(Type.String()),
+	lastFailureAlertAtMs: Type.Optional(Type.Integer({ minimum: 0 }))
+}, { additionalProperties: false });
+const CronJobSchema = Type.Object({
+	id: NonEmptyString,
+	agentId: Type.Optional(NonEmptyString),
+	sessionKey: Type.Optional(NonEmptyString),
+	name: NonEmptyString,
+	description: Type.Optional(Type.String()),
+	enabled: Type.Boolean(),
+	deleteAfterRun: Type.Optional(Type.Boolean()),
+	createdAtMs: Type.Integer({ minimum: 0 }),
+	updatedAtMs: Type.Integer({ minimum: 0 }),
+	schedule: CronScheduleSchema,
+	sessionTarget: CronSessionTargetSchema,
+	wakeMode: CronWakeModeSchema,
+	payload: CronPayloadSchema,
+	delivery: Type.Optional(CronDeliverySchema),
+	failureAlert: Type.Optional(Type.Union([Type.Literal(false), CronFailureAlertSchema])),
+	state: CronJobStateSchema
+}, { additionalProperties: false });
+const CronListParamsSchema = Type.Object({
+	includeDisabled: Type.Optional(Type.Boolean()),
+	limit: Type.Optional(Type.Integer({
+		minimum: 1,
+		maximum: 200
+	})),
+	offset: Type.Optional(Type.Integer({ minimum: 0 })),
+	query: Type.Optional(Type.String()),
+	enabled: Type.Optional(CronJobsEnabledFilterSchema),
+	sortBy: Type.Optional(CronJobsSortBySchema),
+	sortDir: Type.Optional(CronSortDirSchema),
+	agentId: Type.Optional(NonEmptyString)
+}, { additionalProperties: false });
+const CronStatusParamsSchema = Type.Object({}, { additionalProperties: false });
+const CronAddParamsSchema = Type.Object({
+	name: NonEmptyString,
+	...CronCommonOptionalFields,
+	schedule: CronScheduleSchema,
+	sessionTarget: CronSessionTargetSchema,
+	wakeMode: CronWakeModeSchema,
+	payload: CronPayloadSchema,
+	delivery: Type.Optional(CronDeliverySchema),
+	failureAlert: Type.Optional(Type.Union([Type.Literal(false), CronFailureAlertSchema]))
+}, { additionalProperties: false });
+const CronUpdateParamsSchema = cronIdOrJobIdParams({ patch: Type.Object({
+	name: Type.Optional(NonEmptyString),
+	...CronCommonOptionalFields,
+	schedule: Type.Optional(CronScheduleSchema),
+	sessionTarget: Type.Optional(CronSessionTargetSchema),
+	wakeMode: Type.Optional(CronWakeModeSchema),
+	payload: Type.Optional(CronPayloadPatchSchema),
+	delivery: Type.Optional(CronDeliveryPatchSchema),
+	failureAlert: Type.Optional(Type.Union([Type.Literal(false), CronFailureAlertSchema])),
+	state: Type.Optional(CronJobStatePatchSchema)
+}, { additionalProperties: false }) });
+const CronRemoveParamsSchema = cronIdOrJobIdParams({});
+const CronRunParamsSchema = cronIdOrJobIdParams({ mode: Type.Optional(Type.Union([Type.Literal("due"), Type.Literal("force")])) });
+const CronRunsParamsSchema = Type.Object({
+	scope: Type.Optional(Type.Union([Type.Literal("job"), Type.Literal("all")])),
+	id: Type.Optional(CronRunLogJobIdSchema),
+	jobId: Type.Optional(CronRunLogJobIdSchema),
+	limit: Type.Optional(Type.Integer({
+		minimum: 1,
+		maximum: 200
+	})),
+	offset: Type.Optional(Type.Integer({ minimum: 0 })),
+	statuses: Type.Optional(Type.Array(CronRunsStatusValueSchema, {
+		minItems: 1,
+		maxItems: 3
+	})),
+	status: Type.Optional(CronRunsStatusFilterSchema),
+	deliveryStatuses: Type.Optional(Type.Array(CronDeliveryStatusSchema, {
+		minItems: 1,
+		maxItems: 4
+	})),
+	deliveryStatus: Type.Optional(CronDeliveryStatusSchema),
+	query: Type.Optional(Type.String()),
+	sortDir: Type.Optional(CronSortDirSchema)
+}, { additionalProperties: false });
+const CronRunLogEntrySchema = Type.Object({
+	ts: Type.Integer({ minimum: 0 }),
+	jobId: NonEmptyString,
+	action: Type.Literal("finished"),
+	status: Type.Optional(CronRunStatusSchema),
+	error: Type.Optional(Type.String()),
+	summary: Type.Optional(Type.String()),
+	diagnostics: Type.Optional(CronRunDiagnosticsSchema),
+	delivered: Type.Optional(Type.Boolean()),
+	deliveryStatus: Type.Optional(CronDeliveryStatusSchema),
+	deliveryError: Type.Optional(Type.String()),
+	sessionId: Type.Optional(NonEmptyString),
+	sessionKey: Type.Optional(NonEmptyString),
+	runId: Type.Optional(NonEmptyString),
+	runAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+	durationMs: Type.Optional(Type.Integer({ minimum: 0 })),
+	nextRunAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+	model: Type.Optional(Type.String()),
+	provider: Type.Optional(Type.String()),
+	usage: Type.Optional(Type.Object({
+		input_tokens: Type.Optional(Type.Number()),
+		output_tokens: Type.Optional(Type.Number()),
+		total_tokens: Type.Optional(Type.Number()),
+		cache_read_tokens: Type.Optional(Type.Number()),
+		cache_write_tokens: Type.Optional(Type.Number())
+	}, { additionalProperties: false })),
+	jobName: Type.Optional(Type.String())
+}, { additionalProperties: false });
+//#endregion
+//#region src/gateway/protocol/schema/error-codes.ts
+const ErrorCodes = {
+	NOT_LINKED: "NOT_LINKED",
+	NOT_PAIRED: "NOT_PAIRED",
+	AGENT_TIMEOUT: "AGENT_TIMEOUT",
+	INVALID_REQUEST: "INVALID_REQUEST",
+	APPROVAL_NOT_FOUND: "APPROVAL_NOT_FOUND",
+	UNAVAILABLE: "UNAVAILABLE"
+};
+function errorShape(code, message, opts) {
+	return {
+		code,
+		message,
+		...opts
+	};
+}
+//#endregion
+//#region src/gateway/protocol/schema/environments.ts
+const EnvironmentStatusSchema = Type.String({ enum: [
+	"available",
+	"unavailable",
+	"starting",
+	"stopping",
+	"error"
+] });
+function createEnvironmentSummarySchema() {
+	return Type.Object({
+		id: NonEmptyString,
+		type: NonEmptyString,
+		label: Type.Optional(NonEmptyString),
+		status: EnvironmentStatusSchema,
+		capabilities: Type.Optional(Type.Array(NonEmptyString))
+	}, { additionalProperties: false });
+}
+const EnvironmentSummarySchema = createEnvironmentSummarySchema();
+const EnvironmentsListParamsSchema = Type.Object({}, { additionalProperties: false });
+const EnvironmentsListResultSchema = Type.Object({ environments: Type.Array(EnvironmentSummarySchema) }, { additionalProperties: false });
+const EnvironmentsStatusParamsSchema = Type.Object({ environmentId: NonEmptyString }, { additionalProperties: false });
+const EnvironmentsStatusResultSchema = createEnvironmentSummarySchema();
+//#endregion
+//#region src/gateway/protocol/schema/exec-approvals.ts
+const ExecApprovalsAllowlistEntrySchema = Type.Object({
+	id: Type.Optional(NonEmptyString),
+	pattern: Type.String(),
+	source: Type.Optional(Type.Literal("allow-always")),
+	commandText: Type.Optional(Type.String()),
+	argPattern: Type.Optional(Type.String()),
+	lastUsedAt: Type.Optional(Type.Integer({ minimum: 0 })),
+	lastUsedCommand: Type.Optional(Type.String()),
+	lastResolvedPath: Type.Optional(Type.String())
+}, { additionalProperties: false });
+const ExecApprovalsPolicyFields = {
+	security: Type.Optional(Type.String()),
+	ask: Type.Optional(Type.String()),
+	askFallback: Type.Optional(Type.String()),
+	autoAllowSkills: Type.Optional(Type.Boolean())
+};
+const ExecApprovalsDefaultsSchema = Type.Object(ExecApprovalsPolicyFields, { additionalProperties: false });
+const ExecApprovalsAgentSchema = Type.Object({
+	...ExecApprovalsPolicyFields,
+	allowlist: Type.Optional(Type.Array(ExecApprovalsAllowlistEntrySchema))
+}, { additionalProperties: false });
+const ExecApprovalsFileSchema = Type.Object({
+	version: Type.Literal(1),
+	socket: Type.Optional(Type.Object({
+		path: Type.Optional(Type.String()),
+		token: Type.Optional(Type.String())
+	}, { additionalProperties: false })),
+	defaults: Type.Optional(ExecApprovalsDefaultsSchema),
+	agents: Type.Optional(Type.Record(Type.String(), ExecApprovalsAgentSchema))
+}, { additionalProperties: false });
+const ExecApprovalsSnapshotSchema = Type.Object({
+	path: NonEmptyString,
+	exists: Type.Boolean(),
+	hash: NonEmptyString,
+	file: ExecApprovalsFileSchema
+}, { additionalProperties: false });
+const ExecApprovalsGetParamsSchema = Type.Object({}, { additionalProperties: false });
+const ExecApprovalsSetParamsSchema = Type.Object({
+	file: ExecApprovalsFileSchema,
+	baseHash: Type.Optional(NonEmptyString)
+}, { additionalProperties: false });
+const ExecApprovalsNodeGetParamsSchema = Type.Object({ nodeId: NonEmptyString }, { additionalProperties: false });
+const ExecApprovalsNodeSetParamsSchema = Type.Object({
+	nodeId: NonEmptyString,
+	file: ExecApprovalsFileSchema,
+	baseHash: Type.Optional(NonEmptyString)
+}, { additionalProperties: false });
+const ExecApprovalGetParamsSchema = Type.Object({ id: NonEmptyString }, { additionalProperties: false });
+const ExecApprovalRequestParamsSchema = Type.Object({
+	id: Type.Optional(NonEmptyString),
+	command: Type.Optional(NonEmptyString),
+	commandArgv: Type.Optional(Type.Array(Type.String())),
+	systemRunPlan: Type.Optional(Type.Object({
+		argv: Type.Array(Type.String()),
+		cwd: Type.Union([Type.String(), Type.Null()]),
+		commandText: Type.String(),
+		commandPreview: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+		agentId: Type.Union([Type.String(), Type.Null()]),
+		sessionKey: Type.Union([Type.String(), Type.Null()]),
+		mutableFileOperand: Type.Optional(Type.Union([Type.Object({
+			argvIndex: Type.Integer({ minimum: 0 }),
+			path: Type.String(),
+			sha256: Type.String()
+		}, { additionalProperties: false }), Type.Null()]))
+	}, { additionalProperties: false })),
+	env: Type.Optional(Type.Record(NonEmptyString, Type.String())),
+	cwd: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+	nodeId: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+	host: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+	security: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+	ask: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+	warningText: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+	commandSpans: Type.Optional(Type.Array(Type.Object({
+		startIndex: Type.Integer({
+			minimum: 0,
+			description: "Inclusive UTF-16 code unit offset into command."
+		}),
+		endIndex: Type.Integer({
+			minimum: 1,
+			description: "Exclusive UTF-16 code unit offset into command; must be greater than startIndex and no greater than command.length."
+		})
+	}, { additionalProperties: false }))),
+	agentId: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+	resolvedPath: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+	sessionKey: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+	turnSourceChannel: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+	turnSourceTo: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+	turnSourceAccountId: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+	turnSourceThreadId: Type.Optional(Type.Union([
+		Type.String(),
+		Type.Number(),
+		Type.Null()
+	])),
+	timeoutMs: Type.Optional(Type.Integer({ minimum: 1 })),
+	twoPhase: Type.Optional(Type.Boolean())
+}, { additionalProperties: false });
+const ExecApprovalResolveParamsSchema = Type.Object({
+	id: NonEmptyString,
+	decision: NonEmptyString
+}, { additionalProperties: false });
+//#endregion
+//#region src/gateway/protocol/schema/devices.ts
+const DevicePairListParamsSchema = Type.Object({}, { additionalProperties: false });
+const DevicePairApproveParamsSchema = Type.Object({ requestId: NonEmptyString }, { additionalProperties: false });
+const DevicePairRejectParamsSchema = Type.Object({ requestId: NonEmptyString }, { additionalProperties: false });
+const DevicePairRemoveParamsSchema = Type.Object({ deviceId: NonEmptyString }, { additionalProperties: false });
+const DeviceTokenRotateParamsSchema = Type.Object({
+	deviceId: NonEmptyString,
+	role: NonEmptyString,
+	scopes: Type.Optional(Type.Array(NonEmptyString))
+}, { additionalProperties: false });
+const DeviceTokenRevokeParamsSchema = Type.Object({
+	deviceId: NonEmptyString,
+	role: NonEmptyString
+}, { additionalProperties: false });
+const DevicePairRequestedEventSchema = Type.Object({
+	requestId: NonEmptyString,
+	deviceId: NonEmptyString,
+	publicKey: NonEmptyString,
+	displayName: Type.Optional(NonEmptyString),
+	platform: Type.Optional(NonEmptyString),
+	deviceFamily: Type.Optional(NonEmptyString),
+	clientId: Type.Optional(NonEmptyString),
+	clientMode: Type.Optional(NonEmptyString),
+	role: Type.Optional(NonEmptyString),
+	roles: Type.Optional(Type.Array(NonEmptyString)),
+	scopes: Type.Optional(Type.Array(NonEmptyString)),
+	remoteIp: Type.Optional(NonEmptyString),
+	silent: Type.Optional(Type.Boolean()),
+	isRepair: Type.Optional(Type.Boolean()),
+	ts: Type.Integer({ minimum: 0 })
+}, { additionalProperties: false });
+const DevicePairResolvedEventSchema = Type.Object({
+	requestId: NonEmptyString,
+	deviceId: NonEmptyString,
+	decision: NonEmptyString,
+	ts: Type.Integer({ minimum: 0 })
+}, { additionalProperties: false });
+//#endregion
+//#region src/gateway/protocol/schema/snapshot.ts
+const PresenceEntrySchema = Type.Object({
+	host: Type.Optional(NonEmptyString),
+	ip: Type.Optional(NonEmptyString),
+	version: Type.Optional(NonEmptyString),
+	platform: Type.Optional(NonEmptyString),
+	deviceFamily: Type.Optional(NonEmptyString),
+	modelIdentifier: Type.Optional(NonEmptyString),
+	mode: Type.Optional(NonEmptyString),
+	lastInputSeconds: Type.Optional(Type.Integer({ minimum: 0 })),
+	reason: Type.Optional(NonEmptyString),
+	tags: Type.Optional(Type.Array(NonEmptyString)),
+	text: Type.Optional(Type.String()),
+	ts: Type.Integer({ minimum: 0 }),
+	deviceId: Type.Optional(NonEmptyString),
+	roles: Type.Optional(Type.Array(NonEmptyString)),
+	scopes: Type.Optional(Type.Array(NonEmptyString)),
+	instanceId: Type.Optional(NonEmptyString)
+}, { additionalProperties: false });
+const HealthSnapshotSchema = Type.Any();
+const SessionDefaultsSchema = Type.Object({
+	defaultAgentId: NonEmptyString,
+	mainKey: NonEmptyString,
+	mainSessionKey: NonEmptyString,
+	scope: Type.Optional(NonEmptyString)
+}, { additionalProperties: false });
+const StateVersionSchema = Type.Object({
+	presence: Type.Integer({ minimum: 0 }),
+	health: Type.Integer({ minimum: 0 })
+}, { additionalProperties: false });
+const SnapshotSchema = Type.Object({
+	presence: Type.Array(PresenceEntrySchema),
+	health: HealthSnapshotSchema,
+	stateVersion: StateVersionSchema,
+	uptimeMs: Type.Integer({ minimum: 0 }),
+	configPath: Type.Optional(NonEmptyString),
+	stateDir: Type.Optional(NonEmptyString),
+	sessionDefaults: Type.Optional(SessionDefaultsSchema),
+	authMode: Type.Optional(Type.Union([
+		Type.Literal("none"),
+		Type.Literal("token"),
+		Type.Literal("password"),
+		Type.Literal("trusted-proxy")
+	])),
+	updateAvailable: Type.Optional(Type.Object({
+		currentVersion: NonEmptyString,
+		latestVersion: NonEmptyString,
+		channel: NonEmptyString
+	}))
+}, { additionalProperties: false });
+//#endregion
+//#region src/gateway/protocol/schema/frames.ts
+const TickEventSchema = Type.Object({ ts: Type.Integer({ minimum: 0 }) }, { additionalProperties: false });
+const ShutdownEventSchema = Type.Object({
+	reason: NonEmptyString,
+	restartExpectedMs: Type.Optional(Type.Integer({ minimum: 0 }))
+}, { additionalProperties: false });
+const ConnectParamsSchema = Type.Object({
+	minProtocol: Type.Integer({ minimum: 1 }),
+	maxProtocol: Type.Integer({ minimum: 1 }),
+	client: Type.Object({
+		id: GatewayClientIdSchema,
+		displayName: Type.Optional(NonEmptyString),
+		version: NonEmptyString,
+		platform: NonEmptyString,
+		deviceFamily: Type.Optional(NonEmptyString),
+		modelIdentifier: Type.Optional(NonEmptyString),
+		mode: GatewayClientModeSchema,
+		instanceId: Type.Optional(NonEmptyString)
+	}, { additionalProperties: false }),
+	caps: Type.Optional(Type.Array(NonEmptyString, { default: [] })),
+	commands: Type.Optional(Type.Array(NonEmptyString)),
+	permissions: Type.Optional(Type.Record(NonEmptyString, Type.Boolean())),
+	pathEnv: Type.Optional(Type.String()),
+	role: Type.Optional(NonEmptyString),
+	scopes: Type.Optional(Type.Array(NonEmptyString)),
+	device: Type.Optional(Type.Object({
+		id: NonEmptyString,
+		publicKey: NonEmptyString,
+		signature: NonEmptyString,
+		signedAt: Type.Integer({ minimum: 0 }),
+		nonce: NonEmptyString
+	}, { additionalProperties: false })),
+	auth: Type.Optional(Type.Object({
+		token: Type.Optional(Type.String()),
+		bootstrapToken: Type.Optional(Type.String()),
+		deviceToken: Type.Optional(Type.String()),
+		password: Type.Optional(Type.String())
+	}, { additionalProperties: false })),
+	locale: Type.Optional(Type.String()),
+	userAgent: Type.Optional(Type.String())
+}, { additionalProperties: false });
+const HelloOkSchema = Type.Object({
+	type: Type.Literal("hello-ok"),
+	protocol: Type.Integer({ minimum: 1 }),
+	server: Type.Object({
+		version: NonEmptyString,
+		connId: NonEmptyString
+	}, { additionalProperties: false }),
+	features: Type.Object({
+		methods: Type.Array(NonEmptyString),
+		events: Type.Array(NonEmptyString)
+	}, { additionalProperties: false }),
+	snapshot: SnapshotSchema,
+	pluginSurfaceUrls: Type.Optional(Type.Record(NonEmptyString, NonEmptyString)),
+	auth: Type.Object({
+		deviceToken: Type.Optional(NonEmptyString),
+		role: NonEmptyString,
+		scopes: Type.Array(NonEmptyString),
+		issuedAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+		deviceTokens: Type.Optional(Type.Array(Type.Object({
+			deviceToken: NonEmptyString,
+			role: NonEmptyString,
+			scopes: Type.Array(NonEmptyString),
+			issuedAtMs: Type.Integer({ minimum: 0 })
+		}, { additionalProperties: false })))
+	}, { additionalProperties: false }),
+	policy: Type.Object({
+		maxPayload: Type.Integer({ minimum: 1 }),
+		maxBufferedBytes: Type.Integer({ minimum: 1 }),
+		tickIntervalMs: Type.Integer({ minimum: 1 })
+	}, { additionalProperties: false })
+}, { additionalProperties: false });
+const ErrorShapeSchema = Type.Object({
+	code: NonEmptyString,
+	message: NonEmptyString,
+	details: Type.Optional(Type.Unknown()),
+	retryable: Type.Optional(Type.Boolean()),
+	retryAfterMs: Type.Optional(Type.Integer({ minimum: 0 }))
+}, { additionalProperties: false });
+const RequestFrameSchema = Type.Object({
+	type: Type.Literal("req"),
+	id: NonEmptyString,
+	method: NonEmptyString,
+	params: Type.Optional(Type.Unknown())
+}, { additionalProperties: false });
+const ResponseFrameSchema = Type.Object({
+	type: Type.Literal("res"),
+	id: NonEmptyString,
+	ok: Type.Boolean(),
+	payload: Type.Optional(Type.Unknown()),
+	error: Type.Optional(ErrorShapeSchema)
+}, { additionalProperties: false });
+const EventFrameSchema = Type.Object({
+	type: Type.Literal("event"),
+	event: NonEmptyString,
+	payload: Type.Optional(Type.Unknown()),
+	seq: Type.Optional(Type.Integer({ minimum: 0 })),
+	stateVersion: Type.Optional(StateVersionSchema)
+}, { additionalProperties: false });
+const GatewayFrameSchema = Type.Union([
+	RequestFrameSchema,
+	ResponseFrameSchema,
+	EventFrameSchema
+], { discriminator: "type" });
+//#endregion
+//#region src/gateway/protocol/schema/logs-chat.ts
+const LogsTailParamsSchema = Type.Object({
+	cursor: Type.Optional(Type.Integer({ minimum: 0 })),
+	limit: Type.Optional(Type.Integer({
+		minimum: 1,
+		maximum: 5e3
+	})),
+	maxBytes: Type.Optional(Type.Integer({
+		minimum: 1,
+		maximum: 1e6
+	}))
+}, { additionalProperties: false });
+const LogsTailResultSchema = Type.Object({
+	file: NonEmptyString,
+	cursor: Type.Integer({ minimum: 0 }),
+	size: Type.Integer({ minimum: 0 }),
+	lines: Type.Array(Type.String()),
+	truncated: Type.Optional(Type.Boolean()),
+	reset: Type.Optional(Type.Boolean())
+}, { additionalProperties: false });
+const ChatHistoryParamsSchema = Type.Object({
+	sessionKey: NonEmptyString,
+	limit: Type.Optional(Type.Integer({
+		minimum: 1,
+		maximum: 1e3
+	})),
+	maxChars: Type.Optional(Type.Integer({
+		minimum: 1,
+		maximum: 5e5
+	}))
+}, { additionalProperties: false });
+const ChatSendParamsSchema = Type.Object({
+	sessionKey: ChatSendSessionKeyString,
+	sessionId: Type.Optional(NonEmptyString),
+	message: Type.String(),
+	thinking: Type.Optional(Type.String()),
+	fastMode: Type.Optional(Type.Boolean()),
+	deliver: Type.Optional(Type.Boolean()),
+	originatingChannel: Type.Optional(Type.String()),
+	originatingTo: Type.Optional(Type.String()),
+	originatingAccountId: Type.Optional(Type.String()),
+	originatingThreadId: Type.Optional(Type.String()),
+	attachments: Type.Optional(Type.Array(Type.Unknown())),
+	timeoutMs: Type.Optional(Type.Integer({ minimum: 0 })),
+	systemInputProvenance: Type.Optional(InputProvenanceSchema),
+	systemProvenanceReceipt: Type.Optional(Type.String()),
+	idempotencyKey: NonEmptyString
+}, { additionalProperties: false });
+const ChatAbortParamsSchema = Type.Object({
+	sessionKey: NonEmptyString,
+	runId: Type.Optional(NonEmptyString)
+}, { additionalProperties: false });
+const ChatInjectParamsSchema = Type.Object({
+	sessionKey: NonEmptyString,
+	message: NonEmptyString,
+	label: Type.Optional(Type.String({ maxLength: 100 }))
+}, { additionalProperties: false });
+const ChatEventSchema = Type.Object({
+	runId: NonEmptyString,
+	sessionKey: NonEmptyString,
+	spawnedBy: Type.Optional(NonEmptyString),
+	seq: Type.Integer({ minimum: 0 }),
+	state: Type.Union([
+		Type.Literal("delta"),
+		Type.Literal("final"),
+		Type.Literal("aborted"),
+		Type.Literal("error")
+	]),
+	message: Type.Optional(Type.Unknown()),
+	errorMessage: Type.Optional(Type.String()),
+	errorKind: Type.Optional(Type.Union([
+		Type.Literal("refusal"),
+		Type.Literal("timeout"),
+		Type.Literal("rate_limit"),
+		Type.Literal("context_length"),
+		Type.Literal("unknown")
+	])),
+	usage: Type.Optional(Type.Unknown()),
+	stopReason: Type.Optional(Type.String())
+}, { additionalProperties: false });
+//#endregion
+//#region src/gateway/protocol/schema/nodes.ts
+const NodePendingWorkTypeSchema = Type.String({ enum: ["status.request", "location.request"] });
+const NodePendingWorkPrioritySchema = Type.String({ enum: ["normal", "high"] });
+const NodePresenceAliveReasonSchema = Type.String({ enum: [
+	"background",
+	"silent_push",
+	"bg_app_refresh",
+	"significant_location",
+	"manual",
+	"connect"
+] });
+const NodePresenceAlivePayloadSchema = Type.Object({
+	trigger: NodePresenceAliveReasonSchema,
+	sentAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+	displayName: Type.Optional(NonEmptyString),
+	version: Type.Optional(NonEmptyString),
+	platform: Type.Optional(NonEmptyString),
+	deviceFamily: Type.Optional(NonEmptyString),
+	modelIdentifier: Type.Optional(NonEmptyString),
+	pushTransport: Type.Optional(NonEmptyString)
+}, { additionalProperties: false });
+const NodeEventResultSchema = Type.Object({
+	ok: Type.Boolean(),
+	event: NonEmptyString,
+	handled: Type.Boolean(),
+	reason: Type.Optional(NonEmptyString)
+}, { additionalProperties: false });
+const NodePairRequestParamsSchema = Type.Object({
+	nodeId: NonEmptyString,
+	displayName: Type.Optional(NonEmptyString),
+	platform: Type.Optional(NonEmptyString),
+	version: Type.Optional(NonEmptyString),
+	coreVersion: Type.Optional(NonEmptyString),
+	uiVersion: Type.Optional(NonEmptyString),
+	deviceFamily: Type.Optional(NonEmptyString),
+	modelIdentifier: Type.Optional(NonEmptyString),
+	caps: Type.Optional(Type.Array(NonEmptyString)),
+	commands: Type.Optional(Type.Array(NonEmptyString)),
+	remoteIp: Type.Optional(NonEmptyString),
+	silent: Type.Optional(Type.Boolean())
+}, { additionalProperties: false });
+const NodePairListParamsSchema = Type.Object({}, { additionalProperties: false });
+const NodePairApproveParamsSchema = Type.Object({ requestId: NonEmptyString }, { additionalProperties: false });
+const NodePairRejectParamsSchema = Type.Object({ requestId: NonEmptyString }, { additionalProperties: false });
+const NodePairRemoveParamsSchema = Type.Object({ nodeId: NonEmptyString }, { additionalProperties: false });
+const NodePairVerifyParamsSchema = Type.Object({
+	nodeId: NonEmptyString,
+	token: NonEmptyString
+}, { additionalProperties: false });
+const NodeRenameParamsSchema = Type.Object({
+	nodeId: NonEmptyString,
+	displayName: NonEmptyString
+}, { additionalProperties: false });
+const NodeListParamsSchema = Type.Object({}, { additionalProperties: false });
+const NodePendingAckParamsSchema = Type.Object({ ids: Type.Array(NonEmptyString, { minItems: 1 }) }, { additionalProperties: false });
+const NodeDescribeParamsSchema = Type.Object({ nodeId: NonEmptyString }, { additionalProperties: false });
+const NodeInvokeParamsSchema = Type.Object({
+	nodeId: NonEmptyString,
+	command: NonEmptyString,
+	params: Type.Optional(Type.Unknown()),
+	timeoutMs: Type.Optional(Type.Integer({ minimum: 0 })),
+	idempotencyKey: NonEmptyString
+}, { additionalProperties: false });
+const NodeInvokeResultParamsSchema = Type.Object({
+	id: NonEmptyString,
+	nodeId: NonEmptyString,
+	ok: Type.Boolean(),
+	payload: Type.Optional(Type.Unknown()),
+	payloadJSON: Type.Optional(Type.String()),
+	error: Type.Optional(Type.Object({
+		code: Type.Optional(NonEmptyString),
+		message: Type.Optional(NonEmptyString)
+	}, { additionalProperties: false }))
+}, { additionalProperties: false });
+const NodeEventParamsSchema = Type.Object({
+	event: NonEmptyString,
+	payload: Type.Optional(Type.Unknown()),
+	payloadJSON: Type.Optional(Type.String())
+}, { additionalProperties: false });
+const NodePendingDrainParamsSchema = Type.Object({ maxItems: Type.Optional(Type.Integer({
+	minimum: 1,
+	maximum: 10
+})) }, { additionalProperties: false });
+const NodePendingDrainItemSchema = Type.Object({
+	id: NonEmptyString,
+	type: NodePendingWorkTypeSchema,
+	priority: Type.String({ enum: [
+		"default",
+		"normal",
+		"high"
+	] }),
+	createdAtMs: Type.Integer({ minimum: 0 }),
+	expiresAtMs: Type.Optional(Type.Union([Type.Integer({ minimum: 0 }), Type.Null()])),
+	payload: Type.Optional(Type.Record(Type.String(), Type.Unknown()))
+}, { additionalProperties: false });
+const NodePendingDrainResultSchema = Type.Object({
+	nodeId: NonEmptyString,
+	revision: Type.Integer({ minimum: 0 }),
+	items: Type.Array(NodePendingDrainItemSchema),
+	hasMore: Type.Boolean()
+}, { additionalProperties: false });
+const NodePendingEnqueueParamsSchema = Type.Object({
+	nodeId: NonEmptyString,
+	type: NodePendingWorkTypeSchema,
+	priority: Type.Optional(NodePendingWorkPrioritySchema),
+	expiresInMs: Type.Optional(Type.Integer({
+		minimum: 1e3,
+		maximum: 864e5
+	})),
+	wake: Type.Optional(Type.Boolean())
+}, { additionalProperties: false });
+const NodePendingEnqueueResultSchema = Type.Object({
+	nodeId: NonEmptyString,
+	revision: Type.Integer({ minimum: 0 }),
+	queued: NodePendingDrainItemSchema,
+	wakeTriggered: Type.Boolean()
+}, { additionalProperties: false });
+const NodeInvokeRequestEventSchema = Type.Object({
+	id: NonEmptyString,
+	nodeId: NonEmptyString,
+	command: NonEmptyString,
+	paramsJSON: Type.Optional(Type.String()),
+	timeoutMs: Type.Optional(Type.Integer({ minimum: 0 })),
+	idempotencyKey: Type.Optional(NonEmptyString)
+}, { additionalProperties: false });
+//#endregion
+//#region src/gateway/protocol/schema/plugin-approvals.ts
+const PluginApprovalRequestParamsSchema = Type.Object({
+	pluginId: Type.Optional(NonEmptyString),
+	title: Type.String({
+		minLength: 1,
+		maxLength: 80
+	}),
+	description: Type.String({
+		minLength: 1,
+		maxLength: 256
+	}),
+	severity: Type.Optional(Type.String({ enum: [
+		"info",
+		"warning",
+		"critical"
+	] })),
+	toolName: Type.Optional(Type.String()),
+	toolCallId: Type.Optional(Type.String()),
+	allowedDecisions: Type.Optional(Type.Array(Type.String({ enum: [
+		"allow-once",
+		"allow-always",
+		"deny"
+	] }), {
+		minItems: 1,
+		maxItems: 3
+	})),
+	agentId: Type.Optional(Type.String()),
+	sessionKey: Type.Optional(Type.String()),
+	turnSourceChannel: Type.Optional(Type.String()),
+	turnSourceTo: Type.Optional(Type.String()),
+	turnSourceAccountId: Type.Optional(Type.String()),
+	turnSourceThreadId: Type.Optional(Type.Union([Type.String(), Type.Number()])),
+	timeoutMs: Type.Optional(Type.Integer({
+		minimum: 1,
+		maximum: MAX_PLUGIN_APPROVAL_TIMEOUT_MS
+	})),
+	twoPhase: Type.Optional(Type.Boolean())
+}, { additionalProperties: false });
+const PluginApprovalResolveParamsSchema = Type.Object({
+	id: NonEmptyString,
+	decision: NonEmptyString
+}, { additionalProperties: false });
+//#endregion
+//#region src/gateway/protocol/schema/plugins.ts
+const PluginJsonValueSchema = Type.Unknown();
+const PluginControlUiActiveWhenSchema = Type.Object({
+	sessionExtensionNamespace: NonEmptyString,
+	valuePath: Type.Optional(NonEmptyString),
+	equals: Type.Optional(PluginJsonValueSchema)
+}, { additionalProperties: false });
+const PluginControlUiDescriptorSchema = Type.Object({
+	id: NonEmptyString,
+	pluginId: NonEmptyString,
+	pluginName: Type.Optional(NonEmptyString),
+	surface: Type.Union([
+		Type.Literal("session"),
+		Type.Literal("tool"),
+		Type.Literal("run"),
+		Type.Literal("settings"),
+		Type.Literal("chat-message"),
+		Type.Literal("chat-input-bar"),
+		Type.Literal("chat-header-chip")
+	]),
+	label: NonEmptyString,
+	description: Type.Optional(Type.String()),
+	placement: Type.Optional(Type.String()),
+	schema: Type.Optional(PluginJsonValueSchema),
+	requiredScopes: Type.Optional(Type.Array(NonEmptyString)),
+	priority: Type.Optional(Type.Number()),
+	activeWhen: Type.Optional(PluginControlUiActiveWhenSchema)
+}, { additionalProperties: false });
+const PluginsUiDescriptorsParamsSchema = Type.Object({}, { additionalProperties: false });
+const PluginsUiDescriptorsResultSchema = Type.Object({
+	ok: Type.Literal(true),
+	descriptors: Type.Array(PluginControlUiDescriptorSchema)
+}, { additionalProperties: false });
+const PluginsSessionActionParamsSchema = Type.Object({
+	pluginId: NonEmptyString,
+	actionId: NonEmptyString,
+	sessionKey: Type.Optional(NonEmptyString),
+	payload: Type.Optional(PluginJsonValueSchema)
+}, { additionalProperties: false });
+const PluginsSessionActionSuccessResultSchema = Type.Object({
+	ok: Type.Literal(true),
+	result: Type.Optional(PluginJsonValueSchema),
+	continueAgent: Type.Optional(Type.Boolean()),
+	reply: Type.Optional(PluginJsonValueSchema)
+}, { additionalProperties: false });
+const PluginsSessionActionFailureResultSchema = Type.Object({
+	ok: Type.Literal(false),
+	error: Type.String(),
+	code: Type.Optional(Type.String()),
+	details: Type.Optional(PluginJsonValueSchema)
+}, { additionalProperties: false });
+const PluginsSessionActionResultSchema = Type.Union([PluginsSessionActionSuccessResultSchema, PluginsSessionActionFailureResultSchema]);
+//#endregion
+//#region src/gateway/protocol/schema/push.ts
+const ApnsEnvironmentSchema = Type.String({ enum: ["sandbox", "production"] });
+const PushTestParamsSchema = Type.Object({
+	nodeId: NonEmptyString,
+	title: Type.Optional(Type.String()),
+	body: Type.Optional(Type.String()),
+	environment: Type.Optional(ApnsEnvironmentSchema)
+}, { additionalProperties: false });
+const PushTestResultSchema = Type.Object({
+	ok: Type.Boolean(),
+	status: Type.Integer(),
+	apnsId: Type.Optional(Type.String()),
+	reason: Type.Optional(Type.String()),
+	tokenSuffix: Type.String(),
+	topic: Type.String(),
+	environment: ApnsEnvironmentSchema,
+	transport: Type.String({ enum: ["direct", "relay"] })
+}, { additionalProperties: false });
+const WebPushKeysSchema = Type.Object({
+	p256dh: Type.String({
+		minLength: 1,
+		maxLength: 512
+	}),
+	auth: Type.String({
+		minLength: 1,
+		maxLength: 512
+	})
+}, { additionalProperties: false });
+const WebPushVapidPublicKeyParamsSchema = Type.Object({}, { additionalProperties: false });
+const WebPushSubscribeParamsSchema = Type.Object({
+	endpoint: Type.String({
+		minLength: 1,
+		maxLength: 2048,
+		pattern: "^https://"
+	}),
+	keys: WebPushKeysSchema
+}, { additionalProperties: false });
+const WebPushUnsubscribeParamsSchema = Type.Object({ endpoint: Type.String({
+	minLength: 1,
+	maxLength: 2048,
+	pattern: "^https://"
+}) }, { additionalProperties: false });
+const WebPushTestParamsSchema = Type.Object({
+	title: Type.Optional(Type.String()),
+	body: Type.Optional(Type.String())
+}, { additionalProperties: false });
+//#endregion
+//#region src/gateway/protocol/schema/secrets.ts
+const SecretsReloadParamsSchema = Type.Object({}, { additionalProperties: false });
+const SecretsResolveParamsSchema = Type.Object({
+	commandName: NonEmptyString,
+	targetIds: Type.Array(NonEmptyString)
+}, { additionalProperties: false });
+const SecretsResolveAssignmentSchema = Type.Object({
+	path: Type.Optional(NonEmptyString),
+	pathSegments: Type.Array(NonEmptyString),
+	value: Type.Unknown()
+}, { additionalProperties: false });
+const SecretsResolveResultSchema = Type.Object({
+	ok: Type.Optional(Type.Boolean()),
+	assignments: Type.Optional(Type.Array(SecretsResolveAssignmentSchema)),
+	diagnostics: Type.Optional(Type.Array(NonEmptyString)),
+	inactiveRefPaths: Type.Optional(Type.Array(NonEmptyString))
+}, { additionalProperties: false });
+//#endregion
+//#region src/gateway/protocol/schema/sessions.ts
+const SessionCompactionCheckpointReasonSchema = Type.Union([
+	Type.Literal("manual"),
+	Type.Literal("auto-threshold"),
+	Type.Literal("overflow-retry"),
+	Type.Literal("timeout-retry")
+]);
+const SessionCompactionTranscriptReferenceSchema = Type.Object({
+	sessionId: NonEmptyString,
+	sessionFile: Type.Optional(NonEmptyString),
+	leafId: Type.Optional(NonEmptyString),
+	entryId: Type.Optional(NonEmptyString)
+}, { additionalProperties: false });
+const SessionCompactionCheckpointSchema = Type.Object({
+	checkpointId: NonEmptyString,
+	sessionKey: NonEmptyString,
+	sessionId: NonEmptyString,
+	createdAt: Type.Integer({ minimum: 0 }),
+	reason: SessionCompactionCheckpointReasonSchema,
+	tokensBefore: Type.Optional(Type.Integer({ minimum: 0 })),
+	tokensAfter: Type.Optional(Type.Integer({ minimum: 0 })),
+	summary: Type.Optional(Type.String()),
+	firstKeptEntryId: Type.Optional(NonEmptyString),
+	preCompaction: SessionCompactionTranscriptReferenceSchema,
+	postCompaction: SessionCompactionTranscriptReferenceSchema
+}, { additionalProperties: false });
+const SessionsListParamsSchema = Type.Object({
+	/**
+	* Maximum rows to return. Omitted Gateway RPC calls use a bounded default
+	* to keep large session stores from monopolizing the event loop.
+	*/
+	limit: Type.Optional(Type.Integer({ minimum: 1 })),
+	activeMinutes: Type.Optional(Type.Integer({ minimum: 1 })),
+	includeGlobal: Type.Optional(Type.Boolean()),
+	includeUnknown: Type.Optional(Type.Boolean()),
+	/**
+	* Limit returned agent-scoped rows to agents currently present in config.
+	* Broad disk discovery remains the default for recovery/ACP consumers.
+	*/
+	configuredAgentsOnly: Type.Optional(Type.Boolean()),
+	/**
+	* Read first 8KB of each session transcript to derive title from first user message.
+	* Performs a file read per session - use `limit` to bound result set on large stores.
+	*/
+	includeDerivedTitles: Type.Optional(Type.Boolean()),
+	/**
+	* Read last 16KB of each session transcript to extract most recent message preview.
+	* Performs a file read per session - use `limit` to bound result set on large stores.
+	*/
+	includeLastMessage: Type.Optional(Type.Boolean()),
+	label: Type.Optional(SessionLabelString),
+	spawnedBy: Type.Optional(NonEmptyString),
+	agentId: Type.Optional(NonEmptyString),
+	search: Type.Optional(Type.String())
+}, { additionalProperties: false });
+const SessionsCleanupParamsSchema = Type.Object({
+	agent: Type.Optional(NonEmptyString),
+	allAgents: Type.Optional(Type.Boolean()),
+	enforce: Type.Optional(Type.Boolean()),
+	activeKey: Type.Optional(NonEmptyString),
+	fixMissing: Type.Optional(Type.Boolean()),
+	fixDmScope: Type.Optional(Type.Boolean())
+}, { additionalProperties: false });
+const SessionsPreviewParamsSchema = Type.Object({
+	keys: Type.Array(NonEmptyString, { minItems: 1 }),
+	limit: Type.Optional(Type.Integer({ minimum: 1 })),
+	maxChars: Type.Optional(Type.Integer({ minimum: 20 }))
+}, { additionalProperties: false });
+const SessionsDescribeParamsSchema = Type.Object({
+	key: NonEmptyString,
+	includeDerivedTitles: Type.Optional(Type.Boolean()),
+	includeLastMessage: Type.Optional(Type.Boolean())
+}, { additionalProperties: false });
+const SessionsResolveParamsSchema = Type.Object({
+	key: Type.Optional(NonEmptyString),
+	sessionId: Type.Optional(NonEmptyString),
+	label: Type.Optional(SessionLabelString),
+	agentId: Type.Optional(NonEmptyString),
+	spawnedBy: Type.Optional(NonEmptyString),
+	includeGlobal: Type.Optional(Type.Boolean()),
+	includeUnknown: Type.Optional(Type.Boolean())
+}, { additionalProperties: false });
+const SessionsCreateParamsSchema = Type.Object({
+	key: Type.Optional(NonEmptyString),
+	agentId: Type.Optional(NonEmptyString),
+	label: Type.Optional(SessionLabelString),
+	model: Type.Optional(NonEmptyString),
+	parentSessionKey: Type.Optional(NonEmptyString),
+	emitCommandHooks: Type.Optional(Type.Boolean()),
+	task: Type.Optional(Type.String()),
+	message: Type.Optional(Type.String())
+}, { additionalProperties: false });
+const SessionsSendParamsSchema = Type.Object({
+	key: NonEmptyString,
+	message: Type.String(),
+	thinking: Type.Optional(Type.String()),
+	attachments: Type.Optional(Type.Array(Type.Unknown())),
+	timeoutMs: Type.Optional(Type.Integer({ minimum: 0 })),
+	idempotencyKey: Type.Optional(NonEmptyString)
+}, { additionalProperties: false });
+const SessionsMessagesSubscribeParamsSchema = Type.Object({ key: NonEmptyString }, { additionalProperties: false });
+const SessionsMessagesUnsubscribeParamsSchema = Type.Object({ key: NonEmptyString }, { additionalProperties: false });
+const SessionsAbortParamsSchema = Type.Object({
+	key: Type.Optional(NonEmptyString),
+	runId: Type.Optional(NonEmptyString)
+}, { additionalProperties: false });
+const SessionsPatchParamsSchema = Type.Object({
+	key: NonEmptyString,
+	label: Type.Optional(Type.Union([SessionLabelString, Type.Null()])),
+	thinkingLevel: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+	fastMode: Type.Optional(Type.Union([Type.Boolean(), Type.Null()])),
+	verboseLevel: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+	traceLevel: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+	reasoningLevel: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+	responseUsage: Type.Optional(Type.Union([
+		Type.Literal("off"),
+		Type.Literal("tokens"),
+		Type.Literal("full"),
+		Type.Literal("on"),
+		Type.Null()
+	])),
+	elevatedLevel: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+	execHost: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+	execSecurity: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+	execAsk: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+	execNode: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+	model: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+	spawnedBy: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+	spawnedWorkspaceDir: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+	spawnDepth: Type.Optional(Type.Union([Type.Integer({ minimum: 0 }), Type.Null()])),
+	subagentRole: Type.Optional(Type.Union([
+		Type.Literal("orchestrator"),
+		Type.Literal("leaf"),
+		Type.Null()
+	])),
+	subagentControlScope: Type.Optional(Type.Union([
+		Type.Literal("children"),
+		Type.Literal("none"),
+		Type.Null()
+	])),
+	sendPolicy: Type.Optional(Type.Union([
+		Type.Literal("allow"),
+		Type.Literal("deny"),
+		Type.Null()
+	])),
+	groupActivation: Type.Optional(Type.Union([
+		Type.Literal("mention"),
+		Type.Literal("always"),
+		Type.Null()
+	]))
+}, { additionalProperties: false });
+const SessionsPluginPatchParamsSchema = Type.Object({
+	key: NonEmptyString,
+	pluginId: NonEmptyString,
+	namespace: NonEmptyString,
+	value: Type.Optional(PluginJsonValueSchema),
+	unset: Type.Optional(Type.Boolean())
+}, { additionalProperties: false });
+const SessionsPluginPatchResultSchema = Type.Object({
+	ok: Type.Literal(true),
+	key: NonEmptyString,
+	value: Type.Optional(PluginJsonValueSchema)
+}, { additionalProperties: false });
+const SessionsResetParamsSchema = Type.Object({
+	key: NonEmptyString,
+	reason: Type.Optional(Type.Union([Type.Literal("new"), Type.Literal("reset")]))
+}, { additionalProperties: false });
+const SessionsDeleteParamsSchema = Type.Object({
+	key: NonEmptyString,
+	deleteTranscript: Type.Optional(Type.Boolean()),
+	emitLifecycleHooks: Type.Optional(Type.Boolean())
+}, { additionalProperties: false });
+const SessionsCompactParamsSchema = Type.Object({
+	key: NonEmptyString,
+	maxLines: Type.Optional(Type.Integer({ minimum: 1 }))
+}, { additionalProperties: false });
+const SessionsCompactionListParamsSchema = Type.Object({ key: NonEmptyString }, { additionalProperties: false });
+const SessionsCompactionGetParamsSchema = Type.Object({
+	key: NonEmptyString,
+	checkpointId: NonEmptyString
+}, { additionalProperties: false });
+const SessionsCompactionBranchParamsSchema = Type.Object({
+	key: NonEmptyString,
+	checkpointId: NonEmptyString
+}, { additionalProperties: false });
+const SessionsCompactionRestoreParamsSchema = Type.Object({
+	key: NonEmptyString,
+	checkpointId: NonEmptyString
+}, { additionalProperties: false });
+const SessionsCompactionListResultSchema = Type.Object({
+	ok: Type.Literal(true),
+	key: NonEmptyString,
+	checkpoints: Type.Array(SessionCompactionCheckpointSchema)
+}, { additionalProperties: false });
+const SessionsCompactionGetResultSchema = Type.Object({
+	ok: Type.Literal(true),
+	key: NonEmptyString,
+	checkpoint: SessionCompactionCheckpointSchema
+}, { additionalProperties: false });
+const SessionsCompactionBranchResultSchema = Type.Object({
+	ok: Type.Literal(true),
+	sourceKey: NonEmptyString,
+	key: NonEmptyString,
+	sessionId: NonEmptyString,
+	checkpoint: SessionCompactionCheckpointSchema,
+	entry: Type.Object({
+		sessionId: NonEmptyString,
+		updatedAt: Type.Integer({ minimum: 0 })
+	}, { additionalProperties: true })
+}, { additionalProperties: false });
+const SessionsCompactionRestoreResultSchema = Type.Object({
+	ok: Type.Literal(true),
+	key: NonEmptyString,
+	sessionId: NonEmptyString,
+	checkpoint: SessionCompactionCheckpointSchema,
+	entry: Type.Object({
+		sessionId: NonEmptyString,
+		updatedAt: Type.Integer({ minimum: 0 })
+	}, { additionalProperties: true })
+}, { additionalProperties: false });
+const SessionsUsageParamsSchema = Type.Object({
+	/** Specific session key to analyze; if omitted returns all sessions. */
+	key: Type.Optional(NonEmptyString),
+	/** Start date for range filter (YYYY-MM-DD). */
+	startDate: Type.Optional(Type.String({ pattern: "^\\d{4}-\\d{2}-\\d{2}$" })),
+	/** End date for range filter (YYYY-MM-DD). */
+	endDate: Type.Optional(Type.String({ pattern: "^\\d{4}-\\d{2}-\\d{2}$" })),
+	/** How start/end dates should be interpreted. Defaults to UTC when omitted. */
+	mode: Type.Optional(Type.Union([
+		Type.Literal("utc"),
+		Type.Literal("gateway"),
+		Type.Literal("specific")
+	])),
+	/** Preset range for usage queries when explicit start/end dates are omitted. */
+	range: Type.Optional(Type.Union([
+		Type.Literal("7d"),
+		Type.Literal("30d"),
+		Type.Literal("90d"),
+		Type.Literal("1y"),
+		Type.Literal("all")
+	])),
+	/** Usage row grouping. `family` rolls up known rotated session ids for a logical key. */
+	groupBy: Type.Optional(Type.Union([Type.Literal("instance"), Type.Literal("family")])),
+	/** Backward-compatible alias for requesting family grouping. */
+	includeHistorical: Type.Optional(Type.Boolean()),
+	/** UTC offset to use when mode is `specific` (for example, UTC-4 or UTC+5:30). */
+	utcOffset: Type.Optional(Type.String({ pattern: "^UTC[+-]\\d{1,2}(?::[0-5]\\d)?$" })),
+	/** Maximum sessions to return (default 50). */
+	limit: Type.Optional(Type.Integer({ minimum: 1 })),
+	/** Include context weight breakdown (systemPromptReport). */
+	includeContextWeight: Type.Optional(Type.Boolean())
+}, { additionalProperties: false });
+//#endregion
+//#region src/gateway/protocol/schema/tasks.ts
+const TaskLedgerStatusSchema = Type.Union([
+	Type.Literal("queued"),
+	Type.Literal("running"),
+	Type.Literal("completed"),
+	Type.Literal("failed"),
+	Type.Literal("cancelled"),
+	Type.Literal("timed_out")
+]);
+const TimestampSchema = Type.Union([Type.String(), Type.Integer({ minimum: 0 })]);
+const TaskSummarySchema = Type.Object({
+	id: NonEmptyString,
+	kind: Type.Optional(Type.String()),
+	runtime: Type.Optional(Type.String()),
+	status: TaskLedgerStatusSchema,
+	title: Type.Optional(Type.String()),
+	agentId: Type.Optional(Type.String()),
+	sessionKey: Type.Optional(Type.String()),
+	childSessionKey: Type.Optional(Type.String()),
+	ownerKey: Type.Optional(Type.String()),
+	runId: Type.Optional(Type.String()),
+	taskId: Type.Optional(Type.String()),
+	flowId: Type.Optional(Type.String()),
+	parentTaskId: Type.Optional(Type.String()),
+	sourceId: Type.Optional(Type.String()),
+	createdAt: Type.Optional(TimestampSchema),
+	updatedAt: Type.Optional(TimestampSchema),
+	startedAt: Type.Optional(TimestampSchema),
+	endedAt: Type.Optional(TimestampSchema),
+	progressSummary: Type.Optional(Type.String()),
+	terminalSummary: Type.Optional(Type.String()),
+	error: Type.Optional(Type.String())
+}, { additionalProperties: false });
+const TasksListParamsSchema = Type.Object({
+	status: Type.Optional(Type.Union([TaskLedgerStatusSchema, Type.Array(TaskLedgerStatusSchema)])),
+	agentId: Type.Optional(NonEmptyString),
+	sessionKey: Type.Optional(NonEmptyString),
+	limit: Type.Optional(Type.Integer({
+		minimum: 1,
+		maximum: 500
+	})),
+	cursor: Type.Optional(Type.String())
+}, { additionalProperties: false });
+const TasksListResultSchema = Type.Object({
+	tasks: Type.Array(TaskSummarySchema),
+	nextCursor: Type.Optional(Type.String())
+}, { additionalProperties: false });
+const TasksGetParamsSchema = Type.Object({ taskId: NonEmptyString }, { additionalProperties: false });
+const TasksGetResultSchema = Type.Object({ task: TaskSummarySchema }, { additionalProperties: false });
+const TasksCancelParamsSchema = Type.Object({
+	taskId: NonEmptyString,
+	reason: Type.Optional(Type.String())
+}, { additionalProperties: false });
+const TasksCancelResultSchema = Type.Object({
+	found: Type.Boolean(),
+	cancelled: Type.Boolean(),
+	reason: Type.Optional(Type.String()),
+	task: Type.Optional(TaskSummarySchema)
+}, { additionalProperties: false });
+//#endregion
+//#region src/gateway/protocol/schema/wizard.ts
+const WizardRunStatusSchema = Type.Union([
+	Type.Literal("running"),
+	Type.Literal("done"),
+	Type.Literal("cancelled"),
+	Type.Literal("error")
+]);
+const WizardStartParamsSchema = Type.Object({
+	mode: Type.Optional(Type.Union([Type.Literal("local"), Type.Literal("remote")])),
+	workspace: Type.Optional(Type.String())
+}, { additionalProperties: false });
+const WizardAnswerSchema = Type.Object({
+	stepId: NonEmptyString,
+	value: Type.Optional(Type.Unknown())
+}, { additionalProperties: false });
+const WizardNextParamsSchema = Type.Object({
+	sessionId: NonEmptyString,
+	answer: Type.Optional(WizardAnswerSchema)
+}, { additionalProperties: false });
+const WizardSessionIdParamsSchema = Type.Object({ sessionId: NonEmptyString }, { additionalProperties: false });
+const WizardCancelParamsSchema = WizardSessionIdParamsSchema;
+const WizardStatusParamsSchema = WizardSessionIdParamsSchema;
+const WizardStepOptionSchema = Type.Object({
+	value: Type.Unknown(),
+	label: NonEmptyString,
+	hint: Type.Optional(Type.String())
+}, { additionalProperties: false });
+const WizardStepSchema = Type.Object({
+	id: NonEmptyString,
+	type: Type.Union([
+		Type.Literal("note"),
+		Type.Literal("select"),
+		Type.Literal("text"),
+		Type.Literal("confirm"),
+		Type.Literal("multiselect"),
+		Type.Literal("progress"),
+		Type.Literal("action")
+	]),
+	title: Type.Optional(Type.String()),
+	message: Type.Optional(Type.String()),
+	format: Type.Optional(Type.Union([Type.Literal("plain")])),
+	options: Type.Optional(Type.Array(WizardStepOptionSchema)),
+	initialValue: Type.Optional(Type.Unknown()),
+	placeholder: Type.Optional(Type.String()),
+	sensitive: Type.Optional(Type.Boolean()),
+	executor: Type.Optional(Type.Union([Type.Literal("gateway"), Type.Literal("client")]))
+}, { additionalProperties: false });
+const WizardResultFields = {
+	done: Type.Boolean(),
+	step: Type.Optional(WizardStepSchema),
+	status: Type.Optional(WizardRunStatusSchema),
+	error: Type.Optional(Type.String())
+};
+const WizardNextResultSchema = Type.Object(WizardResultFields, { additionalProperties: false });
+const WizardStartResultSchema = Type.Object({
+	sessionId: NonEmptyString,
+	...WizardResultFields
+}, { additionalProperties: false });
+const WizardStatusResultSchema = Type.Object({
+	status: WizardRunStatusSchema,
+	error: Type.Optional(Type.String())
+}, { additionalProperties: false });
+//#endregion
+//#region src/gateway/protocol/schema/protocol-schemas.ts
+const ProtocolSchemas = {
+	ConnectParams: ConnectParamsSchema,
+	HelloOk: HelloOkSchema,
+	RequestFrame: RequestFrameSchema,
+	ResponseFrame: ResponseFrameSchema,
+	EventFrame: EventFrameSchema,
+	GatewayFrame: GatewayFrameSchema,
+	PresenceEntry: PresenceEntrySchema,
+	StateVersion: StateVersionSchema,
+	Snapshot: SnapshotSchema,
+	ErrorShape: ErrorShapeSchema,
+	EnvironmentStatus: EnvironmentStatusSchema,
+	EnvironmentSummary: EnvironmentSummarySchema,
+	EnvironmentsListParams: EnvironmentsListParamsSchema,
+	EnvironmentsListResult: EnvironmentsListResultSchema,
+	EnvironmentsStatusParams: EnvironmentsStatusParamsSchema,
+	EnvironmentsStatusResult: EnvironmentsStatusResultSchema,
+	AgentEvent: AgentEventSchema,
+	MessageActionParams: MessageActionParamsSchema,
+	SendParams: SendParamsSchema,
+	PollParams: PollParamsSchema,
+	AgentParams: AgentParamsSchema,
+	AgentIdentityParams: AgentIdentityParamsSchema,
+	AgentIdentityResult: AgentIdentityResultSchema,
+	AgentWaitParams: AgentWaitParamsSchema,
+	WakeParams: WakeParamsSchema,
+	NodePairRequestParams: NodePairRequestParamsSchema,
+	NodePairListParams: NodePairListParamsSchema,
+	NodePairApproveParams: NodePairApproveParamsSchema,
+	NodePairRejectParams: NodePairRejectParamsSchema,
+	NodePairRemoveParams: NodePairRemoveParamsSchema,
+	NodePairVerifyParams: NodePairVerifyParamsSchema,
+	NodeRenameParams: NodeRenameParamsSchema,
+	NodeListParams: NodeListParamsSchema,
+	NodePendingAckParams: NodePendingAckParamsSchema,
+	NodeDescribeParams: NodeDescribeParamsSchema,
+	NodeInvokeParams: NodeInvokeParamsSchema,
+	NodeInvokeResultParams: NodeInvokeResultParamsSchema,
+	NodeEventParams: NodeEventParamsSchema,
+	NodeEventResult: NodeEventResultSchema,
+	NodePresenceAlivePayload: NodePresenceAlivePayloadSchema,
+	NodePresenceAliveReason: NodePresenceAliveReasonSchema,
+	NodePendingDrainParams: NodePendingDrainParamsSchema,
+	NodePendingDrainResult: NodePendingDrainResultSchema,
+	NodePendingEnqueueParams: NodePendingEnqueueParamsSchema,
+	NodePendingEnqueueResult: NodePendingEnqueueResultSchema,
+	NodeInvokeRequestEvent: NodeInvokeRequestEventSchema,
+	PushTestParams: PushTestParamsSchema,
+	PushTestResult: PushTestResultSchema,
+	SecretsReloadParams: SecretsReloadParamsSchema,
+	SecretsResolveParams: SecretsResolveParamsSchema,
+	SecretsResolveAssignment: SecretsResolveAssignmentSchema,
+	SecretsResolveResult: SecretsResolveResultSchema,
+	SessionsListParams: SessionsListParamsSchema,
+	SessionsCleanupParams: SessionsCleanupParamsSchema,
+	SessionsPreviewParams: SessionsPreviewParamsSchema,
+	SessionsDescribeParams: SessionsDescribeParamsSchema,
+	SessionsResolveParams: SessionsResolveParamsSchema,
+	SessionCompactionCheckpoint: SessionCompactionCheckpointSchema,
+	SessionsCompactionListParams: SessionsCompactionListParamsSchema,
+	SessionsCompactionGetParams: SessionsCompactionGetParamsSchema,
+	SessionsCompactionBranchParams: SessionsCompactionBranchParamsSchema,
+	SessionsCompactionRestoreParams: SessionsCompactionRestoreParamsSchema,
+	SessionsCompactionListResult: SessionsCompactionListResultSchema,
+	SessionsCompactionGetResult: SessionsCompactionGetResultSchema,
+	SessionsCompactionBranchResult: SessionsCompactionBranchResultSchema,
+	SessionsCompactionRestoreResult: SessionsCompactionRestoreResultSchema,
+	SessionsCreateParams: SessionsCreateParamsSchema,
+	SessionsSendParams: SessionsSendParamsSchema,
+	SessionsMessagesSubscribeParams: SessionsMessagesSubscribeParamsSchema,
+	SessionsMessagesUnsubscribeParams: SessionsMessagesUnsubscribeParamsSchema,
+	SessionsAbortParams: SessionsAbortParamsSchema,
+	SessionsPatchParams: SessionsPatchParamsSchema,
+	SessionsPluginPatchParams: SessionsPluginPatchParamsSchema,
+	SessionsPluginPatchResult: SessionsPluginPatchResultSchema,
+	SessionsResetParams: SessionsResetParamsSchema,
+	SessionsDeleteParams: SessionsDeleteParamsSchema,
+	SessionsCompactParams: SessionsCompactParamsSchema,
+	SessionsUsageParams: SessionsUsageParamsSchema,
+	TaskSummary: TaskSummarySchema,
+	TasksListParams: TasksListParamsSchema,
+	TasksListResult: TasksListResultSchema,
+	TasksGetParams: TasksGetParamsSchema,
+	TasksGetResult: TasksGetResultSchema,
+	TasksCancelParams: TasksCancelParamsSchema,
+	TasksCancelResult: TasksCancelResultSchema,
+	ConfigGetParams: ConfigGetParamsSchema,
+	ConfigSetParams: ConfigSetParamsSchema,
+	ConfigApplyParams: ConfigApplyParamsSchema,
+	ConfigPatchParams: ConfigPatchParamsSchema,
+	ConfigSchemaParams: ConfigSchemaParamsSchema,
+	ConfigSchemaLookupParams: ConfigSchemaLookupParamsSchema,
+	ConfigSchemaResponse: ConfigSchemaResponseSchema,
+	ConfigSchemaLookupResult: ConfigSchemaLookupResultSchema,
+	WizardStartParams: WizardStartParamsSchema,
+	WizardNextParams: WizardNextParamsSchema,
+	WizardCancelParams: WizardCancelParamsSchema,
+	WizardStatusParams: WizardStatusParamsSchema,
+	WizardStep: WizardStepSchema,
+	WizardNextResult: WizardNextResultSchema,
+	WizardStartResult: WizardStartResultSchema,
+	WizardStatusResult: WizardStatusResultSchema,
+	TalkModeParams: TalkModeParamsSchema,
+	TalkEvent: TalkEventSchema,
+	TalkCatalogParams: TalkCatalogParamsSchema,
+	TalkCatalogResult: TalkCatalogResultSchema,
+	TalkClientCreateParams: TalkClientCreateParamsSchema,
+	TalkClientCreateResult: TalkClientCreateResultSchema,
+	TalkClientToolCallParams: TalkClientToolCallParamsSchema,
+	TalkClientToolCallResult: TalkClientToolCallResultSchema,
+	TalkConfigParams: TalkConfigParamsSchema,
+	TalkConfigResult: TalkConfigResultSchema,
+	TalkSessionAppendAudioParams: TalkSessionAppendAudioParamsSchema,
+	TalkSessionCancelOutputParams: TalkSessionCancelOutputParamsSchema,
+	TalkSessionCancelTurnParams: TalkSessionCancelTurnParamsSchema,
+	TalkSessionCreateParams: TalkSessionCreateParamsSchema,
+	TalkSessionCreateResult: TalkSessionCreateResultSchema,
+	TalkSessionJoinParams: TalkSessionJoinParamsSchema,
+	TalkSessionJoinResult: TalkSessionJoinResultSchema,
+	TalkSessionTurnParams: TalkSessionTurnParamsSchema,
+	TalkSessionTurnResult: TalkSessionTurnResultSchema,
+	TalkSessionSubmitToolResultParams: TalkSessionSubmitToolResultParamsSchema,
+	TalkSessionCloseParams: TalkSessionCloseParamsSchema,
+	TalkSessionOkResult: TalkSessionOkResultSchema,
+	TalkSpeakParams: TalkSpeakParamsSchema,
+	TalkSpeakResult: TalkSpeakResultSchema,
+	ChannelsStatusParams: ChannelsStatusParamsSchema,
+	ChannelsStatusResult: ChannelsStatusResultSchema,
+	ChannelsStartParams: ChannelsStartParamsSchema,
+	ChannelsStopParams: ChannelsStopParamsSchema,
+	ChannelsLogoutParams: ChannelsLogoutParamsSchema,
+	WebLoginStartParams: WebLoginStartParamsSchema,
+	WebLoginWaitParams: WebLoginWaitParamsSchema,
+	AgentSummary: AgentSummarySchema,
+	AgentsCreateParams: AgentsCreateParamsSchema,
+	AgentsCreateResult: AgentsCreateResultSchema,
+	AgentsUpdateParams: AgentsUpdateParamsSchema,
+	AgentsUpdateResult: AgentsUpdateResultSchema,
+	AgentsDeleteParams: AgentsDeleteParamsSchema,
+	AgentsDeleteResult: AgentsDeleteResultSchema,
+	AgentsFileEntry: AgentsFileEntrySchema,
+	AgentsFilesListParams: AgentsFilesListParamsSchema,
+	AgentsFilesListResult: AgentsFilesListResultSchema,
+	AgentsFilesGetParams: AgentsFilesGetParamsSchema,
+	AgentsFilesGetResult: AgentsFilesGetResultSchema,
+	AgentsFilesSetParams: AgentsFilesSetParamsSchema,
+	AgentsFilesSetResult: AgentsFilesSetResultSchema,
+	ArtifactSummary: ArtifactSummarySchema,
+	ArtifactsListParams: ArtifactsListParamsSchema,
+	ArtifactsListResult: ArtifactsListResultSchema,
+	ArtifactsGetParams: ArtifactsGetParamsSchema,
+	ArtifactsGetResult: ArtifactsGetResultSchema,
+	ArtifactsDownloadParams: ArtifactsDownloadParamsSchema,
+	ArtifactsDownloadResult: ArtifactsDownloadResultSchema,
+	AgentsListParams: AgentsListParamsSchema,
+	AgentsListResult: AgentsListResultSchema,
+	ModelChoice: ModelChoiceSchema,
+	ModelsListParams: ModelsListParamsSchema,
+	ModelsListResult: ModelsListResultSchema,
+	CommandEntry: CommandEntrySchema,
+	CommandsListParams: CommandsListParamsSchema,
+	CommandsListResult: CommandsListResultSchema,
+	SkillsStatusParams: SkillsStatusParamsSchema,
+	ToolsCatalogParams: ToolsCatalogParamsSchema,
+	ToolCatalogProfile: ToolCatalogProfileSchema,
+	ToolCatalogEntry: ToolCatalogEntrySchema,
+	ToolCatalogGroup: ToolCatalogGroupSchema,
+	ToolsCatalogResult: ToolsCatalogResultSchema,
+	ToolsEffectiveParams: ToolsEffectiveParamsSchema,
+	ToolsEffectiveEntry: ToolsEffectiveEntrySchema,
+	ToolsEffectiveGroup: ToolsEffectiveGroupSchema,
+	ToolsEffectiveResult: ToolsEffectiveResultSchema,
+	ToolsInvokeParams: ToolsInvokeParamsSchema,
+	ToolsInvokeError: ToolsInvokeErrorSchema,
+	ToolsInvokeResult: ToolsInvokeResultSchema,
+	SkillsBinsParams: SkillsBinsParamsSchema,
+	SkillsBinsResult: SkillsBinsResultSchema,
+	SkillsSearchParams: SkillsSearchParamsSchema,
+	SkillsSearchResult: SkillsSearchResultSchema,
+	SkillsDetailParams: SkillsDetailParamsSchema,
+	SkillsDetailResult: SkillsDetailResultSchema,
+	SkillsUploadBeginParams: SkillsUploadBeginParamsSchema,
+	SkillsUploadChunkParams: SkillsUploadChunkParamsSchema,
+	SkillsUploadCommitParams: SkillsUploadCommitParamsSchema,
+	SkillsInstallParams: SkillsInstallParamsSchema,
+	SkillsUpdateParams: SkillsUpdateParamsSchema,
+	CronJob: CronJobSchema,
+	CronListParams: CronListParamsSchema,
+	CronStatusParams: CronStatusParamsSchema,
+	CronAddParams: CronAddParamsSchema,
+	CronUpdateParams: CronUpdateParamsSchema,
+	CronRemoveParams: CronRemoveParamsSchema,
+	CronRunParams: CronRunParamsSchema,
+	CronRunsParams: CronRunsParamsSchema,
+	CronRunLogEntry: CronRunLogEntrySchema,
+	LogsTailParams: LogsTailParamsSchema,
+	LogsTailResult: LogsTailResultSchema,
+	ExecApprovalsGetParams: ExecApprovalsGetParamsSchema,
+	ExecApprovalsSetParams: ExecApprovalsSetParamsSchema,
+	ExecApprovalsNodeGetParams: ExecApprovalsNodeGetParamsSchema,
+	ExecApprovalsNodeSetParams: ExecApprovalsNodeSetParamsSchema,
+	ExecApprovalsSnapshot: ExecApprovalsSnapshotSchema,
+	ExecApprovalGetParams: ExecApprovalGetParamsSchema,
+	ExecApprovalRequestParams: ExecApprovalRequestParamsSchema,
+	ExecApprovalResolveParams: ExecApprovalResolveParamsSchema,
+	PluginApprovalRequestParams: PluginApprovalRequestParamsSchema,
+	PluginApprovalResolveParams: PluginApprovalResolveParamsSchema,
+	PluginControlUiDescriptor: PluginControlUiDescriptorSchema,
+	PluginsSessionActionFailureResult: PluginsSessionActionFailureResultSchema,
+	PluginsSessionActionParams: PluginsSessionActionParamsSchema,
+	PluginsSessionActionResult: PluginsSessionActionResultSchema,
+	PluginsSessionActionSuccessResult: PluginsSessionActionSuccessResultSchema,
+	PluginsUiDescriptorsParams: PluginsUiDescriptorsParamsSchema,
+	PluginsUiDescriptorsResult: PluginsUiDescriptorsResultSchema,
+	DevicePairListParams: DevicePairListParamsSchema,
+	DevicePairApproveParams: DevicePairApproveParamsSchema,
+	DevicePairRejectParams: DevicePairRejectParamsSchema,
+	DevicePairRemoveParams: DevicePairRemoveParamsSchema,
+	DeviceTokenRotateParams: DeviceTokenRotateParamsSchema,
+	DeviceTokenRevokeParams: DeviceTokenRevokeParamsSchema,
+	DevicePairRequestedEvent: DevicePairRequestedEventSchema,
+	DevicePairResolvedEvent: DevicePairResolvedEventSchema,
+	ChatHistoryParams: ChatHistoryParamsSchema,
+	ChatSendParams: ChatSendParamsSchema,
+	ChatAbortParams: ChatAbortParamsSchema,
+	ChatInjectParams: ChatInjectParamsSchema,
+	ChatEvent: ChatEventSchema,
+	UpdateStatusParams: UpdateStatusParamsSchema,
+	UpdateRunParams: UpdateRunParamsSchema,
+	TickEvent: TickEventSchema,
+	ShutdownEvent: ShutdownEventSchema
+};
+//#endregion
+//#region src/gateway/protocol/index.ts
+const ajv = new AjvPkg({
+	allErrors: true,
+	strict: false,
+	removeAdditional: false
+});
+const validateCommandsListParams = ajv.compile(CommandsListParamsSchema);
+const validateConnectParams = ajv.compile(ConnectParamsSchema);
+const validateRequestFrame = ajv.compile(RequestFrameSchema);
+const validateResponseFrame = ajv.compile(ResponseFrameSchema);
+const validateEventFrame = ajv.compile(EventFrameSchema);
+const validateMessageActionParams = ajv.compile(MessageActionParamsSchema);
+const validateSendParams = ajv.compile(SendParamsSchema);
+const validatePollParams = ajv.compile(PollParamsSchema);
+const validateAgentParams = ajv.compile(AgentParamsSchema);
+const validateAgentIdentityParams = ajv.compile(AgentIdentityParamsSchema);
+const validateAgentWaitParams = ajv.compile(AgentWaitParamsSchema);
+const validateWakeParams = ajv.compile(WakeParamsSchema);
+const validateAgentsListParams = ajv.compile(AgentsListParamsSchema);
+const validateAgentsCreateParams = ajv.compile(AgentsCreateParamsSchema);
+const validateAgentsUpdateParams = ajv.compile(AgentsUpdateParamsSchema);
+const validateAgentsDeleteParams = ajv.compile(AgentsDeleteParamsSchema);
+const validateAgentsFilesListParams = ajv.compile(AgentsFilesListParamsSchema);
+const validateAgentsFilesGetParams = ajv.compile(AgentsFilesGetParamsSchema);
+const validateAgentsFilesSetParams = ajv.compile(AgentsFilesSetParamsSchema);
+const validateArtifactsListParams = ajv.compile(ArtifactsListParamsSchema);
+const validateArtifactsGetParams = ajv.compile(ArtifactsGetParamsSchema);
+const validateArtifactsDownloadParams = ajv.compile(ArtifactsDownloadParamsSchema);
+const validateNodePairRequestParams = ajv.compile(NodePairRequestParamsSchema);
+const validateNodePairListParams = ajv.compile(NodePairListParamsSchema);
+const validateNodePairApproveParams = ajv.compile(NodePairApproveParamsSchema);
+const validateNodePairRejectParams = ajv.compile(NodePairRejectParamsSchema);
+const validateNodePairRemoveParams = ajv.compile(NodePairRemoveParamsSchema);
+const validateNodePairVerifyParams = ajv.compile(NodePairVerifyParamsSchema);
+const validateNodeRenameParams = ajv.compile(NodeRenameParamsSchema);
+const validateNodeListParams = ajv.compile(NodeListParamsSchema);
+const validateEnvironmentsListParams = ajv.compile(EnvironmentsListParamsSchema);
+const validateEnvironmentsStatusParams = ajv.compile(EnvironmentsStatusParamsSchema);
+const validateNodePendingAckParams = ajv.compile(NodePendingAckParamsSchema);
+const validateNodeDescribeParams = ajv.compile(NodeDescribeParamsSchema);
+const validateNodeInvokeParams = ajv.compile(NodeInvokeParamsSchema);
+const validateNodeInvokeResultParams = ajv.compile(NodeInvokeResultParamsSchema);
+const validateNodeEventParams = ajv.compile(NodeEventParamsSchema);
+const validateNodeEventResult = ajv.compile(NodeEventResultSchema);
+const validateNodePresenceAlivePayload = ajv.compile(NodePresenceAlivePayloadSchema);
+const validateNodePendingDrainParams = ajv.compile(NodePendingDrainParamsSchema);
+const validateNodePendingEnqueueParams = ajv.compile(NodePendingEnqueueParamsSchema);
+const validatePushTestParams = ajv.compile(PushTestParamsSchema);
+const validateWebPushVapidPublicKeyParams = ajv.compile(WebPushVapidPublicKeyParamsSchema);
+const validateWebPushSubscribeParams = ajv.compile(WebPushSubscribeParamsSchema);
+const validateWebPushUnsubscribeParams = ajv.compile(WebPushUnsubscribeParamsSchema);
+const validateWebPushTestParams = ajv.compile(WebPushTestParamsSchema);
+const validateSecretsResolveParams = ajv.compile(SecretsResolveParamsSchema);
+const validateSecretsResolveResult = ajv.compile(SecretsResolveResultSchema);
+const validateSessionsListParams = ajv.compile(SessionsListParamsSchema);
+const validateSessionsCleanupParams = ajv.compile(SessionsCleanupParamsSchema);
+const validateSessionsPreviewParams = ajv.compile(SessionsPreviewParamsSchema);
+const validateSessionsDescribeParams = ajv.compile(SessionsDescribeParamsSchema);
+const validateSessionsResolveParams = ajv.compile(SessionsResolveParamsSchema);
+const validateSessionsCreateParams = ajv.compile(SessionsCreateParamsSchema);
+const validateSessionsSendParams = ajv.compile(SessionsSendParamsSchema);
+const validateSessionsMessagesSubscribeParams = ajv.compile(SessionsMessagesSubscribeParamsSchema);
+const validateSessionsMessagesUnsubscribeParams = ajv.compile(SessionsMessagesUnsubscribeParamsSchema);
+const validateSessionsAbortParams = ajv.compile(SessionsAbortParamsSchema);
+const validateSessionsPatchParams = ajv.compile(SessionsPatchParamsSchema);
+const validateSessionsPluginPatchParams = ajv.compile(SessionsPluginPatchParamsSchema);
+const validateSessionsResetParams = ajv.compile(SessionsResetParamsSchema);
+const validateSessionsDeleteParams = ajv.compile(SessionsDeleteParamsSchema);
+const validateSessionsCompactParams = ajv.compile(SessionsCompactParamsSchema);
+const validateSessionsCompactionListParams = ajv.compile(SessionsCompactionListParamsSchema);
+const validateSessionsCompactionGetParams = ajv.compile(SessionsCompactionGetParamsSchema);
+const validateSessionsCompactionBranchParams = ajv.compile(SessionsCompactionBranchParamsSchema);
+const validateSessionsCompactionRestoreParams = ajv.compile(SessionsCompactionRestoreParamsSchema);
+const validateSessionsUsageParams = ajv.compile(SessionsUsageParamsSchema);
+const validateTasksListParams = ajv.compile(TasksListParamsSchema);
+const validateTasksGetParams = ajv.compile(TasksGetParamsSchema);
+const validateTasksCancelParams = ajv.compile(TasksCancelParamsSchema);
+const validateConfigGetParams = ajv.compile(ConfigGetParamsSchema);
+const validateConfigSetParams = ajv.compile(ConfigSetParamsSchema);
+const validateConfigApplyParams = ajv.compile(ConfigApplyParamsSchema);
+const validateConfigPatchParams = ajv.compile(ConfigPatchParamsSchema);
+const validateConfigSchemaParams = ajv.compile(ConfigSchemaParamsSchema);
+const validateConfigSchemaLookupParams = ajv.compile(ConfigSchemaLookupParamsSchema);
+const validateConfigSchemaLookupResult = ajv.compile(ConfigSchemaLookupResultSchema);
+const validateWizardStartParams = ajv.compile(WizardStartParamsSchema);
+const validateWizardNextParams = ajv.compile(WizardNextParamsSchema);
+const validateWizardCancelParams = ajv.compile(WizardCancelParamsSchema);
+const validateWizardStatusParams = ajv.compile(WizardStatusParamsSchema);
+const validateTalkModeParams = ajv.compile(TalkModeParamsSchema);
+const validateTalkEvent = ajv.compile(TalkEventSchema);
+const validateTalkCatalogParams = ajv.compile(TalkCatalogParamsSchema);
+const validateTalkCatalogResult = ajv.compile(TalkCatalogResultSchema);
+const validateTalkConfigParams = ajv.compile(TalkConfigParamsSchema);
+const validateTalkConfigResult = ajv.compile(TalkConfigResultSchema);
+const validateTalkClientCreateParams = ajv.compile(TalkClientCreateParamsSchema);
+const validateTalkClientCreateResult = ajv.compile(TalkClientCreateResultSchema);
+const validateTalkClientToolCallParams = ajv.compile(TalkClientToolCallParamsSchema);
+const validateTalkClientToolCallResult = ajv.compile(TalkClientToolCallResultSchema);
+const validateTalkSessionCreateParams = ajv.compile(TalkSessionCreateParamsSchema);
+const validateTalkSessionCreateResult = ajv.compile(TalkSessionCreateResultSchema);
+const validateTalkSessionJoinParams = ajv.compile(TalkSessionJoinParamsSchema);
+const validateTalkSessionJoinResult = ajv.compile(TalkSessionJoinResultSchema);
+const validateTalkSessionAppendAudioParams = ajv.compile(TalkSessionAppendAudioParamsSchema);
+const validateTalkSessionTurnParams = ajv.compile(TalkSessionTurnParamsSchema);
+const validateTalkSessionCancelTurnParams = ajv.compile(TalkSessionCancelTurnParamsSchema);
+const validateTalkSessionCancelOutputParams = ajv.compile(TalkSessionCancelOutputParamsSchema);
+const validateTalkSessionTurnResult = ajv.compile(TalkSessionTurnResultSchema);
+const validateTalkSessionSubmitToolResultParams = ajv.compile(TalkSessionSubmitToolResultParamsSchema);
+const validateTalkSessionCloseParams = ajv.compile(TalkSessionCloseParamsSchema);
+const validateTalkSessionOkResult = ajv.compile(TalkSessionOkResultSchema);
+const validateTalkSpeakParams = ajv.compile(TalkSpeakParamsSchema);
+const validateTalkSpeakResult = ajv.compile(TalkSpeakResultSchema);
+const validateChannelsStatusParams = ajv.compile(ChannelsStatusParamsSchema);
+const validateChannelsStartParams = ajv.compile(ChannelsStartParamsSchema);
+const validateChannelsStopParams = ajv.compile(ChannelsStopParamsSchema);
+const validateChannelsLogoutParams = ajv.compile(ChannelsLogoutParamsSchema);
+const validateModelsListParams = ajv.compile(ModelsListParamsSchema);
+const validateSkillsStatusParams = ajv.compile(SkillsStatusParamsSchema);
+const validateToolsCatalogParams = ajv.compile(ToolsCatalogParamsSchema);
+const validateToolsEffectiveParams = ajv.compile(ToolsEffectiveParamsSchema);
+const validateToolsInvokeParams = ajv.compile(ToolsInvokeParamsSchema);
+const validateSkillsBinsParams = ajv.compile(SkillsBinsParamsSchema);
+const validateSkillsInstallParams = ajv.compile(SkillsInstallParamsSchema);
+const validateSkillsUploadBeginParams = ajv.compile(SkillsUploadBeginParamsSchema);
+const validateSkillsUploadChunkParams = ajv.compile(SkillsUploadChunkParamsSchema);
+const validateSkillsUploadCommitParams = ajv.compile(SkillsUploadCommitParamsSchema);
+const validateSkillsUpdateParams = ajv.compile(SkillsUpdateParamsSchema);
+const validateSkillsSearchParams = ajv.compile(SkillsSearchParamsSchema);
+const validateSkillsDetailParams = ajv.compile(SkillsDetailParamsSchema);
+const validateCronListParams = ajv.compile(CronListParamsSchema);
+const validateCronStatusParams = ajv.compile(CronStatusParamsSchema);
+const validateCronAddParams = ajv.compile(CronAddParamsSchema);
+const validateCronUpdateParams = ajv.compile(CronUpdateParamsSchema);
+const validateCronRemoveParams = ajv.compile(CronRemoveParamsSchema);
+const validateCronRunParams = ajv.compile(CronRunParamsSchema);
+const validateCronRunsParams = ajv.compile(CronRunsParamsSchema);
+const validateDevicePairListParams = ajv.compile(DevicePairListParamsSchema);
+const validateDevicePairApproveParams = ajv.compile(DevicePairApproveParamsSchema);
+const validateDevicePairRejectParams = ajv.compile(DevicePairRejectParamsSchema);
+const validateDevicePairRemoveParams = ajv.compile(DevicePairRemoveParamsSchema);
+const validateDeviceTokenRotateParams = ajv.compile(DeviceTokenRotateParamsSchema);
+const validateDeviceTokenRevokeParams = ajv.compile(DeviceTokenRevokeParamsSchema);
+const validateExecApprovalsGetParams = ajv.compile(ExecApprovalsGetParamsSchema);
+const validateExecApprovalsSetParams = ajv.compile(ExecApprovalsSetParamsSchema);
+const validateExecApprovalGetParams = ajv.compile(ExecApprovalGetParamsSchema);
+const validateExecApprovalRequestParams = ajv.compile(ExecApprovalRequestParamsSchema);
+const validateExecApprovalResolveParams = ajv.compile(ExecApprovalResolveParamsSchema);
+const validatePluginApprovalRequestParams = ajv.compile(PluginApprovalRequestParamsSchema);
+const validatePluginApprovalResolveParams = ajv.compile(PluginApprovalResolveParamsSchema);
+const validatePluginsUiDescriptorsParams = ajv.compile(PluginsUiDescriptorsParamsSchema);
+const validatePluginsSessionActionParams = ajv.compile(PluginsSessionActionParamsSchema);
+const validatePluginsSessionActionResult = ajv.compile(PluginsSessionActionResultSchema);
+const validateExecApprovalsNodeGetParams = ajv.compile(ExecApprovalsNodeGetParamsSchema);
+const validateExecApprovalsNodeSetParams = ajv.compile(ExecApprovalsNodeSetParamsSchema);
+const validateLogsTailParams = ajv.compile(LogsTailParamsSchema);
+const validateChatHistoryParams = ajv.compile(ChatHistoryParamsSchema);
+const validateChatSendParams = ajv.compile(ChatSendParamsSchema);
+const validateChatAbortParams = ajv.compile(ChatAbortParamsSchema);
+const validateChatInjectParams = ajv.compile(ChatInjectParamsSchema);
+const validateChatEvent = ajv.compile(ChatEventSchema);
+const validateUpdateStatusParams = ajv.compile(UpdateStatusParamsSchema);
+const validateUpdateRunParams = ajv.compile(UpdateRunParamsSchema);
+const validateWebLoginStartParams = ajv.compile(WebLoginStartParamsSchema);
+const validateWebLoginWaitParams = ajv.compile(WebLoginWaitParamsSchema);
+function formatValidationErrors(errors) {
+	if (!errors?.length) return "unknown validation error";
+	const parts = [];
+	for (const err of errors) {
+		const keyword = typeof err?.keyword === "string" ? err.keyword : "";
+		const instancePath = typeof err?.instancePath === "string" ? err.instancePath : "";
+		if (keyword === "additionalProperties") {
+			const additionalProperty = (err?.params)?.additionalProperty;
+			if (typeof additionalProperty === "string" && additionalProperty.trim()) {
+				const where = instancePath ? `at ${instancePath}` : "at root";
+				parts.push(`${where}: unexpected property '${additionalProperty}'`);
+				continue;
+			}
+		}
+		const message = typeof err?.message === "string" && err.message.trim() ? err.message : "validation error";
+		const where = instancePath ? `at ${instancePath}: ` : "";
+		parts.push(`${where}${message}`);
+	}
+	const unique = Array.from(new Set(parts.filter((part) => part.trim())));
+	if (!unique.length) return ajv.errorsText(errors, { separator: "; " }) || "unknown validation error";
+	return unique.join("; ");
+}
+//#endregion
+export { validateExecApprovalsNodeGetParams as $, SkillsDetailResultSchema as $a, CommandsListParamsSchema as $i, WizardCancelParamsSchema as $n, NodePendingEnqueueParamsSchema as $r, validateSessionsUsageParams as $t, validateConfigSchemaParams as A, WebLoginWaitParamsSchema as Aa, EnvironmentsStatusParamsSchema as Ai, validateTalkSessionTurnResult as An, SessionsSendParamsSchema as Ar, validateResponseFrame as At, validateDevicePairApproveParams as B, AgentsFileEntrySchema as Ba, CronStatusParamsSchema as Bi, validateUpdateStatusParams as Bn, PluginsUiDescriptorsParamsSchema as Br, validateSessionsCompactionRestoreParams as Bt, validateChatSendParams as C, TalkSessionOkResultSchema as Ca, ExecApprovalResolveParamsSchema as Ci, validateTalkSessionCreateParams as Cn, SessionsDescribeParamsSchema as Cr, validatePluginApprovalResolveParams as Ct, validateConfigPatchParams as D, TalkSpeakParamsSchema as Da, EnvironmentSummarySchema as Di, validateTalkSessionOkResult as Dn, SessionsPreviewParamsSchema as Dr, validatePollParams as Dt, validateConfigGetParams as E, TalkSessionTurnResultSchema as Ea, EnvironmentStatusSchema as Ei, validateTalkSessionJoinResult as En, SessionsPluginPatchParamsSchema as Er, validatePluginsUiDescriptorsParams as Et, validateCronRemoveParams as F, AgentSummarySchema as Fa, CronJobSchema as Fi, validateTasksListParams as Fn, WebPushTestParamsSchema as Fr, validateSessionsCleanupParams as Ft, validateDeviceTokenRotateParams as G, AgentsFilesSetParamsSchema as Ga, ConfigSchemaLookupParamsSchema as Gi, validateWebPushTestParams as Gn, NodePairListParamsSchema as Gr, validateSessionsMessagesSubscribeParams as Gt, validateDevicePairRejectParams as H, AgentsFilesGetResultSchema as Ha, ConfigApplyParamsSchema as Hi, validateWebLoginStartParams as Hn, NodeInvokeParamsSchema as Hr, validateSessionsDeleteParams as Ht, validateCronRunParams as I, AgentsCreateParamsSchema as Ia, CronListParamsSchema as Ii, validateToolsCatalogParams as In, WebPushUnsubscribeParamsSchema as Ir, validateSessionsCompactParams as It, validateEventFrame as J, AgentsListResultSchema as Ja, ConfigSchemaResponseSchema as Ji, validateWizardCancelParams as Jn, NodePairRequestParamsSchema as Jr, validateSessionsPluginPatchParams as Jt, validateEnvironmentsListParams as K, AgentsFilesSetResultSchema as Ka, ConfigSchemaLookupResultSchema as Ki, validateWebPushUnsubscribeParams as Kn, NodePairRejectParamsSchema as Kr, validateSessionsMessagesUnsubscribeParams as Kt, validateCronRunsParams as L, AgentsCreateResultSchema as La, CronRemoveParamsSchema as Li, validateToolsEffectiveParams as Ln, WebPushVapidPublicKeyParamsSchema as Lr, validateSessionsCompactionBranchParams as Lt, validateConnectParams as M, ArtifactsDownloadParamsSchema as Ma, ErrorCodes as Mi, validateTalkSpeakResult as Mn, PushTestParamsSchema as Mr, validateSecretsResolveResult as Mt, validateCronAddParams as N, ArtifactsGetParamsSchema as Na, errorShape as Ni, validateTasksCancelParams as Nn, PushTestResultSchema as Nr, validateSendParams as Nt, validateConfigSchemaLookupParams as O, TalkSpeakResultSchema as Oa, EnvironmentsListParamsSchema as Oi, validateTalkSessionSubmitToolResultParams as On, SessionsResetParamsSchema as Or, validatePushTestParams as Ot, validateCronListParams as P, ArtifactsListParamsSchema as Pa, CronAddParamsSchema as Pi, validateTasksGetParams as Pn, WebPushSubscribeParamsSchema as Pr, validateSessionsAbortParams as Pt, validateExecApprovalsGetParams as Q, SkillsDetailParamsSchema as Qa, COMMAND_DESCRIPTION_MAX_LENGTH as Qi, ProtocolSchemas as Qn, NodePendingDrainResultSchema as Qr, validateSessionsSendParams as Qt, validateCronStatusParams as R, AgentsDeleteParamsSchema as Ra, CronRunParamsSchema as Ri, validateToolsInvokeParams as Rn, PluginsSessionActionParamsSchema as Rr, validateSessionsCompactionGetParams as Rt, validateChatInjectParams as S, TalkSessionJoinResultSchema as Sa, ExecApprovalRequestParamsSchema as Si, validateTalkSessionCloseParams as Sn, SessionsDeleteParamsSchema as Sr, validatePluginApprovalRequestParams as St, validateConfigApplyParams as T, TalkSessionTurnParamsSchema as Ta, ExecApprovalsSetParamsSchema as Ti, validateTalkSessionJoinParams as Tn, SessionsPatchParamsSchema as Tr, validatePluginsSessionActionResult as Tt, validateDevicePairRemoveParams as U, AgentsFilesListParamsSchema as Ua, ConfigGetParamsSchema as Ui, validateWebLoginWaitParams as Un, NodeListParamsSchema as Ur, validateSessionsDescribeParams as Ut, validateDevicePairListParams as V, AgentsFilesGetParamsSchema as Va, CronUpdateParamsSchema as Vi, validateWakeParams as Vn, NodeEventResultSchema as Vr, validateSessionsCreateParams as Vt, validateDeviceTokenRevokeParams as W, AgentsFilesListResultSchema as Wa, ConfigPatchParamsSchema as Wi, validateWebPushSubscribeParams as Wn, NodePairApproveParamsSchema as Wr, validateSessionsListParams as Wt, validateExecApprovalRequestParams as X, AgentsUpdateResultSchema as Xa, UpdateRunParamsSchema as Xi, validateWizardStartParams as Xn, NodePendingAckParamsSchema as Xr, validateSessionsResetParams as Xt, validateExecApprovalGetParams as Y, AgentsUpdateParamsSchema as Ya, ConfigSetParamsSchema as Yi, validateWizardNextParams as Yn, NodePairVerifyParamsSchema as Yr, validateSessionsPreviewParams as Yt, validateExecApprovalResolveParams as Z, ModelsListParamsSchema as Za, UpdateStatusParamsSchema as Zi, validateWizardStatusParams as Zn, NodePendingDrainParamsSchema as Zr, validateSessionsResolveParams as Zt, validateChannelsStatusParams as _, TalkSessionCancelTurnParamsSchema as _a, TickEventSchema as _i, validateTalkEvent as _n, SendParamsSchema as _o, SessionsCompactionBranchParamsSchema as _r, validateNodePendingAckParams as _t, validateAgentsCreateParams as a, ChannelsStopParamsSchema as aa, ChatInjectParamsSchema as ai, validateSkillsUpdateParams as an, SkillsUploadBeginParamsSchema as ao, WizardStatusResultSchema as ar, validateNodeDescribeParams as at, validateChatEvent as b, TalkSessionCreateResultSchema as ba, StateVersionSchema as bi, validateTalkSessionCancelOutputParams as bn, AGENT_INTERNAL_EVENT_TYPE_TASK_COMPLETION as bo, SessionsCompactionRestoreParamsSchema as br, validateNodePresenceAlivePayload as bt, validateAgentsFilesListParams as c, TalkClientCreateParamsSchema as ca, LogsTailResultSchema as ci, validateSkillsUploadCommitParams as cn, ToolsCatalogParamsSchema as co, TasksCancelParamsSchema as cr, validateNodeInvokeParams as ct, validateAgentsUpdateParams as d, TalkClientToolCallResultSchema as da, EventFrameSchema as di, validateTalkClientCreateParams as dn, AgentEventSchema as do, TasksGetResultSchema as dr, validateNodePairApproveParams as dt, CommandsListResultSchema as ea, NodePendingEnqueueResultSchema as ei, validateSkillsBinsParams as en, SkillsInstallParamsSchema as eo, WizardNextParamsSchema as er, validateExecApprovalsNodeSetParams as et, validateArtifactsDownloadParams as f, TalkConfigParamsSchema as fa, GatewayFrameSchema as fi, validateTalkClientCreateResult as fn, AgentIdentityParamsSchema as fo, TasksListParamsSchema as fr, validateNodePairListParams as ft, validateChannelsStartParams as g, TalkSessionCancelOutputParamsSchema as ga, ShutdownEventSchema as gi, validateTalkConfigResult as gn, PollParamsSchema as go, SessionsCompactParamsSchema as gr, validateNodePairVerifyParams as gt, validateChannelsLogoutParams as h, TalkSessionAppendAudioParamsSchema as ha, ResponseFrameSchema as hi, validateTalkConfigParams as hn, MessageActionParamsSchema as ho, SessionsCleanupParamsSchema as hr, validateNodePairRequestParams as ht, validateAgentWaitParams as i, ChannelsStatusResultSchema as ia, ChatHistoryParamsSchema as ii, validateSkillsStatusParams as in, SkillsUpdateParamsSchema as io, WizardStatusParamsSchema as ir, validateModelsListParams as it, validateConfigSetParams as j, ArtifactSummarySchema as ja, EnvironmentsStatusResultSchema as ji, validateTalkSpeakParams as jn, SessionsUsageParamsSchema as jr, validateSecretsResolveParams as jt, validateConfigSchemaLookupResult as k, WebLoginStartParamsSchema as ka, EnvironmentsListResultSchema as ki, validateTalkSessionTurnParams as kn, SessionsResolveParamsSchema as kr, validateRequestFrame as kt, validateAgentsFilesSetParams as l, TalkClientCreateResultSchema as la, ConnectParamsSchema as li, validateTalkCatalogParams as ln, ToolsEffectiveParamsSchema as lo, TasksCancelResultSchema as lr, validateNodeInvokeResultParams as lt, validateArtifactsListParams as m, TalkEventSchema as ma, RequestFrameSchema as mi, validateTalkClientToolCallResult as mn, AgentParamsSchema as mo, SessionsAbortParamsSchema as mr, validateNodePairRemoveParams as mt, validateAgentIdentityParams as n, ChannelsStartParamsSchema as na, NodePresenceAliveReasonSchema as ni, validateSkillsInstallParams as nn, SkillsSearchResultSchema as no, WizardStartParamsSchema as nr, validateLogsTailParams as nt, validateAgentsDeleteParams as o, TalkCatalogParamsSchema as oa, ChatSendParamsSchema as oi, validateSkillsUploadBeginParams as on, SkillsUploadChunkParamsSchema as oo, WizardStepSchema as or, validateNodeEventParams as ot, validateArtifactsGetParams as p, TalkConfigResultSchema as pa, HelloOkSchema as pi, validateTalkClientToolCallParams as pn, AgentIdentityResultSchema as po, TasksListResultSchema as pr, validateNodePairRejectParams as pt, validateEnvironmentsStatusParams as q, AgentsListParamsSchema as qa, ConfigSchemaParamsSchema as qi, validateWebPushVapidPublicKeyParams as qn, NodePairRemoveParamsSchema as qr, validateSessionsPatchParams as qt, validateAgentParams as r, ChannelsStatusParamsSchema as ra, ChatEventSchema as ri, validateSkillsSearchParams as rn, SkillsStatusParamsSchema as ro, WizardStartResultSchema as rr, validateMessageActionParams as rt, validateAgentsFilesGetParams as s, TalkCatalogResultSchema as sa, LogsTailParamsSchema as si, validateSkillsUploadChunkParams as sn, SkillsUploadCommitParamsSchema as so, TaskSummarySchema as sr, validateNodeEventResult as st, formatValidationErrors as t, ChannelsLogoutParamsSchema as ta, NodePresenceAlivePayloadSchema as ti, validateSkillsDetailParams as tn, SkillsSearchParamsSchema as to, WizardNextResultSchema as tr, validateExecApprovalsSetParams as tt, validateAgentsListParams as u, TalkClientToolCallParamsSchema as ua, ErrorShapeSchema as ui, validateTalkCatalogResult as un, ToolsInvokeParamsSchema as uo, TasksGetParamsSchema as ur, validateNodeListParams as ut, validateChannelsStopParams as v, TalkSessionCloseParamsSchema as va, PresenceEntrySchema as vi, validateTalkModeParams as vn, WakeParamsSchema as vo, SessionsCompactionGetParamsSchema as vr, validateNodePendingDrainParams as vt, validateCommandsListParams as w, TalkSessionSubmitToolResultParamsSchema as wa, ExecApprovalsGetParamsSchema as wi, validateTalkSessionCreateResult as wn, SessionsListParamsSchema as wr, validatePluginsSessionActionParams as wt, validateChatHistoryParams as x, TalkSessionJoinParamsSchema as xa, ExecApprovalGetParamsSchema as xi, validateTalkSessionCancelTurnParams as xn, SessionsCreateParamsSchema as xr, validateNodeRenameParams as xt, validateChatAbortParams as y, TalkSessionCreateParamsSchema as ya, SnapshotSchema as yi, validateTalkSessionAppendAudioParams as yn, parseSessionLabel as yo, SessionsCompactionListParamsSchema as yr, validateNodePendingEnqueueParams as yt, validateCronUpdateParams as z, AgentsDeleteResultSchema as za, CronRunsParamsSchema as zi, validateUpdateRunParams as zn, PluginsSessionActionResultSchema as zr, validateSessionsCompactionListParams as zt };

--- a/scripts/install-chat-stream-seam.mjs
+++ b/scripts/install-chat-stream-seam.mjs
@@ -1,0 +1,260 @@
+#!/usr/bin/env node
+/**
+ * install-chat-stream-seam.mjs
+ *
+ * Smarter-Claw side patcher: applies the chat-stream Control UI seam
+ * to an installed openclaw npm package by replacing two compiled bundle
+ * files with seam-built equivalents.
+ *
+ * Background
+ * ----------
+ *
+ * The chat-stream renderer seam (new `chat-message`, `chat-input-bar`,
+ * `chat-header-chip` surfaces + `priority` + `activeWhen` predicate on
+ * PluginControlUiDescriptor) was filed as upstream openclaw PR #80982.
+ * Until that merges and ships in a published openclaw release, this
+ * patcher applies the seam to a locally-installed openclaw so Smarter-Claw's
+ * v1.0 inline UI can run.
+ *
+ * Once the upstream PR lands in an `openclaw@>=X` release, bump
+ * `peerDependencies.openclaw` in our package.json + drop this patcher.
+ *
+ * What this script does
+ * ---------------------
+ *
+ *   1. Reads `patches/<manifest-dir>/manifest.json` (default `openclaw-2026.5.10-beta.5/`)
+ *   2. Locates the installed openclaw at `node_modules/openclaw/` (caller-supplied or auto-detected)
+ *   3. Verifies installed version matches manifest's `openclawVersion`
+ *   4. SHA256-checks each baseline file matches manifest's `baselineSha256` (refuses to apply on drift)
+ *   5. Backs up the originals into `node_modules/openclaw/.smarter-claw-backups/`
+ *   6. Copies the overlay files into `node_modules/openclaw/dist/`
+ *   7. Writes a sentinel at `node_modules/openclaw/.smarter-claw-chat-stream-seam-applied.json`
+ *      with version + timestamp + applied-SHA records
+ *
+ * Failure modes
+ * -------------
+ *
+ *   - Wrong openclaw version → refuse + report mismatch
+ *   - Baseline file drift (SHA doesn't match) → refuse + report; suggests
+ *     operator either reinstall openclaw or update Smarter-Claw to a
+ *     newer manifest entry
+ *   - Already applied (sentinel present) → no-op + report
+ *   - Cannot write backup or overlay → refuse + restore any partial state
+ *
+ * Usage
+ * -----
+ *
+ *   $ node scripts/install-chat-stream-seam.mjs [--host <path>] [--dry-run] [--force]
+ *
+ *   --host <path>   Path to the openclaw install (default: ./node_modules/openclaw)
+ *   --dry-run       Report what would change; do not write
+ *   --force         Skip baseline SHA verification (NOT RECOMMENDED)
+ *
+ * Companion scripts:
+ *   - scripts/verify-chat-stream-seam.mjs    Check sentinel + patched-file SHAs
+ *   - scripts/uninstall-chat-stream-seam.mjs Restore originals from backup
+ */
+
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync, copyFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..");
+const MANIFEST_RELDIR = "patches/openclaw-2026.5.10-beta.5";
+const SENTINEL_RELPATH = ".smarter-claw-chat-stream-seam-applied.json";
+const BACKUP_RELDIR = ".smarter-claw-backups";
+
+function parseArgs(argv) {
+  const args = { host: null, dryRun: false, force: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--host" && argv[i + 1]) {
+      args.host = argv[++i];
+    } else if (a === "--dry-run") {
+      args.dryRun = true;
+    } else if (a === "--force") {
+      args.force = true;
+    } else if (a === "--help" || a === "-h") {
+      console.log(readFileSync(fileURLToPath(import.meta.url), "utf8").split("\n").slice(0, 50).join("\n"));
+      process.exit(0);
+    } else {
+      console.error(`Unknown arg: ${a}`);
+      process.exit(2);
+    }
+  }
+  return args;
+}
+
+function sha256(buf) {
+  return createHash("sha256").update(buf).digest("hex");
+}
+
+function resolveHostDir(suppliedHost) {
+  if (suppliedHost) {
+    const abs = resolve(suppliedHost);
+    if (!existsSync(abs)) {
+      throw new Error(`--host path does not exist: ${abs}`);
+    }
+    return abs;
+  }
+  // Auto-detect: walk up from REPO_ROOT looking for node_modules/openclaw.
+  let dir = REPO_ROOT;
+  for (let depth = 0; depth < 5; depth++) {
+    const candidate = join(dir, "node_modules", "openclaw");
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error(
+    "Could not auto-locate node_modules/openclaw. Pass --host /path/to/openclaw to specify.",
+  );
+}
+
+function readManifest() {
+  const path = join(REPO_ROOT, MANIFEST_RELDIR, "manifest.json");
+  if (!existsSync(path)) {
+    throw new Error(`Manifest missing at ${path}`);
+  }
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function readHostVersion(hostDir) {
+  const pkgPath = join(hostDir, "package.json");
+  if (!existsSync(pkgPath)) {
+    throw new Error(`No package.json at ${pkgPath}`);
+  }
+  const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+  return pkg.version;
+}
+
+function alreadyApplied(hostDir) {
+  return existsSync(join(hostDir, SENTINEL_RELPATH));
+}
+
+function backupOriginal(hostDir, relPath, dryRun) {
+  const src = join(hostDir, relPath);
+  const backupDir = join(hostDir, BACKUP_RELDIR, dirname(relPath));
+  const backupPath = join(hostDir, BACKUP_RELDIR, relPath);
+  if (dryRun) {
+    console.log(`  [dry-run] would backup ${relPath} → ${BACKUP_RELDIR}/${relPath}`);
+    return;
+  }
+  mkdirSync(backupDir, { recursive: true });
+  copyFileSync(src, backupPath);
+}
+
+function applyOverlay(hostDir, manifestDir, relPath, dryRun) {
+  const overlayFilename = relPath.split("/").pop();
+  const overlaySrc = join(manifestDir, overlayFilename);
+  const overlayDst = join(hostDir, relPath);
+  if (dryRun) {
+    console.log(`  [dry-run] would overlay ${relPath}`);
+    return;
+  }
+  copyFileSync(overlaySrc, overlayDst);
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const manifest = readManifest();
+  const manifestDir = join(REPO_ROOT, MANIFEST_RELDIR);
+  const hostDir = resolveHostDir(args.host);
+
+  console.log(`Smarter-Claw chat-stream seam patcher`);
+  console.log(`  host: ${hostDir}`);
+  console.log(`  manifest version: ${manifest.openclawVersion}`);
+
+  const installedVersion = readHostVersion(hostDir);
+  console.log(`  installed openclaw version: ${installedVersion}`);
+  if (installedVersion !== manifest.openclawVersion) {
+    console.error(
+      `\nFAIL: installed openclaw version ${installedVersion} does not match manifest version ${manifest.openclawVersion}.\n` +
+        `Either: (a) install the matching openclaw version, or (b) update Smarter-Claw to a version with a manifest for ${installedVersion}.`,
+    );
+    process.exit(3);
+  }
+
+  if (alreadyApplied(hostDir)) {
+    console.log(`\nAlready applied. Sentinel found at ${SENTINEL_RELPATH}.`);
+    console.log("Run scripts/uninstall-chat-stream-seam.mjs to revert, then re-install.");
+    process.exit(0);
+  }
+
+  // Pre-flight: verify each baseline file SHA before touching anything.
+  console.log(`\nVerifying ${manifest.files.length} baseline files…`);
+  const issues = [];
+  for (const f of manifest.files) {
+    const fullPath = join(hostDir, f.relativePath);
+    if (!existsSync(fullPath)) {
+      issues.push(`MISSING: ${f.relativePath}`);
+      continue;
+    }
+    const actualSha = sha256(readFileSync(fullPath));
+    if (actualSha !== f.baselineSha256) {
+      issues.push(
+        `DRIFT: ${f.relativePath} (expected ${f.baselineSha256.slice(0, 12)}…, got ${actualSha.slice(0, 12)}…)`,
+      );
+    } else {
+      console.log(`  ✓ ${f.relativePath}`);
+    }
+  }
+
+  if (issues.length > 0) {
+    if (!args.force) {
+      console.error(`\nFAIL: ${issues.length} baseline integrity issue(s):`);
+      for (const i of issues) console.error(`  ${i}`);
+      console.error(
+        "\nThe installed openclaw differs from what this manifest expects.\n" +
+          "Refusing to apply (use --force to override at your own risk).",
+      );
+      process.exit(4);
+    } else {
+      console.warn(`\nWARNING: ${issues.length} baseline issue(s), but --force was supplied:`);
+      for (const i of issues) console.warn(`  ${i}`);
+    }
+  }
+
+  // Apply.
+  console.log(`\n${args.dryRun ? "Dry-run: would apply" : "Applying"} ${manifest.files.length} overlays…`);
+  for (const f of manifest.files) {
+    backupOriginal(hostDir, f.relativePath, args.dryRun);
+    applyOverlay(hostDir, manifestDir, f.relativePath, args.dryRun);
+    if (!args.dryRun) {
+      const post = sha256(readFileSync(join(hostDir, f.relativePath)));
+      if (post !== f.patchedSha256) {
+        console.error(
+          `\nFAIL: post-overlay SHA mismatch on ${f.relativePath}\n  expected ${f.patchedSha256}\n  got      ${post}`,
+        );
+        process.exit(5);
+      }
+      console.log(`  ✓ ${f.relativePath}`);
+    }
+  }
+
+  if (args.dryRun) {
+    console.log("\nDry-run complete. No changes written.");
+    return;
+  }
+
+  const sentinel = {
+    appliedAt: new Date().toISOString(),
+    openclawVersion: manifest.openclawVersion,
+    manifestPath: MANIFEST_RELDIR,
+    seamSource: manifest.seamSource,
+    appliedFiles: manifest.files.map((f) => ({
+      relativePath: f.relativePath,
+      sha256: f.patchedSha256,
+    })),
+  };
+  writeFileSync(
+    join(hostDir, SENTINEL_RELPATH),
+    JSON.stringify(sentinel, null, 2) + "\n",
+  );
+  console.log(`\nDone. Sentinel: ${SENTINEL_RELPATH}`);
+  console.log("To revert: node scripts/uninstall-chat-stream-seam.mjs");
+}
+
+main();

--- a/scripts/uninstall-chat-stream-seam.mjs
+++ b/scripts/uninstall-chat-stream-seam.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * uninstall-chat-stream-seam.mjs
+ *
+ * Reverts the chat-stream seam patch by restoring originals from
+ * `node_modules/openclaw/.smarter-claw-backups/`.
+ *
+ * Usage:
+ *   $ node scripts/uninstall-chat-stream-seam.mjs [--host <path>] [--dry-run]
+ *
+ * Exits 0 on success, 1 if no sentinel found (= not currently patched).
+ */
+
+import { existsSync, readFileSync, rmSync, copyFileSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..");
+const SENTINEL_RELPATH = ".smarter-claw-chat-stream-seam-applied.json";
+const BACKUP_RELDIR = ".smarter-claw-backups";
+
+function parseArgs(argv) {
+  const args = { host: null, dryRun: false };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--host" && argv[i + 1]) args.host = argv[++i];
+    else if (argv[i] === "--dry-run") args.dryRun = true;
+  }
+  return args;
+}
+
+function resolveHostDir(suppliedHost) {
+  if (suppliedHost) return resolve(suppliedHost);
+  let dir = REPO_ROOT;
+  for (let depth = 0; depth < 5; depth++) {
+    const candidate = join(dir, "node_modules", "openclaw");
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error("Could not auto-locate node_modules/openclaw. Pass --host /path.");
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const hostDir = resolveHostDir(args.host);
+  const sentinelPath = join(hostDir, SENTINEL_RELPATH);
+
+  if (!existsSync(sentinelPath)) {
+    console.log("NOT APPLIED — no sentinel; nothing to revert.");
+    process.exit(1);
+  }
+
+  const sentinel = JSON.parse(readFileSync(sentinelPath, "utf8"));
+  console.log(
+    `Reverting chat-stream seam patch (applied ${sentinel.appliedAt}, openclaw ${sentinel.openclawVersion})…`,
+  );
+
+  for (const f of sentinel.appliedFiles) {
+    const backupPath = join(hostDir, BACKUP_RELDIR, f.relativePath);
+    const targetPath = join(hostDir, f.relativePath);
+    if (!existsSync(backupPath)) {
+      console.error(`  MISSING BACKUP: ${BACKUP_RELDIR}/${f.relativePath}`);
+      console.error("  Cannot restore. Reinstall openclaw to recover.");
+      process.exit(2);
+    }
+    if (args.dryRun) {
+      console.log(`  [dry-run] would restore ${f.relativePath} from backup`);
+    } else {
+      copyFileSync(backupPath, targetPath);
+      console.log(`  ✓ ${f.relativePath} restored`);
+    }
+  }
+
+  if (!args.dryRun) {
+    rmSync(join(hostDir, BACKUP_RELDIR), { recursive: true, force: true });
+    rmSync(sentinelPath);
+    console.log(`\nDone. Sentinel + backups removed.`);
+  } else {
+    console.log("\nDry-run complete. No changes written.");
+  }
+}
+
+main();

--- a/scripts/verify-chat-stream-seam.mjs
+++ b/scripts/verify-chat-stream-seam.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/**
+ * verify-chat-stream-seam.mjs
+ *
+ * Verifies that the chat-stream seam patch is correctly applied to an
+ * installed openclaw. Exit codes:
+ *   0 - applied + all SHAs match
+ *   1 - not applied (no sentinel)
+ *   2 - applied but SHAs don't match (drift / corruption)
+ *   3 - other error
+ *
+ * Usage:
+ *   $ node scripts/verify-chat-stream-seam.mjs [--host <path>]
+ */
+
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..");
+const SENTINEL_RELPATH = ".smarter-claw-chat-stream-seam-applied.json";
+
+function parseArgs(argv) {
+  const args = { host: null };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--host" && argv[i + 1]) args.host = argv[++i];
+  }
+  return args;
+}
+
+function sha256(buf) {
+  return createHash("sha256").update(buf).digest("hex");
+}
+
+function resolveHostDir(suppliedHost) {
+  if (suppliedHost) return resolve(suppliedHost);
+  let dir = REPO_ROOT;
+  for (let depth = 0; depth < 5; depth++) {
+    const candidate = join(dir, "node_modules", "openclaw");
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error("Could not auto-locate node_modules/openclaw. Pass --host /path.");
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const hostDir = resolveHostDir(args.host);
+  const sentinelPath = join(hostDir, SENTINEL_RELPATH);
+
+  if (!existsSync(sentinelPath)) {
+    console.log("NOT APPLIED");
+    console.log(`  No sentinel at ${SENTINEL_RELPATH}`);
+    console.log("  Run scripts/install-chat-stream-seam.mjs to apply.");
+    process.exit(1);
+  }
+
+  const sentinel = JSON.parse(readFileSync(sentinelPath, "utf8"));
+  console.log(`APPLIED (${sentinel.appliedAt})`);
+  console.log(`  manifest: ${sentinel.manifestPath}`);
+  console.log(`  openclaw version at apply time: ${sentinel.openclawVersion}`);
+
+  // Verify each file's SHA matches what the sentinel records.
+  const issues = [];
+  for (const f of sentinel.appliedFiles) {
+    const full = join(hostDir, f.relativePath);
+    if (!existsSync(full)) {
+      issues.push(`MISSING: ${f.relativePath}`);
+      continue;
+    }
+    const actual = sha256(readFileSync(full));
+    if (actual !== f.sha256) {
+      issues.push(
+        `DRIFT: ${f.relativePath} (sentinel: ${f.sha256.slice(0, 12)}…, actual: ${actual.slice(0, 12)}…)`,
+      );
+    } else {
+      console.log(`  ✓ ${f.relativePath}`);
+    }
+  }
+
+  if (issues.length > 0) {
+    console.error(`\nFAIL: ${issues.length} integrity issue(s):`);
+    for (const i of issues) console.error(`  ${i}`);
+    console.error("\nRecommended: uninstall + reinstall the seam patch.");
+    process.exit(2);
+  }
+
+  console.log("\nAll patched files verified.");
+  process.exit(0);
+}
+
+main();

--- a/src/index.ts
+++ b/src/index.ts
@@ -550,8 +550,78 @@ export default definePluginEntry({
       `[smarter-claw] registered v1-port skeleton — namespace="${PLAN_MODE_SESSION_EXTENSION_NAMESPACE}"`,
     );
     api.logger.info(`[smarter-claw] ${buildAdvisorySessionMessage()}`);
+
+    // Chat-stream seam patch advisory: report whether the operator has
+    // applied the tactical patch (`npm run patch:chat-stream-seam`) that
+    // enables inline chat-stream UI surfaces. Fires once at register-time
+    // (not per session) to keep log noise low.
+    //
+    // The patch is required for the v1.0 inline-UI experience. v0.x
+    // sidebar UX works without it. The advisory ONLY informs; it does NOT
+    // try to auto-apply (operator opt-in is the contract).
+    //
+    // Detection is best-effort: looks for the patcher sentinel at
+    // `node_modules/openclaw/.smarter-claw-chat-stream-seam-applied.json`.
+    // If the openclaw install path can't be resolved (e.g. unusual layout),
+    // the advisory is skipped silently.
+    api.logger.info(`[smarter-claw] ${buildChatStreamSeamAdvisory()}`);
   },
 });
+
+/**
+ * Best-effort advisory for whether the chat-stream seam patch is applied
+ * to the operator's installed openclaw. Reads a sentinel at
+ * `node_modules/openclaw/.smarter-claw-chat-stream-seam-applied.json`.
+ *
+ * Behavior:
+ *   - Sentinel present + parseable: "chat-stream seam patch applied (openclaw X, applied Y)"
+ *   - Sentinel absent: "chat-stream seam patch not applied — run `npm run patch:chat-stream-seam` to enable inline UI (v1.0 surface). Sidebar UI works without the patch."
+ *   - Detection fails (can't find openclaw): silent no-op (returns generic message)
+ */
+function buildChatStreamSeamAdvisory(): string {
+  // Lazy-require fs to keep the plugin entry side-effect-free at import
+  // time for tests + parity harness.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const fs = require("node:fs") as typeof import("node:fs");
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const pathModule = require("node:path") as typeof import("node:path");
+
+  // Resolve openclaw install dir from this module's location.
+  // The plugin imports `openclaw/plugin-sdk/...`, so Node has resolved
+  // openclaw's package directory. We walk up from `require.resolve` if
+  // available; otherwise fall back to relative path heuristic.
+  let openclawDir: string | null = null;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const req = require("node:module").createRequire(import.meta.url) as NodeRequire;
+    const openclawPkg = req.resolve("openclaw/package.json");
+    openclawDir = pathModule.dirname(openclawPkg);
+  } catch {
+    return "chat-stream seam patch: could not detect openclaw install path (advisory skipped).";
+  }
+
+  const sentinelPath = pathModule.join(
+    openclawDir,
+    ".smarter-claw-chat-stream-seam-applied.json",
+  );
+  if (!fs.existsSync(sentinelPath)) {
+    return (
+      "chat-stream seam patch: NOT applied. Sidebar UI works as-is. " +
+      "For v1.0 inline-UI surfaces, run `npm run patch:chat-stream-seam` (or `node scripts/install-chat-stream-seam.mjs --host=" +
+      openclawDir +
+      "`). Patch is reversible via `npm run patch:chat-stream-seam:uninstall`."
+    );
+  }
+  try {
+    const sentinel = JSON.parse(fs.readFileSync(sentinelPath, "utf8")) as {
+      appliedAt?: string;
+      openclawVersion?: string;
+    };
+    return `chat-stream seam patch: APPLIED (openclaw ${sentinel.openclawVersion ?? "?"}, ${sentinel.appliedAt ?? "?"}). Inline UI surfaces enabled.`;
+  } catch (err) {
+    return `chat-stream seam patch: sentinel present but unreadable (${(err as Error).message}).`;
+  }
+}
 
 /**
  * Test-only exports. Internal API; not part of the plugin's public
@@ -560,6 +630,7 @@ export default definePluginEntry({
  */
 export const __testing = {
   buildAdvisorySessionMessage,
+  buildChatStreamSeamAdvisory,
   resolveConfig,
   DEFAULT_CONFIG,
 };

--- a/tests/patcher/chat-stream-seam-patcher.test.ts
+++ b/tests/patcher/chat-stream-seam-patcher.test.ts
@@ -1,0 +1,301 @@
+/**
+ * End-to-end test for the chat-stream seam patcher.
+ *
+ * Builds a fake `node_modules/openclaw/` install in a tmp dir, runs the
+ * install / verify / uninstall scripts as child processes, and asserts:
+ *   - install: refuses on wrong version, refuses on baseline-SHA drift,
+ *     applies overlays + writes sentinel + backups on a clean baseline
+ *   - verify: reports applied state correctly
+ *   - uninstall: restores originals, removes sentinel + backups
+ *
+ * Uses real script invocation (no mocks) so we cover the actual operator
+ * flow.
+ */
+
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { execFileSync } from "node:child_process";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "../..");
+const INSTALL_SCRIPT = join(REPO_ROOT, "scripts/install-chat-stream-seam.mjs");
+const VERIFY_SCRIPT = join(REPO_ROOT, "scripts/verify-chat-stream-seam.mjs");
+const UNINSTALL_SCRIPT = join(REPO_ROOT, "scripts/uninstall-chat-stream-seam.mjs");
+const MANIFEST_PATH = join(
+  REPO_ROOT,
+  "patches/openclaw-2026.5.10-beta.5/manifest.json",
+);
+
+interface ScriptResult {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+function runScript(script: string, args: string[]): ScriptResult {
+  try {
+    const out = execFileSync("node", [script, ...args], {
+      encoding: "utf8",
+      stdio: "pipe",
+    });
+    return { status: 0, stdout: out, stderr: "" };
+  } catch (err: unknown) {
+    const e = err as {
+      status?: number;
+      stdout?: string;
+      stderr?: string;
+    };
+    return {
+      status: typeof e.status === "number" ? e.status : 1,
+      stdout: e.stdout ?? "",
+      stderr: e.stderr ?? "",
+    };
+  }
+}
+
+interface FakeHost {
+  hostDir: string;
+}
+
+function buildFakeHost(opts: { version: string; tamperBaseline?: boolean }): FakeHost {
+  // Make a tmp `node_modules/openclaw/` that contains the baseline
+  // versions of the two patched files (copied from this repo's
+  // patches/<manifest>/ overlays — those overlay files would be the
+  // PATCHED versions, not baseline). We have NO actual baseline files
+  // bundled in the repo (they live in openclaw's real npm package), so
+  // we synthesize: use the manifest's expected baseline SHAs against
+  // synthetic baseline content whose SHA we control.
+  //
+  // For these tests we use the REAL openclaw beta.5 install's baseline
+  // content (which we have access to via /Volumes/LEXAR — but that's a
+  // dev-machine path; not portable). Instead we generate synthetic
+  // baseline files whose content we deterministically craft to match
+  // the manifest's baseline SHAs.
+  //
+  // SIMPLER APPROACH: copy the manifest's overlay (patched) files into
+  // the fake-host as if they were baseline. Then the install script will
+  // refuse because baseline SHA won't match. That tests the SHA-drift
+  // detection. To test the success path, we craft synthetic baseline
+  // bytes whose SHA matches.
+  //
+  // For full coverage we'd run against a real beta.5 install. That's
+  // expensive in CI. Instead this test file exercises the SHA-mismatch
+  // refusal path (which is the highest-risk one). The success path is
+  // covered by a separate smoke check on the Eva machine where openclaw
+  // is actually installed.
+  const dir = join(
+    tmpdir(),
+    `smarter-claw-patcher-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+  );
+  const hostDir = join(dir, "node_modules", "openclaw");
+  mkdirSync(join(hostDir, "dist"), { recursive: true });
+  writeFileSync(
+    join(hostDir, "package.json"),
+    JSON.stringify({ name: "openclaw", version: opts.version }) + "\n",
+  );
+
+  // For the SHA-mismatch test we just write garbage into the dist files.
+  // The install script will SHA-check them and refuse.
+  if (opts.tamperBaseline) {
+    writeFileSync(join(hostDir, "dist", "loader-DdN5GTsW.js"), "// tampered\n");
+    writeFileSync(join(hostDir, "dist", "protocol-BBwaRnfZ.js"), "// tampered\n");
+  } else {
+    // For tests that need the success path, copy the OVERLAY files —
+    // which means the manifest's "baseline SHA" check will fail (the
+    // overlay SHA doesn't match the baseline SHA). That's intentional:
+    // a real success-path test requires a real openclaw install, which
+    // we don't have in CI.
+    const manifestDir = join(REPO_ROOT, "patches/openclaw-2026.5.10-beta.5");
+    copyFileSync(
+      join(manifestDir, "loader-DdN5GTsW.js"),
+      join(hostDir, "dist", "loader-DdN5GTsW.js"),
+    );
+    copyFileSync(
+      join(manifestDir, "protocol-BBwaRnfZ.js"),
+      join(hostDir, "dist", "protocol-BBwaRnfZ.js"),
+    );
+  }
+
+  return { hostDir };
+}
+
+function cleanup(host: FakeHost) {
+  try {
+    rmSync(join(host.hostDir, "../.."), { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+}
+
+let host: FakeHost | undefined;
+
+afterEach(() => {
+  if (host) {
+    cleanup(host);
+    host = undefined;
+  }
+});
+
+describe("chat-stream seam patcher — version + baseline guards", () => {
+  it("refuses to apply when installed openclaw version doesn't match manifest", () => {
+    host = buildFakeHost({ version: "2026.5.10-beta.4" });
+    const r = runScript(INSTALL_SCRIPT, ["--host", host.hostDir]);
+    expect(r.status).toBe(3);
+    expect(r.stderr).toMatch(/does not match manifest version/i);
+  });
+
+  it("refuses to apply when baseline file SHA doesn't match manifest", () => {
+    host = buildFakeHost({ version: "2026.5.10-beta.5", tamperBaseline: true });
+    const r = runScript(INSTALL_SCRIPT, ["--host", host.hostDir]);
+    expect(r.status).toBe(4);
+    expect(r.stderr).toMatch(/DRIFT|baseline integrity/i);
+  });
+
+  it("--dry-run reports plan without writing", () => {
+    // Use the "baseline = overlay content" setup with --force so we
+    // skip SHA check; --dry-run must NOT write anything.
+    host = buildFakeHost({ version: "2026.5.10-beta.5" });
+    const r = runScript(INSTALL_SCRIPT, [
+      "--host",
+      host.hostDir,
+      "--dry-run",
+      "--force",
+    ]);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/Dry-run/i);
+    expect(existsSync(join(host.hostDir, ".smarter-claw-chat-stream-seam-applied.json"))).toBe(false);
+    expect(existsSync(join(host.hostDir, ".smarter-claw-backups"))).toBe(false);
+  });
+
+  it("--force overrides SHA check + writes sentinel + backups", () => {
+    host = buildFakeHost({ version: "2026.5.10-beta.5", tamperBaseline: true });
+    const r = runScript(INSTALL_SCRIPT, [
+      "--host",
+      host.hostDir,
+      "--force",
+    ]);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/Done/i);
+    expect(existsSync(join(host.hostDir, ".smarter-claw-chat-stream-seam-applied.json"))).toBe(true);
+    expect(existsSync(join(host.hostDir, ".smarter-claw-backups", "dist", "loader-DdN5GTsW.js"))).toBe(true);
+    expect(existsSync(join(host.hostDir, ".smarter-claw-backups", "dist", "protocol-BBwaRnfZ.js"))).toBe(true);
+  });
+});
+
+describe("chat-stream seam patcher — sentinel idempotency", () => {
+  it("install + verify + uninstall round-trip preserves originals", () => {
+    host = buildFakeHost({ version: "2026.5.10-beta.5", tamperBaseline: true });
+    const originalLoader = readFileSync(
+      join(host.hostDir, "dist", "loader-DdN5GTsW.js"),
+      "utf8",
+    );
+
+    // Install with --force.
+    const i = runScript(INSTALL_SCRIPT, ["--host", host.hostDir, "--force"]);
+    expect(i.status).toBe(0);
+
+    // Verify.
+    const v = runScript(VERIFY_SCRIPT, ["--host", host.hostDir]);
+    expect(v.status).toBe(0);
+    expect(v.stdout).toMatch(/APPLIED/);
+    expect(v.stdout).toMatch(/All patched files verified/);
+
+    // Uninstall.
+    const u = runScript(UNINSTALL_SCRIPT, ["--host", host.hostDir]);
+    expect(u.status).toBe(0);
+    expect(u.stdout).toMatch(/restored/);
+
+    // Originals restored.
+    const restored = readFileSync(
+      join(host.hostDir, "dist", "loader-DdN5GTsW.js"),
+      "utf8",
+    );
+    expect(restored).toBe(originalLoader);
+
+    // Sentinel + backups removed.
+    expect(
+      existsSync(join(host.hostDir, ".smarter-claw-chat-stream-seam-applied.json")),
+    ).toBe(false);
+    expect(existsSync(join(host.hostDir, ".smarter-claw-backups"))).toBe(false);
+  });
+
+  it("install on already-patched host is a no-op (exits 0)", () => {
+    host = buildFakeHost({ version: "2026.5.10-beta.5", tamperBaseline: true });
+
+    // Apply.
+    runScript(INSTALL_SCRIPT, ["--host", host.hostDir, "--force"]);
+
+    // Re-apply.
+    const r = runScript(INSTALL_SCRIPT, ["--host", host.hostDir, "--force"]);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/Already applied/i);
+  });
+
+  it("verify on un-patched host exits 1", () => {
+    host = buildFakeHost({ version: "2026.5.10-beta.5" });
+    const r = runScript(VERIFY_SCRIPT, ["--host", host.hostDir]);
+    expect(r.status).toBe(1);
+    expect(r.stdout).toMatch(/NOT APPLIED/);
+  });
+
+  it("uninstall on un-patched host exits 1", () => {
+    host = buildFakeHost({ version: "2026.5.10-beta.5" });
+    const r = runScript(UNINSTALL_SCRIPT, ["--host", host.hostDir]);
+    expect(r.status).toBe(1);
+    expect(r.stdout).toMatch(/NOT APPLIED/);
+  });
+
+  it("verify detects patched-file drift (someone tampered post-install)", () => {
+    host = buildFakeHost({ version: "2026.5.10-beta.5", tamperBaseline: true });
+    runScript(INSTALL_SCRIPT, ["--host", host.hostDir, "--force"]);
+    // Tamper one of the patched files post-install.
+    writeFileSync(
+      join(host.hostDir, "dist", "loader-DdN5GTsW.js"),
+      "// post-install tamper\n",
+    );
+    const r = runScript(VERIFY_SCRIPT, ["--host", host.hostDir]);
+    expect(r.status).toBe(2);
+    expect(r.stderr).toMatch(/DRIFT/);
+  });
+});
+
+describe("manifest integrity", () => {
+  it("manifest.json is parseable + has expected fields", () => {
+    const m = JSON.parse(readFileSync(MANIFEST_PATH, "utf8"));
+    expect(m.openclawVersion).toBe("2026.5.10-beta.5");
+    expect(Array.isArray(m.files)).toBe(true);
+    expect(m.files).toHaveLength(2);
+    for (const f of m.files) {
+      expect(typeof f.relativePath).toBe("string");
+      expect(/^[0-9a-f]{64}$/.test(f.baselineSha256)).toBe(true);
+      expect(/^[0-9a-f]{64}$/.test(f.patchedSha256)).toBe(true);
+    }
+  });
+
+  it("overlay files exist at manifest's claimed sha256", async () => {
+    const { createHash } = await import("node:crypto");
+    const m = JSON.parse(readFileSync(MANIFEST_PATH, "utf8"));
+    for (const f of m.files) {
+      const overlayPath = join(
+        REPO_ROOT,
+        "patches/openclaw-2026.5.10-beta.5",
+        f.relativePath.split("/").pop(),
+      );
+      expect(existsSync(overlayPath)).toBe(true);
+      const sha = createHash("sha256")
+        .update(readFileSync(overlayPath))
+        .digest("hex");
+      expect(sha).toBe(f.patchedSha256);
+    }
+  });
+});


### PR DESCRIPTION
Tactical patcher that applies the chat-stream Control UI seam to a locally-installed openclaw npm package by replacing 2 compiled bundle files. Unblocks v1.0 inline UI work while we wait for [upstream openclaw PR #80982](https://github.com/openclaw/openclaw/pull/80982) to land in a published release.

## How it works

- `scripts/install-chat-stream-seam.mjs` runs version check + baseline SHA check + backup + overlay + sentinel write. Refuses on version mismatch (exit 3) or baseline drift (exit 4). Supports `--host`, `--dry-run`, `--force`.
- `patches/openclaw-2026.5.10-beta.5/` carries the 2 overlay files (loader + protocol bundles, ~370KB total) generated by cherry-picking the 3 seam commits onto v2026.5.10-beta.5 and rebuilding.
- Plugin runtime adds a `buildChatStreamSeamAdvisory()` helper that fires once at register-time, reading the sentinel + reporting APPLIED / NOT APPLIED in gateway logs.

## Operator flow

```bash
npm run patch:chat-stream-seam              # apply
npm run patch:chat-stream-seam:verify       # verify
npm run patch:chat-stream-seam:uninstall    # revert
```

## Test footprint

**596/596 tests pass** (was 585, added 11):
- Refuses to apply on wrong openclaw version (exit 3)
- Refuses to apply on baseline SHA drift (exit 4)
- `--dry-run` reports plan without writing
- `--force` overrides SHA check + writes sentinel + backups
- Round-trip: install + verify + uninstall restores originals
- Re-install on already-patched is a no-op
- Verify on un-patched exits 1, uninstall on un-patched exits 1
- Verify detects post-install file tamper (exit 2)
- Manifest.json shape integrity + overlay SHA matches manifest

## When this PR's work is no longer needed

When upstream PR #80982 lands in a published openclaw release, we'll cut a follow-up PR that bumps `peerDependencies.openclaw` + drops `scripts/install-chat-stream-seam.mjs` + drops `patches/` entirely. The patcher is intentionally version-aware (manifest pins exact openclaw version) so it can be retired cleanly.

Tracker: #77 (epic), #78 (upstream blocker).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a temporary chat-stream seam patch mechanism with install, verify, and uninstall commands, enabling inline UI functionality locally while awaiting upstream integration. Includes automatic integrity checking and rollback support.

* **Documentation**
  * Added optional patch workflow documentation covering setup, verification, and uninstallation procedures with alternative installation methods.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/Smarter-Claw/pull/84)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->