### PR TITLE
Surgical PR #2: re-port enter/exit plan-mode tools (Wave-1 S1)

### DIFF
--- a/src/plan-mode/tool-descriptions.ts
+++ b/src/plan-mode/tool-descriptions.ts
@@ -1,0 +1,88 @@
+/**
+ * Tool descriptions for `enter_plan_mode` and `exit_plan_mode`.
+ *
+ * **Parity contract**: byte-identical port of
+ * `src/agents/tool-description-presets.ts:12-15, 98-145` at commit
+ * `ea04ea52c7`
+ * (`/Users/lume/repos/openclaw-pr70071-rebase/src/agents/tool-description-presets.ts`).
+ *
+ * Only adaptation: this file is plan-mode-scoped — the in-host puts
+ * every tool preset in one shared file; the plugin only needs the two
+ * plan-mode ones. No content adapted.
+ *
+ * # Why these descriptions are load-bearing
+ *
+ * Eva's live-test iter-2/iter-3 cycles found the agent demonstrably:
+ *   - Halted after enter_plan_mode (no exit_plan_mode follow-up)
+ *   - Posted the plan as chat text after exit_plan_mode in the same turn
+ *   - Called update_plan with all-terminal steps and expected approval
+ *   - Submitted exit_plan_mode before spawned subagents completed
+ *
+ * Each clause in describeEnterPlanModeTool / describeExitPlanModeTool
+ * exists to steer the model away from a specific failure mode that
+ * really happened during live testing. Do NOT prune for length.
+ *
+ * Surgical-port rationale (2026-05-12): Wave-1 audit slice S1 found
+ * the prior plugin descriptions had drifted by ~70% — they conveyed
+ * the gist but dropped TOOL LIFECYCLE (4-state machine), STOP AFTER,
+ * the chat-text-banned clause, the WAIT FOR SUBAGENTS clause, and the
+ * reference-card pointer. Re-porting the full strings verbatim is the
+ * fix.
+ *
+ * host_ref: src/agents/tool-description-presets.ts:12-15, 98-145
+ */
+
+export const ENTER_PLAN_MODE_TOOL_DISPLAY_SUMMARY =
+  "Enter plan mode — block mutation tools until the user approves a plan.";
+
+export const EXIT_PLAN_MODE_TOOL_DISPLAY_SUMMARY =
+  "Exit plan mode and request user approval of the proposed plan.";
+
+export function describeEnterPlanModeTool(): string {
+  return [
+    "Enter plan mode for this session.",
+    "Mutation tools (write, edit, exec, bash, sessions_send, etc.) become BLOCKED until you call exit_plan_mode and the user approves the proposed plan.",
+    "Read-only tools (read, web_search, web_fetch, update_plan) remain available so you can investigate before proposing changes.",
+    "Use this when the user explicitly asks for a plan-first workflow, or when the agent wants to confirm a multi-step change before executing.",
+    // Live-test iter-2 Bug F: lifecycle clarity. Agent demonstrably
+    // misordered tool calls (called update_plan with all-terminal
+    // steps and expected approval card; called exit_plan_mode then
+    // posted more chat). Spell out the lifecycle so the agent treats
+    // these tools as a small state machine.
+    "TOOL LIFECYCLE — use the right tool for the right phase: " +
+      "(1) enter_plan_mode = ONCE at the start of a planning cycle (no-op if already in plan mode). " +
+      "(2) update_plan = DURING investigation/execution to track progress (steps + status). Does NOT submit. " +
+      "(3) exit_plan_mode = ONCE when ready to propose. Submits the plan for user approval. " +
+      "After approval, mutations unlock — continue executing without re-entering plan mode unless the user requests a NEW planning cycle.",
+    // Iter-3 D3: pointer to reference card + self-test for full context.
+    "For the full plan-mode reference (state diagram, [PLAN_*]: tag taxonomy, /plan slash commands, common pitfalls, debugging tips): see the bootstrap-injected reference card visible on every in-mode turn. To inspect live plan-mode state at runtime, call `plan_mode_status` (read-only diagnostic).",
+  ].join(" ");
+}
+
+export function describeExitPlanModeTool(): string {
+  return [
+    // Live-test iter-2 Bug A + Bug F: this is the FIRST and most
+    // important rule. The agent kept emitting chat text after
+    // exit_plan_mode in the same turn, which (combined with the
+    // post-approval planMode-deletion stale-cache bug) broke the
+    // approval flow end-to-end. Hard-stop the agent immediately
+    // after the tool call.
+    "STOP AFTER THIS TOOL CALL — do NOT emit any further assistant text in the same turn. The exit_plan_mode call IS your final action; trailing chat text breaks the approval card lifecycle and the user gets stuck. If you want to give context, put it BEFORE the tool call OR inside the tool's `summary`/`analysis` fields.",
+    "REQUIRED when the session is in plan mode: submits the proposed plan to the user for Approve/Edit/Reject.",
+    "When the user asks for a plan while in plan mode, your reply MUST be a brief acknowledgement followed by an exit_plan_mode tool call — do NOT write the plan as a markdown list in chat text, that bypasses the approval flow.",
+    // PR-8 follow-up: belt-and-suspenders steer paired with a hard-block
+    // runtime check. Eva's post-mortem flagged treating "research
+    // launched" as "research complete" as the exact bug this prevents.
+    "WAIT FOR SPAWNED SUBAGENTS BEFORE CALLING THIS TOOL. If you used sessions_spawn during plan-mode investigation (research, adversarial review, etc.), wait for ALL of them to return their completion messages before calling exit_plan_mode. The runtime rejects submission with an error listing pending child run ids if any are still in flight. Treat unresolved children as a blocking dependency of the investigation phase — 'research launched' is not 'research complete.'",
+    "Pass the full plan via `plan` using the same shape as update_plan (array of {step, status, activeForm?}).",
+    // PR-9 Tier 1: explicit title field. Without this, the agent's chat
+    // text leaked into the title slot ("I checked all five VMs..." as
+    // the plan title). Title belongs in the tool call, not in chat.
+    'ALSO PASS `title` (under 80 chars) — a concise plan name used as the approval-card header AND the persisted markdown filename slug. Examples: "Migrate VM provisioning to golden snapshot", "Fix websocket reconnect race in PR-67721". Do NOT put plan content in `title` — that goes in `plan` and `summary`.',
+    "Optionally pass `summary` (one sentence) — surfaced as the subtitle next to the title.",
+    "The runtime emits an approval card; the user can Approve (mutations unlock and you proceed), Approve with edits (same), Reject with feedback (you stay in plan mode and revise; feedback arrives in your next turn as [PLAN_DECISION]: rejected), or let it Time Out.",
+    "Calling this without an active plan-mode session is a no-op; calling it without `plan` content is rejected.",
+    // Iter-3 D3: pointer to reference card + self-test for full context.
+    "For the full plan-mode reference (state diagram, [PLAN_*]: tag taxonomy, /plan slash commands, common pitfalls, debugging tips): see the bootstrap-injected reference card visible on every in-mode turn. To inspect live plan-mode state at runtime, call `plan_mode_status` (read-only diagnostic).",
+  ].join(" ");
+}

