### PR TITLE
fix: surgical re-port of resolvePlanApproval — closes 4 P0 parity drifts (Wave-1 S8)

### DIFF
--- a/src/plan-mode/approval.ts
+++ b/src/plan-mode/approval.ts
@@ -1,0 +1,239 @@
+/**
+ * Plan-mode approval state machine.
+ *
+ * **Parity contract**: byte-identical port of the in-host
+ * `src/agents/plan-mode/approval.ts` at commit `ea04ea52c7`
+ * (`/Users/lume/repos/openclaw-pr70071-rebase/src/agents/plan-mode/approval.ts`).
+ *
+ * The ONLY adaptation is the import path: `./types.js` → `../types.js`
+ * because the plugin's PlanModeSessionState lives at the top-level
+ * `src/types.ts` rather than in a plan-mode subdirectory.
+ *
+ * Surgical-port rationale (2026-05-12): Wave-1 audit slice S8 found
+ * that the prior `PlanModeStore.recordApproval` typed mutator dropped
+ * 4 behaviors vs in-host (rejectionCount reset, feedback clear, mode
+ * transition, rejected→approved path). All 4 divergences were locked
+ * in by passing plugin tests. Re-porting `resolvePlanApproval` verbatim
+ * + delegating from the store mutators eliminates the drift by
+ * construction.
+ *
+ * # Original docstring (preserved from in-host)
+ *
+ * After the agent calls `exit_plan_mode`, the runtime emits a
+ * `plan_approval_requested` event. Channel plugins render inline
+ * buttons (Approve / Edit / Reject). This module manages the
+ * approval lifecycle and resolves the result.
+ *
+ * ## Rejection UX (Decision 4)
+ *
+ * On rejection, mode stays "plan" (fail-closed). The agent receives
+ * a structured [PLAN_DECISION] injection at the start of its next
+ * turn with the user's feedback. The agent revises and calls
+ * update_plan again. No hard limit on cycles; after 3 rejections
+ * the injection suggests asking the user to clarify their goal.
+ *
+ * On edit, the user's edits count as approval — mode transitions
+ * to "normal" and the agent executes the edited plan.
+ *
+ * On timeout, mode stays "plan". The agent is told the proposal
+ * expired and may re-propose when the user returns.
+ */
+
+import type { PlanModeSessionState } from "../types.js";
+
+export interface PlanApprovalConfig {
+  /** Seconds before an unanswered approval expires. Default: 600 (10 min). */
+  approvalTimeoutSeconds: number;
+}
+
+export const DEFAULT_APPROVAL_CONFIG: PlanApprovalConfig = {
+  approvalTimeoutSeconds: 600,
+};
+
+/**
+ * Resolves a plan approval action into the next session state.
+ *
+ * @param feedback - Optional user feedback on rejection
+ * @param expectedApprovalId - Optional version token from the approval event.
+ *   If provided and doesn't match `current.approvalId`, the action is ignored
+ *   as stale (e.g. user clicks Approve on a plan that was already rejected
+ *   and revised on another surface).
+ */
+export function resolvePlanApproval(
+  current: PlanModeSessionState,
+  action: "approve" | "edit" | "reject" | "timeout",
+  feedback?: string,
+  expectedApprovalId?: string,
+): PlanModeSessionState {
+  const now = Date.now();
+
+  // Stale-event guard: if the caller provided an approvalId, the current
+  // state MUST have a matching approvalId. Mismatch — or, importantly,
+  // current state having no approvalId at all when one is expected — means
+  // the event is stale (e.g. user clicked Approve on a plan that was
+  // already approved/rejected and the state moved on). No-op.
+  //
+  // Earlier draft only no-op'd when both sides had defined IDs and they
+  // differed, which left a fail-open: an attacker (or stale UI) could
+  // supply expectedApprovalId and have it accepted whenever the current
+  // state happened to have a cleared/undefined approvalId.
+  if (expectedApprovalId !== undefined) {
+    if (current.approvalId === undefined || expectedApprovalId !== current.approvalId) {
+      return current;
+    }
+  }
+
+  // Terminal-state guard. Approved, edited, and timed_out are terminal —
+  // they require a fresh exit_plan_mode call (which mints a new approvalId)
+  // before any new action can apply. Rejected stays open for re-approval
+  // or re-rejection.
+  //
+  // PR-D review fix (Codex P2 #3096560406 / Copilot #3105172000): also
+  // reject when `current.approval === "none"` AND no `expectedApprovalId`
+  // was supplied. The "none" state means there is no pending approval to
+  // act on — letting Approve/Edit/Reject through here would let an
+  // out-of-sequence callback (e.g. a delayed Reject after state reset)
+  // flip the session into a terminal state without a real
+  // exit_plan_mode call. The `expectedApprovalId` check above already
+  // handles the case where the caller has a token (rejected by the
+  // approvalId mismatch). This adds a no-token defense.
+  if (current.approval !== "pending" && current.approval !== "rejected") {
+    return current;
+  }
+  if (action === "timeout" && current.approval !== "pending") {
+    return current;
+  }
+
+  switch (action) {
+    case "approve":
+      // Approve clears feedback AND resets rejectionCount — the user is
+      // moving forward, so cycle history is no longer relevant.
+      return {
+        ...current,
+        mode: "normal",
+        approval: "approved",
+        confirmedAt: now,
+        updatedAt: now,
+        feedback: undefined,
+        rejectionCount: 0,
+      };
+
+    case "edit":
+      // Edit counts as approval — same reset behavior as approve.
+      return {
+        ...current,
+        mode: "normal",
+        approval: "edited",
+        confirmedAt: now,
+        updatedAt: now,
+        feedback: undefined,
+        rejectionCount: 0,
+      };
+
+    case "reject":
+      return {
+        ...current,
+        mode: "plan",
+        approval: "rejected",
+        confirmedAt: undefined,
+        updatedAt: now,
+        feedback: feedback ?? current.feedback,
+        rejectionCount: (current.rejectionCount ?? 0) + 1,
+      };
+
+    case "timeout":
+      return {
+        ...current,
+        mode: "plan",
+        approval: "timed_out",
+        confirmedAt: undefined,
+        updatedAt: now,
+        feedback: undefined,
+      };
+
+    default: {
+      const _exhaustive: never = action;
+      return current;
+    }
+  }
+}
+
+/**
+ * Grace window (ms) after a subagent completes during plan mode
+ * before exit_plan_mode and sessions.patch approve/edit can fire.
+ * Lets completion events propagate and parent announce-turns settle.
+ * Tuned conservatively: log-forensics shows most event-propagation
+ * lag is < 2s; 10s gives 5× headroom with minimal user-visible
+ * friction.
+ */
+export const SUBAGENT_SETTLE_GRACE_MS = 10_000;
+
+/**
+ * Maximum concurrent subagents allowed during plan mode. Prevents
+ * spawn-stacking during plan investigation which would multiply the
+ * race-window surface at exit_plan_mode time.
+ */
+export const MAX_CONCURRENT_SUBAGENTS_IN_PLAN_MODE = 1;
+
+/**
+ * Builds the context injection for an approved plan.
+ * Tells the agent to execute the approved plan without re-planning.
+ *
+ * Prefixed with the canonical one-line tag `[PLAN_DECISION]: approved`
+ * so downstream tooling (chat renderers that hide synthetic markers,
+ * debug log filters) match uniformly with the reject / timed_out /
+ * question_answer / complete variants.
+ */
+export function buildApprovedPlanInjection(planSteps: string[]): string {
+  const stepList = planSteps.map((s, i) => `${i + 1}. ${s}`).join("\n");
+  return (
+    "[PLAN_DECISION]: approved\n\n" +
+    "The user has approved the following plan. Execute it now without re-planning. " +
+    "If a step is no longer viable, mark it cancelled and add a revised step.\n\n" +
+    stepList
+  );
+}
+
+/**
+ * Builds the context injection for a plan approved with the
+ * acceptEdits permission. Mirrors Claude Code's `acceptEdits` mode —
+ * the user is granting the AGENT permission to self-modify the plan
+ * during execution when ≥95% confident, NOT claiming to have edited
+ * the plan themselves (there is no user-side plan editor today; the
+ * webchat affordance simply surfaces this permission mode).
+ *
+ * Three hard constraints override acceptEdits regardless of confidence
+ * level:
+ *   1. No destructive actions (delete db, delete files, truncate, etc.)
+ *   2. No self-restart (gateway restart, kill the running process)
+ *   3. No configuration changes (openclaw config set, ~/.openclaw/*)
+ *
+ * Prompt teaches the rule; a runtime constraint gate (added in a
+ * follow-up commit) enforces the rule in code. Both layers required.
+ */
+export function buildAcceptEditsPlanInjection(planSteps: string[]): string {
+  const stepList = planSteps.map((s, i) => `${i + 1}. ${s}`).join("\n");
+  return (
+    "[PLAN_DECISION]: edited\n\n" +
+    "The user has approved the following plan with acceptEdits permission. " +
+    "Execute it now. You may self-modify the plan via update_plan during " +
+    "execution when you are ≥95% confident that:\n" +
+    "  - A step needs to be added to reach the goal, OR\n" +
+    "  - A step is no longer necessary (mark it cancelled), OR\n" +
+    "  - The plan needs to pivot based on new information.\n\n" +
+    "Before modifying the plan, briefly state:\n" +
+    "  1. What you're changing\n" +
+    "  2. Your confidence level (must be ≥95%)\n" +
+    "  3. The evidence justifying the change\n\n" +
+    "If confidence is <95%, ask the user instead of modifying.\n\n" +
+    "Hard constraints (OVERRIDE acceptEdits — require explicit user confirmation):\n" +
+    "  - No destructive actions (rm, rmdir, DROP TABLE, DELETE FROM, truncate, " +
+    "overwrites of protected files)\n" +
+    "  - No self-restart (openclaw gateway restart, launchctl kickstart, " +
+    "kill the gateway process)\n" +
+    "  - No configuration changes (openclaw config set, writes to " +
+    "~/.openclaw/config.toml or ~/.claude/config)\n\n" +
+    "The approved plan:\n\n" +
+    stepList
+  );
+}

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -37,6 +37,7 @@
  * isolation.
  */
 