--- a/src/tools/enter-plan-mode.ts
+++ b/src/tools/enter-plan-mode.ts
@@ -1,7 +1,8 @@
 /**
  * `enter_plan_mode` agent tool.
  *
- * host_ref: src/agents/tools/enter-plan-mode-tool.ts (in-host source-of-truth)
+ * host_ref: src/agents/tools/enter-plan-mode-tool.ts (in-host source-of-truth
+ *           at commit ea04ea52c7).
  *
  * # What this does
  *
@@ -21,16 +22,27 @@
  *
  * # Output contract
  *
- * The text content explicitly tells the model that entering plan mode
- * is step 1 of 2, and that exit_plan_mode (with a real plan body) is
- * the next required action. Without this nudge, models commonly
- * respond with "I'm opening a fresh plan cycle" and HALT, leaving the
- * session in plan mode with no plan proposed.
+ * Description + TOOL_OUTPUT_TEXT are byte-identical to in-host
+ * (`src/agents/tool-description-presets.ts:98-117` + the tool's
+ * inline TOOL_OUTPUT_TEXT at `enter-plan-mode-tool.ts:61-66`). The
+ * text explicitly tells the model that entering plan mode is step
+ * 1 of 2 and that `exit_plan_mode` (with a real plan body) is the
+ * next required action. Without this nudge, models commonly respond
+ * with "I'm opening a fresh plan cycle" and HALT, leaving the session
+ * in plan mode with no plan proposed.
  *
- * host_ref output prose: src/agents/tools/enter-plan-mode-tool.ts:62-68
+ * Surgical-port rationale (2026-05-12): Wave-1 audit slice S1 found
+ * the prior plugin description was a short paraphrase missing the
+ * TOOL LIFECYCLE (4-state machine) and reference-card pointer.
+ * Re-porting the full string verbatim from
+ * tool-description-presets.ts closes the parity drift.
  */
 
 import { Type } from "typebox";
+import {
+  describeEnterPlanModeTool,
+  ENTER_PLAN_MODE_TOOL_DISPLAY_SUMMARY,
+} from "../plan-mode/tool-descriptions.js";
 import { PlanModeStore } from "../state/store.js";
 import { readStringParam } from "./common.js";
 
@@ -56,16 +68,21 @@ const SCHEMA = Type.Object(
       }),
     ),
   },
+  // Copilot review #68939 (2026-04-19): forbid additional properties
+  // for consistency with `plan_mode_status` and the post-third-wave
+  // schema-hardening direction.
   { additionalProperties: false },
 );
 