+import { resolvePlanApproval } from "../plan-mode/approval.js";
 import type { PlanModeSessionState, PlanStep } from "../types.js";
 import {
   CURRENT_SCHEMA_VERSION,
@@ -448,19 +449,13 @@ export class PlanModeStore {
   /**
    * Record a plan-approval rejection.
    *
-   * Increments rejectionCount, stores the user's feedback, transitions
-   * approval state to "rejected" (session stays in mode=plan so the
-   * agent can revise). Returns the new rejectionCount so callers can
-   * decide whether to surface the deescalation hint
-   * (rejectionCount ≥ 3, added by buildPlanDecisionInjection).
+   * Delegates to `resolvePlanApproval(action: "reject")` for byte-identical
+   * parity with the in-host state machine. Returns the discriminated-union
+   * result expected by `session-actions.plan.reject`.
    *
-   * Idempotent on no-op: if the session isn't in plan mode or has no
-   * pending approval, returns kind: "skipped" without writing.
-   *
-   * host_ref: in-host rejection-cycle increments are spread across
-   *   sessions-patch.ts + resolvePlanApproval at
-   *   src/agents/plan-mode/approval.ts. We consolidate into the
-   *   typed mutator here.
+   * host_ref: src/agents/plan-mode/approval.ts:resolvePlanApproval
+   *   (commit ea04ea52c7). The surgical port at src/plan-mode/approval.ts
+   *   is byte-identical with import-path adaptation only.
    */
   async recordRejection(input: {
     sessionKey: string;
@@ -470,73 +465,32 @@ export class PlanModeStore {
     | { kind: "skipped"; reason: "not-plan-mode" | "no-pending-approval" }
     | { kind: "failed"; error: Error }
   > {
-    const { sessionKey, feedback } = input;
-    try {
-      let outcome:
-        | { kind: "recorded"; rejectionCount: number; state: PlanModeSessionState }
-        | { kind: "skipped"; reason: "not-plan-mode" | "no-pending-approval" };
-      const { transition } = await this.gateway.withLock<{
-        prev: PlanModeSessionState | undefined;
-        next: PlanModeSessionState;
-      }>(sessionKey, async (current) => {
-        if (!current || current.mode !== "plan") {
-          outcome = { kind: "skipped", reason: "not-plan-mode" };
-          return { next: null };
-        }
-        if (current.approval !== "pending") {
-          outcome = { kind: "skipped", reason: "no-pending-approval" };
-          return { next: null };
-        }
-        const now = Date.now();
-        const newRejectionCount = current.rejectionCount + 1;
-        const next: PlanModeSessionState = {
-          ...current,
-          approval: "rejected",
-          rejectionCount: newRejectionCount,
-          updatedAt: now,
-          ...(feedback ? { feedback } : {}),
-          // Clear approvalId on rejection — the user's next [PLAN_DECISION]
-          // for THIS cycle is resolved; agent must propose anew with a
-          // fresh approvalId on retry.
-          approvalId: undefined,
-        };
-        outcome = {
-          kind: "recorded",
-          rejectionCount: newRejectionCount,
-          state: next,
-        };
-        return {
-          next: stampSchemaVersion(next) as PlanModeSessionState,
-          transition: { prev: current, next },
-        };
-      });
-      if (transition && this.audit) {
-        this.audit({
-          sessionKey,
-          prev: transition.prev,
-          next: transition.next,
-          source: "smarter-claw:PlanModeStore.recordRejection",
-        });
-      }
-      return outcome!;
-    } catch (err) {
-      const wrapped = err instanceof Error ? err : new Error(String(err));
-      this.logger?.warn?.(
-        `PlanModeStore.recordRejection: failed (sessionKey=${sessionKey}): ${wrapped.message}`,
-      );
-      return { kind: "failed", error: wrapped };
+    const result = await this.applyApprovalAction({
+      sessionKey: input.sessionKey,
+      action: "reject",
+      ...(input.feedback !== undefined ? { feedback: input.feedback } : {}),
+    });
+    if (result.kind === "recorded") {
+      return {
+        kind: "recorded",
+        rejectionCount: result.state.rejectionCount,
+        state: result.state,
+      };
     }
+    return result;
   }
 
   /**
    * Record a plan-approval acceptance.
    *
-   * Transitions approval → "approved" (or "edited" when user inline-edited).
-   * The session stays in mode=plan until the runtime processes the
-   * [PLAN_DECISION]: approved injection on the next turn; at that
-   * point the agent exits plan mode and starts executing the plan.
+   * Delegates to `resolvePlanApproval(action: "approve" | "edit")` for
+   * byte-identical parity with the in-host state machine. Both approve
+   * and edit transition mode → "normal", clear feedback, and reset
+   * `rejectionCount` to 0 (the user is moving forward; cycle history
+   * is no longer relevant).
    *
-   * Idempotent on no-op: if session isn't in pending state, skips.
+   * host_ref: src/agents/plan-mode/approval.ts:resolvePlanApproval
+   *   (commit ea04ea52c7).
    */
   async recordApproval(input: {
     sessionKey: string;
@@ -546,10 +500,65 @@ export class PlanModeStore {
     | { kind: "skipped"; reason: "not-plan-mode" | "no-pending-approval" }
     | { kind: "failed"; error: Error }
   > {
-    const { sessionKey, edited } = input;
+    const action: "approve" | "edit" = input.edited ? "edit" : "approve";
+    const result = await this.applyApprovalAction({
+      sessionKey: input.sessionKey,
+      action,
+    });
+    if (result.kind === "recorded") {
+      return {
+        kind: "recorded",
+        approval: action === "edit" ? "edited" : "approved",
+        state: result.state,
+      };
+    }
+    return result;
+  }
+
+  /**
+   * Record a plan-approval timeout.
+   *
+   * Delegates to `resolvePlanApproval(action: "timeout")` for parity with
+   * the in-host state machine. Timeout only applies on `approval ===
+   * "pending"`; any other state is a no-op (returns `skipped`).
+   *
+   * host_ref: src/agents/plan-mode/approval.ts:resolvePlanApproval
+   *   (commit ea04ea52c7).
+   */
+  async recordTimeout(input: {
+    sessionKey: string;
+  }): Promise<
+    | { kind: "recorded"; state: PlanModeSessionState }
+    | { kind: "skipped"; reason: "not-plan-mode" | "no-pending-approval" }
+    | { kind: "failed"; error: Error }
+  > {
+    return this.applyApprovalAction({
+      sessionKey: input.sessionKey,
+      action: "timeout",
+    });
+  }
+
+  /**
+   * Private helper: wraps the gateway lock + the verbatim-ported
+   * `resolvePlanApproval` state machine + audit emission.
+   *
+   * No-op detection: `resolvePlanApproval` returns `current` (by
+   * reference) when its guards fire (terminal-state, stale-event, or
+   * timeout-on-non-pending). We compare `next === current` for skip.
+   */
+  private async applyApprovalAction(input: {
+    sessionKey: string;
+    action: "approve" | "edit" | "reject" | "timeout";
+    feedback?: string;
+  }): Promise<
+    | { kind: "recorded"; state: PlanModeSessionState }
+    | { kind: "skipped"; reason: "not-plan-mode" | "no-pending-approval" }
+    | { kind: "failed"; error: Error }
+  > {
+    const { sessionKey, action, feedback } = input;
     try {
       let outcome:
-        | { kind: "recorded"; approval: "approved" | "edited"; state: PlanModeSessionState }
+        | { kind: "recorded"; state: PlanModeSessionState }
         | { kind: "skipped"; reason: "not-plan-mode" | "no-pending-approval" };
       const { transition } = await this.gateway.withLock<{
         prev: PlanModeSessionState | undefined;
@@ -559,41 +568,39 @@ export class PlanModeStore {
           outcome = { kind: "skipped", reason: "not-plan-mode" };
           return { next: null };
         }
-        if (current.approval !== "pending") {
+        const next = resolvePlanApproval(current, action, feedback);
+        if (next === current) {
+          // Reference equality: resolvePlanApproval's guards fired
+          // (terminal-state for approve/edit/reject, or
+          // timeout-on-non-pending). No write.
           outcome = { kind: "skipped", reason: "no-pending-approval" };
           return { next: null };
         }
-        const now = Date.now();
-        const newApproval: "approved" | "edited" = edited ? "edited" : "approved";
-        const next: PlanModeSessionState = {
-          ...current,
-          approval: newApproval,
-          confirmedAt: now,
-          updatedAt: now,
-        };
-        outcome = {
-          kind: "recorded",
-          approval: newApproval,
-          state: next,
-        };
+        outcome = { kind: "recorded", state: next };
         return {
           next: stampSchemaVersion(next) as PlanModeSessionState,
           transition: { prev: current, next },
         };
       });
       if (transition && this.audit) {
+        const source =
+          action === "reject"
+            ? "smarter-claw:PlanModeStore.recordRejection"
+            : action === "timeout"
+              ? "smarter-claw:PlanModeStore.recordTimeout"
+              : "smarter-claw:PlanModeStore.recordApproval";
         this.audit({
           sessionKey,
           prev: transition.prev,
           next: transition.next,
-          source: "smarter-claw:PlanModeStore.recordApproval",
+          source,
         });
       }
       return outcome!;
     } catch (err) {
       const wrapped = err instanceof Error ? err : new Error(String(err));
       this.logger?.warn?.(
-        `PlanModeStore.recordApproval: failed (sessionKey=${sessionKey}): ${wrapped.message}`,
+        `PlanModeStore.applyApprovalAction[${action}]: failed (sessionKey=${sessionKey}): ${wrapped.message}`,
       );
       return { kind: "failed", error: wrapped };
     }

--- a/tests/eva-live-smokes/smoke-2-plan-approve-flow.test.ts
+++ b/tests/eva-live-smokes/smoke-2-plan-approve-flow.test.ts
@@ -107,18 +107,22 @@ describe("Eva live-smoke #2 — full plan-approve-execute (P-8)", () => {
     });
     const approvalId = exitResult.details.approvalId;
 
-    // First accept succeeds.
+    // First accept succeeds — surgical-port (PR-#) brings the plugin into
+    // parity with in-host resolvePlanApproval, which transitions mode →
+    // "normal" on approve. So a second accept on the same session now
+    // hits the session-action layer's NOT_IN_PLAN_MODE check first
+    // (session has exited plan mode after the successful approve).
     await harness.invokeAction("plan.accept", {
       sessionKey: SESSION_KEY,
       payload: { approvalId },
     });
-    // Second accept should report NO_PENDING_APPROVAL.
+    // Second accept should be rejected — session is no longer in plan mode.
     const second = (await harness.invokeAction("plan.accept", {
       sessionKey: SESSION_KEY,
       payload: { approvalId },
     })) as { ok: boolean; code?: string };
     expect(second.ok).toBe(false);
-    expect(second.code).toBe("NO_PENDING_APPROVAL");
+    expect(second.code).toBe("NOT_IN_PLAN_MODE");
   });
 
   it("STALE_APPROVAL_ID when accept is called with the wrong approvalId", async () => {

--- a/tests/plan-mode/approval.test.ts
+++ b/tests/plan-mode/approval.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Tests for `resolvePlanApproval` — surgical-port companion to
+ * `src/plan-mode/approval.ts`.
+ *
+ * **Parity contract**: verbatim port of the in-host `resolvePlanApproval`
+ * tests at `/Volumes/LEXAR/repos/openclaw-pr70071-rebase/src/agents/plan-mode/approval.test.ts:18-107`
+ * (commit ea04ea52c7).
+ *
+ * The text-builder tests (`buildApprovedPlanInjection`,
+ * `buildAcceptEditsPlanInjection`, `buildPlanDecisionInjection`) from the
+ * same in-host file are deferred — the plugin's
+ * `src/prompt/plan-decision-injection.ts` already covers the rejection
+ * text builder; the approve/edit text builders land in surgical PR #3
+ * alongside the ACTION CONTRACT block port.
+ */
+
+import { describe, expect, it } from "vitest";
+import { resolvePlanApproval } from "../../src/plan-mode/approval.js";
+import type { PlanModeSessionState } from "../../src/types.js";
+
+const BASE_STATE: PlanModeSessionState = {
+  mode: "plan",
+  approval: "pending",
+  enteredAt: 1000,
+  updatedAt: 2000,
+  rejectionCount: 0,
+};
+
+describe("resolvePlanApproval", () => {
+  it("approve transitions to normal mode with approved state", () => {
+    const result = resolvePlanApproval(BASE_STATE, "approve");
+    expect(result.mode).toBe("normal");
+    expect(result.approval).toBe("approved");
+    expect(result.confirmedAt).toBeGreaterThan(0);
+    expect(result.feedback).toBeUndefined();
+  });
+
+  it("edit transitions to normal mode (user edits count as approval)", () => {
+    const result = resolvePlanApproval(BASE_STATE, "edit");
+    expect(result.mode).toBe("normal");
+    expect(result.approval).toBe("edited");
+    expect(result.confirmedAt).toBeGreaterThan(0);
+  });
+
+  it("reject stays in plan mode and increments rejectionCount", () => {
+    const result = resolvePlanApproval(BASE_STATE, "reject", "Combine steps 2 and 3");
+    expect(result.mode).toBe("plan");
+    expect(result.approval).toBe("rejected");
+    expect(result.rejectionCount).toBe(1);
+    expect(result.feedback).toBe("Combine steps 2 and 3");
+  });
+
+  it("accumulates rejectionCount across multiple rejections", () => {
+    let state = BASE_STATE;
+    state = resolvePlanApproval(state, "reject", "Too many steps");
+    expect(state.rejectionCount).toBe(1);
+    state = resolvePlanApproval(state, "reject", "Still too complex");
+    expect(state.rejectionCount).toBe(2);
+    state = resolvePlanApproval(state, "reject");
+    expect(state.rejectionCount).toBe(3);
+  });
+
+  it("timeout stays in plan mode with timed_out state", () => {
+    const result = resolvePlanApproval(BASE_STATE, "timeout");
+    expect(result.mode).toBe("plan");
+    expect(result.approval).toBe("timed_out");
+  });
+
+  it("ignores stale timeout after approval is already resolved", () => {
+    const approved: PlanModeSessionState = {
+      ...BASE_STATE,
+      approval: "approved",
+      mode: "normal",
+    };
+    const result = resolvePlanApproval(approved, "timeout");
+    expect(result.mode).toBe("normal");
+    expect(result.approval).toBe("approved");
+  });
+
+  it("preserves enteredAt across all transitions", () => {
+    for (const action of ["approve", "edit", "reject", "timeout"] as const) {
+      const result = resolvePlanApproval(BASE_STATE, action);
+      expect(result.enteredAt).toBe(1000);
+    }
+  });
+
+  it("clears feedback on approval", () => {
+    const pending: PlanModeSessionState = {
+      ...BASE_STATE,
+      approval: "pending",
+      feedback: "old feedback",
+      rejectionCount: 1,
+    };
+    const result = resolvePlanApproval(pending, "approve");
+    expect(result.feedback).toBeUndefined();
+  });
+
+  it("allows transitions from rejected state (user changes mind)", () => {
+    const rejected: PlanModeSessionState = {
+      ...BASE_STATE,
+      approval: "rejected",
+      feedback: "old feedback",
+    };
+    const result = resolvePlanApproval(rejected, "approve");
+    expect(result.approval).toBe("approved");
+    expect(result.feedback).toBeUndefined();
+  });
+
+  it("ignores actions on terminal states (approved, edited, timed_out)", () => {
+    const approved: PlanModeSessionState = {
+      ...BASE_STATE,
+      approval: "approved",
+      confirmedAt: 3000,
+    };
+    const result = resolvePlanApproval(approved, "reject", "too late");
+    expect(result.approval).toBe("approved"); // no-op
+  });
+
+  // Plugin-port additions: stale-event guard (line 62-66 of approval.ts).
+  // The in-host has integration coverage in approval.test.ts via the
+  // `expectedApprovalId` param of resolvePlanApproval; the in-host's
+  // unit-test file doesn't pin this directly. We pin it here so the
+  // plugin's stale-event-guard contract is regression-tested.
+  describe("expectedApprovalId stale-event guard (in-host approval.ts:62-66)", () => {
+    const APPROVAL_ID = "plan-aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee";
+    const STALE_ID = "plan-00000000-0000-4000-9000-000000000000";
+
+    it("no-ops on approve when expectedApprovalId mismatches current", () => {
+      const pending: PlanModeSessionState = {
+        ...BASE_STATE,
+        approval: "pending",
+        approvalId: APPROVAL_ID,
+      };
+      const result = resolvePlanApproval(pending, "approve", undefined, STALE_ID);
+      expect(result).toBe(pending); // reference-equal — no-op
+    });
+
+    it("no-ops on approve when expectedApprovalId is provided but current.approvalId is undefined", () => {
+      const pending: PlanModeSessionState = {
+        ...BASE_STATE,
+        approval: "pending",
+        // approvalId deliberately undefined
+      };
+      const result = resolvePlanApproval(pending, "approve", undefined, APPROVAL_ID);
+      expect(result).toBe(pending);
+    });
+
+    it("proceeds when expectedApprovalId matches", () => {
+      const pending: PlanModeSessionState = {
+        ...BASE_STATE,
+        approval: "pending",
+        approvalId: APPROVAL_ID,
+      };
+      const result = resolvePlanApproval(pending, "approve", undefined, APPROVAL_ID);
+      expect(result.approval).toBe("approved");
+      expect(result).not.toBe(pending); // new state
+    });
+
+    it("proceeds when expectedApprovalId is undefined (no token, no check)", () => {
+      const pending: PlanModeSessionState = {
+        ...BASE_STATE,
+        approval: "pending",
+        approvalId: APPROVAL_ID,
+      };
+      const result = resolvePlanApproval(pending, "approve");
+      expect(result.approval).toBe("approved");
+    });
+  });
+
+  // Plugin-port addition: "none" state guard (in-host approval.ts:73-83
+  // PR-D review fix Codex P2 #3096560406 / Copilot #3105172000).
+  describe("'none' state guard (in-host approval.ts:73-83)", () => {
+    it("no-ops on approve when approval is 'none' AND no expectedApprovalId", () => {
+      const fresh: PlanModeSessionState = {
+        ...BASE_STATE,
+        approval: "none", // freshly entered plan mode, no proposal yet
+      };
+      const result = resolvePlanApproval(fresh, "approve");
+      expect(result).toBe(fresh);
+    });
+
+    it("no-ops on reject when approval is 'none'", () => {
+      const fresh: PlanModeSessionState = {
+        ...BASE_STATE,
+        approval: "none",
+      };
+      const result = resolvePlanApproval(fresh, "reject", "fb");
+      expect(result).toBe(fresh);
+    });
+  });
+});

--- a/tests/state/store.test.ts
+++ b/tests/state/store.test.ts
@@ -617,9 +617,12 @@ describe("P-11 PlanModeStore.recordRejection — happy path", () => {
     expect(gw.peek(SESSION_KEY)?.feedback).toBe("older feedback");
   });
 
-  it("clears approvalId on rejection (current cycle resolved)", async () => {
+  it("preserves approvalId across rejection (in-host parity — the approval token continues to identify the cycle)", async () => {
+    // Surgical-port fix (Wave-1 audit S8): in-host resolvePlanApproval at
+    // approval.ts:115-124 spreads `...current` which RETAINS approvalId on
+    // reject. Previous plugin code cleared it; that was a parity drift.
     await store.recordRejection({ sessionKey: SESSION_KEY });
-    expect(gw.peek(SESSION_KEY)?.approvalId).toBeUndefined();
+    expect(gw.peek(SESSION_KEY)?.approvalId).toBe(APPROVAL_ID);
   });
 
   it("preserves mode === plan (agent stays in plan mode to revise)", async () => {
@@ -684,14 +687,23 @@ describe("P-11 PlanModeStore.recordRejection — skip paths", () => {
     expect(gw.writeCount).toBe(0);
   });
 
-  it("skips with no-pending-approval when approval is already 'rejected'", async () => {
+  it("allows rejection from 'rejected' state (in-host parity — re-rejection is valid)", async () => {
+    // Surgical-port fix (Wave-1 audit S8): in-host approval.ts:82-83
+    // accepts BOTH "pending" and "rejected" as inputs for action="reject"
+    // (`if (current.approval !== "pending" && current.approval !== "rejected")`).
+    // The "Rejected stays open for re-approval or re-rejection" comment
+    // at line 11 of in-host docstring is the contract.
     gw.seed(
       SESSION_KEY,
-      planModeSession({ mode: "plan", approval: "rejected" }),
+      planModeSession({ mode: "plan", approval: "rejected", rejectionCount: 2 }),
     );
-    const r = await store.recordRejection({ sessionKey: SESSION_KEY });
-    expect(r.kind).toBe("skipped");
-    expect(gw.writeCount).toBe(0);
+    const r = await store.recordRejection({
+      sessionKey: SESSION_KEY,
+      feedback: "still wrong",
+    });
+    expect(r.kind).toBe("recorded");
+    if (r.kind === "recorded") expect(r.rejectionCount).toBe(3);
+    expect(gw.peek(SESSION_KEY)?.approval).toBe("rejected");
   });
 
   it("skips with no-pending-approval when approval is 'approved'", async () => {
@@ -789,9 +801,46 @@ describe("P-11 PlanModeStore.recordApproval — happy path", () => {
     expect(gw.peek(SESSION_KEY)?.approvalId).toBe(APPROVAL_ID);
   });
 
-  it("preserves mode === plan (runtime processes injection before exiting)", async () => {
+  it("transitions mode → normal on approve + clears feedback + resets rejectionCount (in-host parity)", async () => {
+    // Surgical-port fix (Wave-1 audit S8): in-host approval.ts:89-101
+    // sets mode: "normal", feedback: undefined, rejectionCount: 0 on
+    // approve. Prior plugin code kept mode: "plan", retained feedback,
+    // and didn't touch rejectionCount — all 4 P0 parity drifts.
+    gw.seed(
+      SESSION_KEY,
+      planModeSession({
+        mode: "plan",
+        approval: "pending",
+        approvalId: APPROVAL_ID,
+        rejectionCount: 2,
+        feedback: "lingering feedback",
+      }),
+    );
     await store.recordApproval({ sessionKey: SESSION_KEY });
-    expect(gw.peek(SESSION_KEY)?.mode).toBe("plan");
+    const next = gw.peek(SESSION_KEY)!;
+    expect(next.mode).toBe("normal");
+    expect(next.approval).toBe("approved");
+    expect(next.rejectionCount).toBe(0);
+    expect(next.feedback).toBeUndefined();
+  });
+
+  it("transitions mode → normal on edit (same reset behavior as approve)", async () => {
+    gw.seed(
+      SESSION_KEY,
+      planModeSession({
+        mode: "plan",
+        approval: "pending",
+        approvalId: APPROVAL_ID,
+        rejectionCount: 3,
+        feedback: "old fb",
+      }),
+    );
+    await store.recordApproval({ sessionKey: SESSION_KEY, edited: true });
+    const next = gw.peek(SESSION_KEY)!;
+    expect(next.mode).toBe("normal");
+    expect(next.approval).toBe("edited");
+    expect(next.rejectionCount).toBe(0);
+    expect(next.feedback).toBeUndefined();
   });
 
   it("emits audit event on the recorded path", async () => {
@@ -853,13 +902,29 @@ describe("P-11 PlanModeStore.recordApproval — skip paths", () => {
     expect(gw.writeCount).toBe(0);
   });
 
-  it("skips when approval is 'rejected' (revise-and-resubmit flow, not approve)", async () => {
+  it("allows approval from 'rejected' state (in-host parity — user changes mind)", async () => {
+    // Surgical-port fix (Wave-1 audit S8): in-host approval.ts:82-83
+    // accepts BOTH "pending" and "rejected" as inputs for action="approve".
+    // The "Rejected stays open for re-approval or re-rejection" contract
+    // (in-host approval.ts:11). The "user changes mind" path was blocked
+    // by the prior plugin code; resolvePlanApproval restores it.
     gw.seed(
       SESSION_KEY,
-      planModeSession({ mode: "plan", approval: "rejected" }),
+      planModeSession({
+        mode: "plan",
+        approval: "rejected",
+        rejectionCount: 2,
+        feedback: "old feedback",
+      }),
     );
     const r = await store.recordApproval({ sessionKey: SESSION_KEY });
-    expect(r.kind).toBe("skipped");
+    expect(r.kind).toBe("recorded");
+    if (r.kind === "recorded") expect(r.approval).toBe("approved");
+    const next = gw.peek(SESSION_KEY)!;
+    expect(next.approval).toBe("approved");
+    expect(next.mode).toBe("normal"); // approve transitions to normal
+    expect(next.rejectionCount).toBe(0); // reset on approve
+    expect(next.feedback).toBeUndefined(); // cleared on approve
   });
 });
 


### PR DESCRIPTION
## What
Verbatim port of in-host `src/agents/plan-mode/approval.ts` (commit `ea04ea52c7`) into `src/plan-mode/approval.ts`. Refactor `PlanModeStore.recordApproval` + `recordRejection` to delegate. Closes Wave-1 audit S8's 4 P0 parity drifts.

## Why
Wave-1 audit found that the prior typed mutators dropped 4 behaviors vs in-host:
- didn't reset `rejectionCount` on approve/edit
- didn't clear `feedback` on approve/edit
- didn't transition `mode` → "normal" on approve/edit
- blocked `rejected` → `approve/edit/reject` (user-changes-mind path)

All 4 were locked in by passing plugin tests cementing the divergence.

## Discipline (per user 2026-05-12 ask)
The architectural choice this PR fixes is the surgical-port pivot: stop inventing new state machines, just call the in-host's. The plugin gets a new file `src/plan-mode/approval.ts` that is byte-identical to in-host (only import path differs). The discriminated-union API on `PlanModeStore` is unchanged — session-actions and other callers don't need updates.

## Tests
- 16 new cases in `tests/plan-mode/approval.test.ts` (10 verbatim from in-host + 6 stale-event/none-state guards)
- 4 store tests flipped from cementing the divergence to asserting correct behavior
- 1 eva-live-smoke case updated (double-accept now correctly hits NOT_IN_PLAN_MODE)
- **613/613 pass** (was 596; +17 net)
- typecheck clean

## Impact on Wave-1 plan
This closes A-P0-2 through A-P0-5 in [`docs/audits/wave-1-consolidated-plan.md`](https://github.com/electricsheephq/Smarter-Claw/blob/main/docs/audits/wave-1-consolidated-plan.md) — 4 of the 18 P0 bug fixes. Surgical PRs #2–#5 will close the rest.

Tracker: #77 (epic).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented plan approval state machine supporting approve, edit, reject, and timeout actions with protection against stale clicks and out-of-sequence transitions.
  * Added timeout handling for pending approvals with graceful state management and rejection tracking across approval cycles.

* **Tests**
  * Added comprehensive test coverage for plan approval flows, state transitions, and approval state guards.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/Smarter-Claw/pull/86)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->