-const TOOL_DESCRIPTION =
-  "Enter plan mode. While active, mutating tools (Edit, Write, Bash, " +
-  "NotebookEdit) are blocked; the agent must propose a plan via " +
-  "`exit_plan_mode` and get user approval before mutations resume. " +
-  "Use this for multi-file refactors, design decisions with multiple " +
-  "options, or any change the user should review before execution.";
-
+// Byte-identical to in-host enter-plan-mode-tool.ts:61-66. The 4
+// clauses each address a specific live-test failure mode:
+//  1. "Plan mode is now active." — confirms the transition landed
+//  2. "Next required step: ..." — names exit_plan_mode as the
+//     mandatory follow-up; lists allowed read-only tools so the model
+//     knows what IS still callable
+//  3. "Do NOT stop after this tool call" — anti-halt nudge
+//  4. "Do NOT respond with the plan as chat text" — channels the
+//     output into the approval-card-producing tool, not the chat stream
 const TOOL_OUTPUT_TEXT = [
   "Plan mode is now active.",
   "Next required step: investigate read-only if needed (read, web_search, web_fetch), then call `exit_plan_mode` with the proposed plan.",
@@ -73,14 +90,6 @@ const TOOL_OUTPUT_TEXT = [
   "Do NOT respond with the plan as chat text — it must go through `exit_plan_mode` so the user gets Approve/Reject buttons.",
 ].join(" ");
 
-/**
- * Tool factory. Pass into `api.registerTool` in the plugin entry.
- *
- * The factory shape matches `OpenClawPluginToolFactory` — a function
- * that takes a per-call tool context and returns an AnyAgentTool. We
- * receive the store + sessionKey resolver via closure here so each
- * per-call invocation uses the right session.
- */
 /**
  * Tool factory matching the SDK's OpenClawPluginToolFactory signature.
  * Pass into `api.registerTool` in the plugin entry. The SDK invokes
@@ -91,7 +100,11 @@ export function createEnterPlanModeTool(opts: CreateEnterPlanModeToolInput) {
   return (ctx: ToolContext) => ({
     label: "Enter Plan Mode",
     name: "enter_plan_mode",
-    description: TOOL_DESCRIPTION,
+    // displaySummary is not a recognized field on the plugin SDK's
+    // tool factory shape (only `label` + `description` are surfaced),
+    // so we export it as a constant for completeness/parity but do
+    // NOT pass it on the returned tool object.
+    description: describeEnterPlanModeTool(),
     parameters: SCHEMA,
     execute: async (
       _toolCallId: string,
@@ -149,3 +162,7 @@ export function createEnterPlanModeTool(opts: CreateEnterPlanModeToolInput) {
     },
   });
 }
+
+// Re-export the display-summary constant so callers needing parity
+// with the in-host preset can import it from a stable location.
+export { ENTER_PLAN_MODE_TOOL_DISPLAY_SUMMARY };

--- a/src/tools/exit-plan-mode.ts
+++ b/src/tools/exit-plan-mode.ts
@@ -1,46 +1,74 @@
 /**
  * `exit_plan_mode` agent tool.
  *
- * host_ref: src/agents/tools/exit-plan-mode-tool.ts (in-host source-of-truth)
+ * host_ref: src/agents/tools/exit-plan-mode-tool.ts (in-host source-of-truth
+ *           at commit ea04ea52c7).
  *
  * # What this does
  *
- * The agent calls `exit_plan_mode(title, plan, summary?)` to PROPOSE
- * the current plan for user approval. The plugin:
- *   1. Validates the plan steps (at most one `in_progress`)
- *   2. Computes the payloadHash (Invariant 3 duplicate-detection input)
- *   3. Mints an approvalId (security boundary token)
- *   4. Persists approval-pending state via PlanModeStore (the 10-invariant
+ * The agent calls `exit_plan_mode(title, plan, summary?, ...archetype)` to
+ * PROPOSE the current plan for user approval. The plugin:
+ *   1. Validates title is present + clamps to 80 chars (matches in-host)
+ *   2. Validates plan steps (at most one `in_progress`)
+ *   3. Parses optional archetype fields (analysis / assumptions / risks /
+ *      verification / references) with trim + drop-blank-entries
+ *   4. Computes the payloadHash (Invariant 3 duplicate-detection input)
+ *   5. Mints an approvalId (security boundary token)
+ *   6. Persists approval-pending state via PlanModeStore (the 10-invariant
  *      race-fix anchor)
- *   5. Returns a structured result for the model + downstream UI
+ *   7. Returns a structured result for the model + downstream UI
  *
- * # Schema scope (P-4)
+ * # Schema scope
  *
- * P-4 ships the CORE schema: title, plan, summary. The archetype
- * fields (analysis / assumptions / risks / verification / references)
- * are PR-10 from the in-host tree and land here at P-8 (archetype
- * port). For P-4 we accept them as optional pass-through so the
- * agent's schema-aware call doesn't fail, but we don't enforce
- * required-ness or persist them yet.
+ * Full in-host schema — including the 5 archetype fields
+ * (analysis / assumptions / risks / verification / references). Each
+ * field description is byte-identical to in-host.
  *
  * # In-host vs plugin port
  *
  * Same as enter_plan_mode: in-host the runner intercepts the tool
  * call and applies state transitions. Plugin port calls
  * PlanModeStore.persistApprovalRequest from the tool body directly.
+ *
+ * # Surgical-port rationale (2026-05-12)
+ *
+ * Wave-1 audit slice S1 found:
+ *   - title was schema-optional with no runtime check, so the agent's
+ *     chat narration leaked into the approval card title slot
+ *   - 80-char title clamp absent
+ *   - archetype field descriptions stripped from the schema (so the
+ *     model didn't know when to use them)
+ *   - archetype field VALUES dropped from the tool result `details`
+ *   - description text was a short paraphrase missing STOP AFTER,
+ *     WAIT FOR SUBAGENTS, chat-text-banned, and reference-card pointer
+ *
+ * This file ports the full in-host schema + description + handler
+ * verbatim where possible; plugin adaptations are limited to:
+ *   - Plugin-side status names ("approval-requested" vs in-host
+ *     "approval_requested") for consistency with the eva-live-smokes
+ *     + session-action wiring
+ *   - Skipping the subagent-gate (depends on host-internal
+ *     `getAgentRunContext`; the gateway-side gate at sessions-patch.ts
+ *     remains authoritative and is unchanged)
+ *   - Persistence via PlanModeStore.persistApprovalRequest instead of
+ *     in-host's `persistPlanApprovalRequest` helper
  */
 
 import { Type } from "typebox";
-import { computePlanPayloadHash } from "../helpers/payload-hash.js";
 import { newPlanApprovalId } from "../helpers/approval-id.js";
+import { computePlanPayloadHash } from "../helpers/payload-hash.js";
+import {
+  describeExitPlanModeTool,
+  EXIT_PLAN_MODE_TOOL_DISPLAY_SUMMARY,
+} from "../plan-mode/tool-descriptions.js";
 import { PlanModeStore } from "../state/store.js";
+import type { PlanStep } from "../types.js";
 import {
   PLAN_STEP_STATUSES,
   type PlanStepStatus,
   ToolInputError,
   readStringParam,
 } from "./common.js";
-import type { PlanStep } from "../types.js";
 
 export interface CreateExitPlanModeToolInput {
   store: PlanModeStore;
@@ -52,11 +80,19 @@ interface ToolContext {
 
 const SCHEMA = Type.Object(
   {
+    // PR-9 Tier 1: explicit plan title field. Without this the agent's
+    // chat text above the tool call became the de-facto title (brittle —
+    // sometimes the agent's narration leaked in instead of a real title).
+    // Title is required-ish at the schema level but tolerated when
+    // omitted (the runtime falls back to a clear required-error message
+    // — see the runtime guard below).
     title: Type.Optional(
       Type.String({
         description:
-          "Concise plan name (under 80 chars). Used as the approval-card header. " +
-          'Examples: "Migrate VM provisioning to golden snapshot", "Fix websocket reconnect race". ' +
+          "Concise plan name (under 80 chars). Used as the approval-card header, " +
+          "the sidebar title, and (when persisted) the markdown filename slug. " +
+          'Examples: "Migrate VM provisioning to golden snapshot", ' +
+          '"Fix websocket reconnect race in PR-67721". ' +
           "Do NOT put plan content here — that goes in `plan` and `summary`.",
       }),
     ),
@@ -87,43 +123,78 @@ const SCHEMA = Type.Object(
     summary: Type.Optional(
       Type.String({
         description:
-          "Optional one-line summary surfaced in the approval prompt.",
+          "Optional one-line summary surfaced in the approval prompt (UI / channel renderers).",
       }),
     ),
-    // PR-10 archetype fields — accepted but not yet persisted (P-8).
-    analysis: Type.Optional(Type.String()),
-    assumptions: Type.Optional(Type.Array(Type.String())),
+    // PR-10 plan-archetype fields — all optional and backwards-compatible.
+    // The plan-archetype system-prompt fragment (see plan-mode/plan-archetype-prompt.ts)
+    // tells the agent when these are required vs nice-to-have.
+    analysis: Type.Optional(
+      Type.String({
+        description:
+          "Markdown body explaining current state, chosen approach, and rationale. " +
+          "Multi-paragraph; this is the part of the plan that gives the user enough " +
+          "context to evaluate the proposal without re-reading every transcript turn. " +
+          "Required for non-trivial multi-file changes; can be omitted for one-shot fixes.",
+      }),
+    ),
+    assumptions: Type.Optional(
+      Type.Array(Type.String(), {
+        description:
+          "Explicit assumptions made during planning. Each entry is one sentence. " +
+          'Examples: "Tests will pass on first run after the new path lands", ' +
+          '"`packages/auth` retains its current public exports". ' +
+          "If any assumption is wrong, the plan needs revision — surface them.",
+      }),
+    ),
     risks: Type.Optional(
       Type.Array(
         Type.Object(
           {
-            risk: Type.String(),
-            mitigation: Type.String(),
+            risk: Type.String({
+              description: "What could go wrong (one sentence).",
+            }),
+            mitigation: Type.String({
+              description: "How the plan reduces or contains the risk.",
+            }),
           },
           { additionalProperties: false },
         ),
+        {
+          description:
+            "Risk register: things that could go wrong + how the plan mitigates each. " +
+            "Use this to surface known unknowns before approval.",
+        },
       ),
     ),
-    verification: Type.Optional(Type.Array(Type.String())),
-    references: Type.Optional(Type.Array(Type.String())),
+    verification: Type.Optional(
+      Type.Array(Type.String(), {
+        description:
+          "Concrete steps that will confirm the plan succeeded. " +
+          'Examples: "`pnpm test src/agents/...` passes", ' +
+          '"VM 127263714 responds to SSH within 60s", ' +
+          '"Telegram approval card renders inline buttons for kind=plugin". ' +
+          "Required for tasks where premature closure has cost; covers Wave B1 closure-gate criteria.",
+      }),
+    ),
+    references: Type.Optional(
+      Type.Array(Type.String(), {
+        description:
+          "Optional list of file paths, URLs, PR numbers, or doc references the plan builds on. " +
+          'Examples: "src/agents/plan-mode/types.ts:42", "PR #67538", "docs/agents/prompt-stack-spec.md". ' +
+          "Renders as a Reference section in the persisted markdown.",
+      }),
+    ),
   },
   { additionalProperties: false },
 );
-
-const TOOL_DESCRIPTION =
-  "Propose the current plan for user approval. The user gets " +
-  "Approve / Reject buttons. On Approve, mutations resume and the " +
-  "agent executes the plan. On Reject with feedback, the agent stays " +
-  "in plan mode and revises. Always call this AFTER `enter_plan_mode` " +
-  "+ any read-only investigation; never respond with the plan as " +
-  "chat text (the user won't see the approval card).";
 
 /**
  * Validate the plan steps. Throws ToolInputError on schema violations
  * the agent can recover from; the agent sees the error message and
  * can call again with corrections.
  *
- * host_ref: src/agents/tools/exit-plan-mode-tool.ts:155-200 (readPlanSteps)
+ * host_ref: src/agents/tools/exit-plan-mode-tool.ts:154-195 (readPlanSteps)
  */
 function readPlanSteps(params: Record<string, unknown>): PlanStep[] {
   const rawPlan = params.plan;
@@ -173,11 +244,85 @@ function readPlanSteps(params: Record<string, unknown>): PlanStep[] {
   return steps;
 }
 
+/**
+ * PR-10: parse the optional archetype fields from `exit_plan_mode` args.
+ * Each field is parsed defensively (trim + drop blank entries) so a
+ * malformed agent payload doesn't poison the approval card. Returns an
+ * object with only the parsed fields populated; missing/invalid fields
+ * stay undefined (caller spreads them conditionally).
+ *
+ * host_ref: src/agents/tools/exit-plan-mode-tool.ts:417-478
+ *           (readPlanArchetypeFields)
+ */
+function readPlanArchetypeFields(params: Record<string, unknown>): {
+  analysis?: string;
+  assumptions?: string[];
+  risks?: Array<{ risk: string; mitigation: string }>;
+  verification?: string[];
+  references?: string[];
+} {
+  const out: ReturnType<typeof readPlanArchetypeFields> = {};
+  const rawAnalysis = readStringParam(params, "analysis");
+  if (rawAnalysis && rawAnalysis.trim().length > 0) {
+    out.analysis = rawAnalysis.trim();
+  }
+  const rawAssumptions = params.assumptions;
+  if (Array.isArray(rawAssumptions)) {
+    const cleaned = rawAssumptions
+      .filter((entry): entry is string => typeof entry === "string")
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0);
+    if (cleaned.length > 0) {
+      out.assumptions = cleaned;
+    }
+  }
+  const rawRisks = params.risks;
+  if (Array.isArray(rawRisks)) {
+    const cleaned: Array<{ risk: string; mitigation: string }> = [];
+    for (const entry of rawRisks) {
+      if (!entry || typeof entry !== "object") {
+        continue;
+      }
+      const e = entry as Record<string, unknown>;
+      const risk = typeof e.risk === "string" ? e.risk.trim() : "";
+      const mitigation =
+        typeof e.mitigation === "string" ? e.mitigation.trim() : "";
+      if (risk.length > 0 && mitigation.length > 0) {
+        cleaned.push({ risk, mitigation });
+      }
+    }
+    if (cleaned.length > 0) {
+      out.risks = cleaned;
+    }
+  }
+  const rawVerification = params.verification;
+  if (Array.isArray(rawVerification)) {
+    const cleaned = rawVerification
+      .filter((entry): entry is string => typeof entry === "string")
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0);
+    if (cleaned.length > 0) {
+      out.verification = cleaned;
+    }
+  }
+  const rawReferences = params.references;
+  if (Array.isArray(rawReferences)) {
+    const cleaned = rawReferences
+      .filter((entry): entry is string => typeof entry === "string")
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0);
+    if (cleaned.length > 0) {
+      out.references = cleaned;
+    }
+  }
+  return out;
+}
+
 export function createExitPlanModeTool(opts: CreateExitPlanModeToolInput) {
   return (ctx: ToolContext) => ({
     label: "Exit Plan Mode",
     name: "exit_plan_mode",
-    description: TOOL_DESCRIPTION,
+    description: describeExitPlanModeTool(),
     parameters: SCHEMA,
     execute: async (
       _toolCallId: string,
@@ -185,6 +330,40 @@ export function createExitPlanModeTool(opts: CreateExitPlanModeToolInput) {
       _signal?: AbortSignal,
     ) => {
       const params = (args ?? {}) as Record<string, unknown>;
+      const summary = readStringParam(params, "summary");
+
+      // PR-9 Tier 1 + Bug 2/6 fix: title is REQUIRED. Without it the
+      // approval card defaults to "Active Plan" / "Plan approval
+      // requested" which is uninformative for the user reviewing the
+      // plan and unhelpful for the persisted markdown filename slug
+      // (would become `plan-YYYY-MM-DD-untitled.md`). Reject the call
+      // with a clear actionable error so the agent retries with a
+      // proper title on the next attempt — schema enforcement is the
+      // cleanest signal vs a silent fallback.
+      //
+      // Order matters: title check runs BEFORE plan validation so the
+      // agent sees the title-required error first (most common omission)
+      // rather than fixing a plan, retrying, then hitting title-required.
+      // Byte-identical to in-host exit-plan-mode-tool.ts:213-231.
+      const rawTitle = readStringParam(params, "title");
+      const trimmedTitle = rawTitle?.trim();
+      if (!trimmedTitle) {
+        const err = new ToolInputError(
+          "exit_plan_mode requires a `title` field — a concise plan name " +
+            "(under 80 chars) used as the approval-card header, sidebar " +
+            "title, and persisted markdown filename slug. " +
+            'Example: title: "Refactor websocket reconnect race". ' +
+            "Re-call exit_plan_mode with the title field included.",
+        );
+        return {
+          content: [
+            { type: "text" as const, text: `exit_plan_mode: ${err.message}` },
+          ],
+          details: { status: "invalid-input" as const, error: err.message },
+        };
+      }
+      const title = trimmedTitle.slice(0, 80);
+
       let steps: PlanStep[];
       try {
         steps = readPlanSteps(params);
@@ -199,8 +378,10 @@ export function createExitPlanModeTool(opts: CreateExitPlanModeToolInput) {
         }
         throw err; // unexpected — propagate
       }
-      const title = readStringParam(params, "title");
-      const summary = readStringParam(params, "summary");
+
+      // PR-10 archetype fields. All optional; readPlanArchetypeFields
+      // does the parsing + sanitization (trim + drop blank entries).
+      const archetype = readPlanArchetypeFields(params);
 
       const sessionKey = ctx.sessionKey;
       if (!sessionKey) {
@@ -232,7 +413,9 @@ export function createExitPlanModeTool(opts: CreateExitPlanModeToolInput) {
         lastPlanSteps: steps,
       });
 
-      // Map store outcome → tool result.
+      // Map store outcome → tool result. Plugin uses hyphenated status
+      // names (vs in-host underscore) for consistency with the rest of
+      // the plugin status vocabulary + the eva-live-smokes assertions.
       let statusText: string;
       let status:
         | "approval-requested"
@@ -242,9 +425,9 @@ export function createExitPlanModeTool(opts: CreateExitPlanModeToolInput) {
       switch (r.kind) {
         case "persisted":
           status = "approval-requested";
-          statusText =
-            `Plan submitted for approval (${steps.length} ${steps.length === 1 ? "step" : "steps"}). ` +
-            "Waiting for user Approve/Reject.";
+          statusText = title
+            ? `Plan submitted for approval — ${title} (${steps.length} ${steps.length === 1 ? "step" : "steps"}).`
+            : `Plan submitted for approval (${steps.length} ${steps.length === 1 ? "step" : "steps"}).`;
           break;
         case "reused":
           status = "duplicate-detected";
@@ -274,10 +457,30 @@ export function createExitPlanModeTool(opts: CreateExitPlanModeToolInput) {
           approvalId: r.approvalId,
           payloadHash,
           stepCount: steps.length,
+          plan: steps,
           ...(title ? { title } : {}),
           ...(summary ? { summary } : {}),
+          // PR-10 archetype fields. Spread only when the agent supplied
+          // them — keeps the tool result minimal for simple plans.
+          ...(archetype.analysis ? { analysis: archetype.analysis } : {}),
+          ...(archetype.assumptions && archetype.assumptions.length > 0
+            ? { assumptions: archetype.assumptions }
+            : {}),
+          ...(archetype.risks && archetype.risks.length > 0
+            ? { risks: archetype.risks }
+            : {}),
+          ...(archetype.verification && archetype.verification.length > 0
+            ? { verification: archetype.verification }
+            : {}),
+          ...(archetype.references && archetype.references.length > 0
+            ? { references: archetype.references }
+            : {}),
         },
       };
     },
   });
 }
+
+// Re-export the display-summary constant so callers needing parity
+// with the in-host preset can import it from a stable location.
+export { EXIT_PLAN_MODE_TOOL_DISPLAY_SUMMARY };

--- a/tests/tools/enter-plan-mode.test.ts
+++ b/tests/tools/enter-plan-mode.test.ts
@@ -37,6 +37,22 @@ describe("P-4 enter_plan_mode — tool shape", () => {
     const params = tool.parameters as { additionalProperties?: boolean };
     expect(params.additionalProperties).toBe(false);
   });
+
+  it("description contains TOOL LIFECYCLE clause (surgical-port S1 fix)", () => {
+    const { factory } = build();
+    const tool = factory({ sessionKey: SESSION_KEY });
+    expect(tool.description).toMatch(/TOOL LIFECYCLE/);
+    expect(tool.description).toMatch(/enter_plan_mode = ONCE/);
+    expect(tool.description).toMatch(/update_plan = DURING/);
+    expect(tool.description).toMatch(/exit_plan_mode = ONCE when ready to propose/);
+  });
+
+  it("description points to reference card + plan_mode_status diagnostic", () => {
+    const { factory } = build();
+    const tool = factory({ sessionKey: SESSION_KEY });
+    expect(tool.description).toMatch(/reference card/);
+    expect(tool.description).toMatch(/plan_mode_status/);
+  });
 });
 
 describe("P-4 enter_plan_mode — state transitions", () => {

--- a/tests/tools/exit-plan-mode.test.ts
+++ b/tests/tools/exit-plan-mode.test.ts
@@ -1,20 +1,29 @@
 /**
- * P-4 exit_plan_mode tool tests.
+ * exit_plan_mode tool tests.
  *
- * Covers schema validation (plan steps, at-most-one in_progress), the
- * payloadHash + approvalId minting + PlanModeStore wiring. The full
- * Invariant 1-10 behavior is covered by tests/state/store.test.ts +
- * parity-harness; here we test the TOOL-level wrapping (input
- * validation, output shape, error mapping).
+ * Covers schema validation (title-required + 80-char clamp, plan steps,
+ * at-most-one in_progress, archetype fields), the payloadHash +
+ * approvalId minting + PlanModeStore wiring. The full Invariant 1-10
+ * behavior is covered by tests/state/store.test.ts + parity-harness;
+ * here we test the TOOL-level wrapping (input validation, output
+ * shape, error mapping).
+ *
+ * Parity contract: title check + 80-char clamp + archetype echoing
+ * are byte-identical to in-host (`src/agents/tools/exit-plan-mode-tool.ts`
+ * at commit ea04ea52c7). Tests pin the in-host order: title check
+ * runs BEFORE plan validation so the most common omission (no title)
+ * surfaces first rather than after the agent has fixed an unrelated
+ * plan-schema error.
  */
 
 import { describe, expect, it } from "vitest";
 import { createExitPlanModeTool } from "../../src/tools/exit-plan-mode.js";
+import { isPlanApprovalId } from "../../src/helpers/approval-id.js";
 import { InMemoryGateway } from "../../src/state/in-memory-gateway.js";
 import { PlanModeStore } from "../../src/state/store.js";
-import { isPlanApprovalId } from "../../src/helpers/approval-id.js";
 
 const SESSION_KEY = "agent:main:main";
+const TITLE = "Test plan";
 
 function build() {
   const gw = new InMemoryGateway();
@@ -30,7 +39,7 @@ function build() {
   return { gw, store, factory };
 }
 
-describe("P-4 exit_plan_mode — tool shape", () => {
+describe("exit_plan_mode — tool shape", () => {
   it("factory returns a tool definition with required fields", () => {
     const { factory } = build();
     const tool = factory({ sessionKey: SESSION_KEY });
@@ -46,13 +55,81 @@ describe("P-4 exit_plan_mode — tool shape", () => {
     const params = tool.parameters as { additionalProperties?: boolean };
     expect(params.additionalProperties).toBe(false);
   });
+
+  it("description contains the STOP AFTER / chat-text-banned clauses (anti-halt steer)", () => {
+    const { factory } = build();
+    const tool = factory({ sessionKey: SESSION_KEY });
+    expect(tool.description).toMatch(/STOP AFTER THIS TOOL CALL/);
+    expect(tool.description).toMatch(/do NOT write the plan as a markdown list/);
+    expect(tool.description).toMatch(/WAIT FOR SPAWNED SUBAGENTS/);
+  });
 });
 
-describe("P-4 exit_plan_mode — input validation", () => {
-  it("rejects missing plan array", async () => {
+describe("exit_plan_mode — title required (surgical-port S1 fix)", () => {
+  it("rejects when title is missing", async () => {
+    const { factory } = build();
+    const tool = factory({ sessionKey: SESSION_KEY });
+    const result = await tool.execute("call-1", {
+      plan: [{ step: "a", status: "pending" }],
+    });
+    expect(result.details).toEqual(
+      expect.objectContaining({ status: "invalid-input" }),
+    );
+    expect(result.content[0]?.text).toMatch(/requires a `title` field/);
+    expect(result.content[0]?.text).toMatch(/Re-call exit_plan_mode/);
+  });
+
+  it("rejects when title is whitespace-only", async () => {
+    const { factory } = build();
+    const tool = factory({ sessionKey: SESSION_KEY });
+    const result = await tool.execute("call-1", {
+      title: "   ",
+      plan: [{ step: "a", status: "pending" }],
+    });
+    expect((result.details as { status: string }).status).toBe("invalid-input");
+  });
+
+  it("title check runs BEFORE plan validation (in-host order)", async () => {
+    // No title + no plan → should see the title error, not a plan error.
+    // This pins the in-host order: title is the most common omission and
+    // should be reported first.
     const { factory } = build();
     const tool = factory({ sessionKey: SESSION_KEY });
     const result = await tool.execute("call-1", {});
+    expect(result.content[0]?.text).toMatch(/requires a `title` field/);
+    expect(result.content[0]?.text).not.toMatch(/plan required/);
+  });
+
+  it("clamps title to 80 chars (in-host parity)", async () => {
+    const { factory } = build();
+    const tool = factory({ sessionKey: SESSION_KEY });
+    const longTitle = "A".repeat(120);
+    const result = await tool.execute("call-1", {
+      title: longTitle,
+      plan: [{ step: "a", status: "pending" }],
+    });
+    const details = result.details as { title?: string; status: string };
+    expect(details.status).toBe("approval-requested");
+    expect(details.title).toBe("A".repeat(80));
+    expect(details.title?.length).toBe(80);
+  });
+
+  it("trims whitespace before clamping (preserves intent)", async () => {
+    const { factory } = build();
+    const tool = factory({ sessionKey: SESSION_KEY });
+    const result = await tool.execute("call-1", {
+      title: "   Bump deps   ",
+      plan: [{ step: "a", status: "pending" }],
+    });
+    expect((result.details as { title: string }).title).toBe("Bump deps");
+  });
+});
+
+describe("exit_plan_mode — plan input validation", () => {
+  it("rejects missing plan array", async () => {
+    const { factory } = build();
+    const tool = factory({ sessionKey: SESSION_KEY });
+    const result = await tool.execute("call-1", { title: TITLE });
     expect(result.details).toEqual(
       expect.objectContaining({ status: "invalid-input" }),
     );
@@ -62,7 +139,7 @@ describe("P-4 exit_plan_mode — input validation", () => {
   it("rejects empty plan array", async () => {
     const { factory } = build();
     const tool = factory({ sessionKey: SESSION_KEY });
-    const result = await tool.execute("call-1", { plan: [] });
+    const result = await tool.execute("call-1", { title: TITLE, plan: [] });
     expect(result.details).toEqual(
       expect.objectContaining({ status: "invalid-input" }),
     );
@@ -72,6 +149,7 @@ describe("P-4 exit_plan_mode — input validation", () => {
     const { factory } = build();
     const tool = factory({ sessionKey: SESSION_KEY });
     const result = await tool.execute("call-1", {
+      title: TITLE,
       plan: [
         { step: "a", status: "in_progress" },
         { step: "b", status: "in_progress" },
@@ -87,6 +165,7 @@ describe("P-4 exit_plan_mode — input validation", () => {
     const { factory } = build();
     const tool = factory({ sessionKey: SESSION_KEY });
     const result = await tool.execute("call-1", {
+      title: TITLE,
       plan: [{ step: "a", status: "bogus_status" }],
     });
     expect(result.details).toEqual(
@@ -99,6 +178,7 @@ describe("P-4 exit_plan_mode — input validation", () => {
     const { factory } = build();
     const tool = factory({ sessionKey: SESSION_KEY });
     const result = await tool.execute("call-1", {
+      title: TITLE,
       plan: [
         { step: "a", status: "completed" },
         { step: "b", status: "in_progress" },
@@ -111,11 +191,12 @@ describe("P-4 exit_plan_mode — input validation", () => {
   });
 });
 
-describe("P-4 exit_plan_mode — happy path", () => {
+describe("exit_plan_mode — happy path", () => {
   it("mints a valid plan-approvalId via newPlanApprovalId", async () => {
     const { factory } = build();
     const tool = factory({ sessionKey: SESSION_KEY });
     const result = await tool.execute("call-1", {
+      title: TITLE,
       plan: [{ step: "do thing", status: "pending" }],
     });
     const approvalId = (result.details as { approvalId?: string }).approvalId;
@@ -156,9 +237,13 @@ describe("P-4 exit_plan_mode — happy path", () => {
   it("step count reflected in result text", async () => {
     const { factory } = build();
     const tool = factory({ sessionKey: SESSION_KEY });
-    const r1 = await tool.execute("c1", { plan: [{ step: "a", status: "pending" }] });
+    const r1 = await tool.execute("c1", {
+      title: TITLE,
+      plan: [{ step: "a", status: "pending" }],
+    });
     expect(r1.content[0]?.text).toMatch(/1 step/);
     const r2 = await tool.execute("c2", {
+      title: TITLE,
       plan: [
         { step: "a", status: "pending" },
         { step: "b", status: "pending" },
@@ -166,9 +251,116 @@ describe("P-4 exit_plan_mode — happy path", () => {
     });
     expect(r2.content[0]?.text).toMatch(/2 steps/);
   });
+
+  it("result text includes the title (in-host parity)", async () => {
+    const { factory } = build();
+    const tool = factory({ sessionKey: SESSION_KEY });
+    const result = await tool.execute("c1", {
+      title: "Bump deps",
+      plan: [{ step: "a", status: "pending" }],
+    });
+    expect(result.content[0]?.text).toMatch(/Bump deps/);
+  });
 });
 
-describe("P-4 exit_plan_mode — duplicate detection (Invariant 3)", () => {
+describe("exit_plan_mode — archetype fields (surgical-port S1 fix)", () => {
+  it("echoes analysis when provided", async () => {
+    const { factory } = build();
+    const tool = factory({ sessionKey: SESSION_KEY });
+    const result = await tool.execute("c1", {
+      title: TITLE,
+      plan: [{ step: "a", status: "pending" }],
+      analysis: "Current state shows N issues; chosen approach is X because Y.",
+    });
+    expect((result.details as { analysis?: string }).analysis).toBe(
+      "Current state shows N issues; chosen approach is X because Y.",
+    );
+  });
+
+  it("trims and drops blank entries from assumptions array", async () => {
+    const { factory } = build();
+    const tool = factory({ sessionKey: SESSION_KEY });
+    const result = await tool.execute("c1", {
+      title: TITLE,
+      plan: [{ step: "a", status: "pending" }],
+      assumptions: ["  first  ", "", "   ", "second"],
+    });
+    expect((result.details as { assumptions?: string[] }).assumptions).toEqual([
+      "first",
+      "second",
+    ]);
+  });
+
+  it("echoes risks (objects with risk + mitigation)", async () => {
+    const { factory } = build();
+    const tool = factory({ sessionKey: SESSION_KEY });
+    const result = await tool.execute("c1", {
+      title: TITLE,
+      plan: [{ step: "a", status: "pending" }],
+      risks: [
+        { risk: "tests may flake", mitigation: "retry the suite" },
+        { risk: "", mitigation: "drop" }, // dropped (blank risk)
+      ],
+    });
+    expect((result.details as { risks?: Array<unknown> }).risks).toEqual([
+      { risk: "tests may flake", mitigation: "retry the suite" },
+    ]);
+  });
+
+  it("echoes verification array (trimmed, blanks dropped)", async () => {
+    const { factory } = build();
+    const tool = factory({ sessionKey: SESSION_KEY });
+    const result = await tool.execute("c1", {
+      title: TITLE,
+      plan: [{ step: "a", status: "pending" }],
+      verification: ["pnpm test passes", "", "  manual smoke ok  "],
+    });
+    expect(
+      (result.details as { verification?: string[] }).verification,
+    ).toEqual(["pnpm test passes", "manual smoke ok"]);
+  });
+
+  it("echoes references array", async () => {
+    const { factory } = build();
+    const tool = factory({ sessionKey: SESSION_KEY });
+    const result = await tool.execute("c1", {
+      title: TITLE,
+      plan: [{ step: "a", status: "pending" }],
+      references: ["src/agents/plan-mode/types.ts:42", "PR #67538"],
+    });
+    expect(
+      (result.details as { references?: string[] }).references,
+    ).toEqual(["src/agents/plan-mode/types.ts:42", "PR #67538"]);
+  });
+
+  it("omits archetype fields from details when not provided (minimal payload)", async () => {
+    const { factory } = build();
+    const tool = factory({ sessionKey: SESSION_KEY });
+    const result = await tool.execute("c1", {
+      title: TITLE,
+      plan: [{ step: "a", status: "pending" }],
+    });
+    const details = result.details as Record<string, unknown>;
+    expect(details.analysis).toBeUndefined();
+    expect(details.assumptions).toBeUndefined();
+    expect(details.risks).toBeUndefined();
+    expect(details.verification).toBeUndefined();
+    expect(details.references).toBeUndefined();
+  });
+
+  it("drops archetype field with all-blank entries (no empty arrays in result)", async () => {
+    const { factory } = build();
+    const tool = factory({ sessionKey: SESSION_KEY });
+    const result = await tool.execute("c1", {
+      title: TITLE,
+      plan: [{ step: "a", status: "pending" }],
+      assumptions: ["", "   ", ""],
+    });
+    expect((result.details as { assumptions?: string[] }).assumptions).toBeUndefined();
+  });
+});
+
+describe("exit_plan_mode — duplicate detection (Invariant 3)", () => {
   it("returns duplicate-detected status + reuses existing approvalId on identical re-submit", async () => {
     const { factory } = build();
     const tool = factory({ sessionKey: SESSION_KEY });
@@ -190,10 +382,12 @@ describe("P-4 exit_plan_mode — duplicate detection (Invariant 3)", () => {
     const { factory } = build();
     const tool = factory({ sessionKey: SESSION_KEY });
     const first = await tool.execute("c1", {
+      title: TITLE,
       plan: [{ step: "v1", status: "pending" }],
     });
     const firstId = (first.details as { approvalId: string }).approvalId;
     const second = await tool.execute("c2", {
+      title: TITLE,
       plan: [{ step: "v2", status: "pending" }],
     });
     expect((second.details as { approvalId: string }).approvalId).not.toBe(firstId);
@@ -201,13 +395,14 @@ describe("P-4 exit_plan_mode — duplicate detection (Invariant 3)", () => {
   });
 });
 
-describe("P-4 exit_plan_mode — error paths", () => {
+describe("exit_plan_mode — error paths", () => {
   it("returns not-in-plan-mode when session has no plan-mode payload", async () => {
     const gw = new InMemoryGateway(); // unseeded
     const store = new PlanModeStore(gw);
     const factory = createExitPlanModeTool({ store });
     const tool = factory({ sessionKey: SESSION_KEY });
     const result = await tool.execute("c1", {
+      title: TITLE,
       plan: [{ step: "a", status: "pending" }],
     });
     expect((result.details as { status: string }).status).toBe("not-in-plan-mode");
@@ -218,6 +413,7 @@ describe("P-4 exit_plan_mode — error paths", () => {
     const { factory } = build();
     const tool = factory({ sessionKey: undefined });
     const result = await tool.execute("c1", {
+      title: TITLE,
       plan: [{ step: "a", status: "pending" }],
     });
     expect((result.details as { status: string }).status).toBe("no-session");
@@ -233,6 +429,7 @@ describe("P-4 exit_plan_mode — error paths", () => {
     const factory = createExitPlanModeTool({ store });
     const tool = factory({ sessionKey: SESSION_KEY });
     const result = await tool.execute("c1", {
+      title: TITLE,
       plan: [{ step: "a", status: "pending" }],
     });
     expect((result.details as { status: string }).status).toBe("failed");


### PR DESCRIPTION
## Summary

Second of 5 surgical PRs to close Wave-1 audit findings. This one
re-ports the `enter_plan_mode` and `exit_plan_mode` agent tools
verbatim from the in-host source-of-truth (commit `ea04ea52c7`),
closing 7 P0 drifts from audit slice S1.

## What's surgical about it

The prior plugin tools paraphrased the in-host descriptions and
omitted the title-required runtime check, the 80-char clamp, the 5
archetype field descriptions, and the archetype-field echoing. This
PR restores byte-identical strings + behavior wherever the in-host
contract doesn't conflict with a plugin-specific concern (status
name vocabulary, persistence path).

## Closes 7 Wave-1 S1 drifts

| # | Drift | Fix |
|---|---|---|
| S1-P0-1 | enter_plan_mode description drift (~70% paraphrased) | verbatim `describeEnterPlanModeTool()` |
| S1-P0-2 | exit_plan_mode description drift (STOP AFTER, WAIT FOR SUBAGENTS, etc. dropped) | verbatim `describeExitPlanModeTool()` |
| S1-P0-3 | title schema-optional, no runtime check | runtime guard + verbatim in-host error message |
| S1-P0-4 | 80-char title clamp absent | `.slice(0, 80)` after trim |
| S1-P0-5 | archetype field descriptions stripped from schema | verbatim descriptions on all 5 fields |
| S1-P0-6 | archetype values dropped from tool result | conditional spread into `details` |
| S1-P0-7 | plan-first ordering (in-host: title first) | reorder runtime checks |

## What stayed plugin-specific

- Status names use hyphens (`"approval-requested"` etc.) instead of
  in-host underscores — required by eva-live-smokes assertions and
  session-action wiring; documented inline.
- Subagent gate skipped — depends on host-internal
  `getAgentRunContext`; the gateway-side gate at `sessions-patch.ts`
  remains the authoritative safety net.
- Persistence via PlanModeStore.persistApprovalRequest (10-invariant
  typed mutator from PR-3) instead of in-host's
  `persistPlanApprovalRequest` helper.

## Test plan

- [x] Local typecheck clean (`pnpm typecheck`)
- [ ] CI test suite green
- [ ] Eva-live-smoke tests still pass (smoke-2 and smoke-3 both pass
      title in their fixtures already — no regression expected)
- [ ] Re-audit Wave-1 S1 confirms 7 P0s closed

## Files

- `src/plan-mode/tool-descriptions.ts` (NEW, 76 LOC) — verbatim port
  of `tool-description-presets.ts:12-15, 98-145`
- `src/tools/enter-plan-mode.ts` (modified, +63/-19) — uses
  `describeEnterPlanModeTool()`, output text unchanged (already
  byte-identical)
- `src/tools/exit-plan-mode.ts` (modified, +252/-37) — full schema +
  title-required guard + 80-char clamp + archetype parser + archetype
  echo
- `tests/tools/enter-plan-mode.test.ts` (+16) — 2 new assertions for
  TOOL LIFECYCLE + reference-card clauses
- `tests/tools/exit-plan-mode.test.ts` (+228/-3) — 12 new tests
  (5 title + 7 archetype) + existing tests updated to pass title

## References

- host_ref: `src/agents/tools/enter-plan-mode-tool.ts` @ `ea04ea52c7`
- host_ref: `src/agents/tools/exit-plan-mode-tool.ts` @ `ea04ea52c7`
- host_ref: `src/agents/tool-description-presets.ts:12-15, 98-145`
- Wave-1 audit slice: `docs/audits/wave-1/S1-enter-exit-tools.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clearer plan mode tool descriptions and lifecycle guidelines
  * Enhanced documentation of plan mode behavior and requirements

* **Improvements**
  * Stricter schema validation for plan operations
  * Enhanced input validation and error handling
  * Improved title and archetype field processing with trimming and validation

* **Tests**
  * Extended test coverage for plan mode tools and workflows

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/Smarter-Claw/pull/87)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->