### PR TITLE
Surgical PR #3: re-port system-prompt injection + approved-plan preamble (Wave-1 S4/S5)

### DIFF
--- a/src/plan-mode/auto-enable.ts
+++ b/src/plan-mode/auto-enable.ts
@@ -1,0 +1,100 @@
+/**
+ * Plan-mode auto-enable matching.
+ *
+ * **Parity contract**: byte-identical port of the in-host
+ * `src/agents/plan-mode/auto-enable.ts` at commit `ea04ea52c7`
+ * (`/Users/lume/repos/openclaw-pr70071-rebase/src/agents/plan-mode/auto-enable.ts`).
+ *
+ * Only adaptation: this file lives at `src/plan-mode/` to match the
+ * plugin's existing namespace conventions (the in-host puts plan-mode
+ * code under `src/agents/plan-mode/`).
+ *
+ * # What this does
+ *
+ * Evaluates whether a given model id matches any of the regex
+ * patterns configured under `agents.defaults.planMode.autoEnableFor`.
+ * When a match is found, the runtime caller is expected to flip the
+ * session into plan mode at session start (unless the user has
+ * already toggled it explicitly).
+ *
+ * This helper is intentionally pure and synchronous so it can be
+ * called from hot paths (session-entry materialization, cron-turn
+ * setup) without adding async overhead.
+ *
+ * # Compiled-regex cache
+ *
+ * Patterns rarely change at runtime (config is static within a
+ * gateway lifetime); compiling each pattern once and memoizing
+ * avoids per-call regex allocation. The cache key is the raw pattern
+ * string so callers don't need to pre-compile.
+ *
+ * # Surgical-port rationale (2026-05-12)
+ *
+ * Wave-1 audit slice S5 found the plugin had no equivalent of this
+ * helper. The in-host wires `evaluateAutoEnableForMatch` into session-
+ * start so models matching configured patterns auto-enter plan mode.
+ * The plugin's `before_prompt_build` hook reads plan-mode state but
+ * can't proactively enter — this helper restores that capability.
+ *
+ * host_ref: src/agents/plan-mode/auto-enable.ts (commit ea04ea52c7)
+ */
+
+const compiledPatternCache = new Map<string, RegExp | null>();
+
+function compilePattern(pattern: string): RegExp | null {
+  if (compiledPatternCache.has(pattern)) {
+    return compiledPatternCache.get(pattern) ?? null;
+  }
+  let compiled: RegExp | null;
+  try {
+    compiled = new RegExp(pattern);
+  } catch {
+    // Malformed pattern → treat as non-matching. Operators see the
+    // set-value go silent rather than a gateway crash; the intent is
+    // "auto-enable for these models", and a broken pattern should
+    // not enable for EVERY model.
+    compiled = null;
+  }
+  compiledPatternCache.set(pattern, compiled);
+  return compiled;
+}
+
+/**
+ * Returns true when `modelId` matches any of the supplied regex
+ * patterns. Empty / undefined inputs return false (no match, do not
+ * auto-enable).
+ *
+ * @param modelId — session's resolved model id, e.g. `openai/gpt-5.4`
+ * @param patterns — array of regex pattern strings from the config
+ *   under `agents.defaults.planMode.autoEnableFor`
+ */
+export function evaluateAutoEnableForMatch(
+  modelId: string | undefined,
+  patterns: ReadonlyArray<string> | undefined,
+): boolean {
+  if (!modelId || typeof modelId !== "string" || modelId.length === 0) {
+    return false;
+  }
+  if (!patterns || !Array.isArray(patterns) || patterns.length === 0) {
+    return false;
+  }
+  for (const raw of patterns) {
+    if (typeof raw !== "string" || raw.length === 0) {
+      continue;
+    }
+    const compiled = compilePattern(raw);
+    if (compiled && compiled.test(modelId)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Test-only: clear the compiled-pattern cache. Production code should
+ * never call this; tests that exercise malformed-pattern behavior use
+ * it to keep cases independent.
+ */
+export function __resetCompiledPatternCacheForTests(): void {
+  compiledPatternCache.clear();
+}

--- a/src/prompt/plan-mode-injection.ts
+++ b/src/prompt/plan-mode-injection.ts
@@ -1,24 +1,83 @@
 /**
  * Plan-mode system-prompt injection composer.
  *
- * **Parity reference**: the in-host injects an inline block at
- * `/Users/lume/repos/openclaw-pr70071-rebase/src/agents/pi-embedded-runner/run/attempt.ts:702-732`
- * (commit `ea04ea52c7`). That block has FOUR parts:
- *   1. PLAN_MODE_ACTIVE header
- *   2. Hard rules ("Mutating tools are BLOCKED... etc.")
- *   3. PLAN_ARCHETYPE_PROMPT (PR-10 quality steering — ported here at P-7)
- *   4. PLAN_MODE_REFERENCE_CARD (state diagram + tool contract +
- *      tag taxonomy — P-8 ports this companion)
+ * **Parity contract**: byte-identical port of the in-host inline block
+ * at `/Users/lume/repos/openclaw-pr70071-rebase/src/agents/pi-embedded-runner/run/attempt.ts:689-749`
+ * (commit `ea04ea52c7`). Two branches:
  *
- * P-7 ships parts 1, 2, 3. P-8 adds part 4 + the
- * `composePromptWithPendingInjections` queue drain.
+ *   1. `buildPlanModeActiveSystemContext()` — for when planMode === "plan".
+ *      Includes: header, "session IS in plan mode RIGHT NOW" preamble,
+ *      ACTION CONTRACT (3 numbered steps + ack-without-tool-call=defect),
+ *      Investigation Phase (read-only tools + LOGS heuristic +
+ *      ask_user_question guidance), Hard Rules, separator,
+ *      PLAN_ARCHETYPE_PROMPT, PLAN_MODE_REFERENCE_CARD.
+ *
+ *   2. `buildPlanModeAvailableSystemContext()` — for when plan-mode
+ *      feature is enabled but the session is NOT in plan mode. Tells
+ *      the agent it CAN enter plan mode when the user asks for one.
+ *
+ * # Surgical-port rationale (2026-05-12)
+ *
+ * Wave-1 audit slice S4 found:
+ *   - ACTION CONTRACT block missing entirely (the 3-step contract +
+ *     "acknowledgement-without-tool-call as a defect" steer)
+ *   - Investigation phase guidance missing (read-only tools list,
+ *     critical LOGS heuristic — "start at the END (tail)" — and
+ *     ask_user_question guidance)
+ *   - "This session IS in plan mode RIGHT NOW" preamble missing
+ *   - PLAN MODE AVAILABLE branch entirely absent
+ *
+ * Each clause exists because of a documented live-test failure mode.
+ * Do not prune.
+ *
+ * # Why this is in the SYSTEM PROMPT
+ *
+ * The prompt-cache-key is the byte-prefix of the system context. The
+ * full block needs to be byte-identical to the in-host emission so
+ * that any future parity-harness Layer-1 diff catches drift, AND so
+ * that prompt-cache hits work when the plugin runs alongside the
+ * in-host (the per-session prompt key matches).
+ *
+ * host_ref: src/agents/pi-embedded-runner/run/attempt.ts:689-749
  */
 
 import { PLAN_ARCHETYPE_PROMPT } from "./archetype-prompt.js";
 import { PLAN_MODE_REFERENCE_CARD } from "./reference-card.js";
 
-const PLAN_MODE_HEADER = "═══ PLAN MODE ACTIVE ═══";
+// ---------------------------------------------------------------------------
+// Building blocks — sub-constants kept exposed for byte-level test pinning.
+// Don't refactor away: tests in tests/prompt/plan-mode-injection.test.ts
+// assert against these individually to catch drift surgically.
+// ---------------------------------------------------------------------------
 
+const PLAN_MODE_HEADER = "═══ PLAN MODE ACTIVE ═══";
+const PLAN_MODE_SEPARATOR = "═════════════════════════";
+
+// In-host attempt.ts:695 — preamble that pins "you ARE in plan mode".
+const PLAN_MODE_PREAMBLE =
+  "This session IS in plan mode RIGHT NOW. Every user message in this session is a plan-mode message. Your action selection on this turn must reflect that.";
+
+// In-host attempt.ts:697-702 — the ACTION CONTRACT.
+const PLAN_MODE_ACTION_CONTRACT = [
+  "ACTION CONTRACT — when the user says anything that requests a plan, iteration, revision, or 'try again' / 'iterate' / 'fresh' / 'next attempt':",
+  "1. Briefly acknowledge in one short sentence (optional).",
+  '2. CALL `exit_plan_mode(title="…", summary="…", plan=[...])` IN THE SAME TURN. `title` and `plan` are required; non-trivial plans should also include `analysis`, `assumptions`, `risks`, `verification`.',
+  "3. Stop after the tool call. Do NOT respond with any further chat text in that turn.",
+  "",
+  "If you skip step 2 — if you respond with chat-only acknowledgement — you have failed the plan-mode contract and the user has to re-prompt you, which they should not have to do. Treat acknowledgement-without-tool-call as a defect, not as 'staying conversational'.",
+].join("\n");
+
+// In-host attempt.ts:704-708 — Investigation phase guidance (including
+// the load-bearing LOGS heuristic and ask_user_question rule).
+const PLAN_MODE_INVESTIGATION_PHASE = [
+  "Investigation phase (when needed):",
+  "- Use read-only tools first (read, web_search, web_fetch, lcm_grep, lcm_describe, lcm_expand_query). Track investigation in update_plan.",
+  "- For LOGS: start at the END (tail), use grep + time-window filters. Reading the first 100/400 lines of a multi-MB rolling log is almost always wrong — start with `tail -n 100`, then narrow by marker (e.g. `grep '[plan-mode/'`) or timestamp. Only widen to full file if the recent slice is insufficient.",
+  "- Use `ask_user_question` ONLY for tradeoffs you can't resolve via local investigation.",
+  "- Then call exit_plan_mode with the proposed plan, then STOP (no chat text after the tool call).",
+].join("\n");
+
+// In-host attempt.ts:710-714 — Hard rules (5 lines).
 const PLAN_MODE_HARD_RULES = [
   "Hard rules:",
   "- Mutating tools (write, edit, exec/bash with side-effects, apply_patch) are BLOCKED by the runtime — calling them wastes a turn.",
@@ -27,7 +86,27 @@ const PLAN_MODE_HARD_RULES = [
   "- After `exit_plan_mode` in this turn: STOP. Do not emit any further chat text. The next turn (after user approval) delivers `[PLAN_DECISION]: approved` and you can resume execution then. Trailing chat poisons the approval card lifecycle.",
 ].join("\n");
 
-const PLAN_MODE_SEPARATOR = "═════════════════════════";
+// In-host attempt.ts:735-748 — PLAN MODE AVAILABLE branch (when feature
+// flag is on but the session is not currently in plan mode).
+const PLAN_MODE_AVAILABLE_BODY = [
+  "═══ PLAN MODE AVAILABLE ═══",
+  "",
+  "Plan mode is available on this session but not currently active. When the user asks for a NEW plan / debugging-plan / refactor-plan / 'next plan' / a plan-first workflow, call `enter_plan_mode` to start a fresh planning cycle. The runtime will arm the mutation gate and you should then:",
+  "",
+  "1. Investigate read-only (use update_plan for in-progress tracking).",
+  "2. Call `exit_plan_mode` with the proposed plan to surface Accept/Edit/Reject buttons to the user.",
+  "3. After approval, mutating tools unlock and you execute.",
+  "",
+  "If the user is already executing an approved plan and asks you to keep going, do NOT re-enter plan mode — just continue executing the work.",
+  "",
+  "If the user asks a simple question or for a quick non-planning answer, do NOT enter plan mode. Plan mode is for multi-step proposals that benefit from explicit user approval before mutations.",
+  "",
+  "═════════════════════════════", // 29 box-drawing chars — note: in-host uses 29 vs ACTIVE's 25
+].join("\n");
+
+// ---------------------------------------------------------------------------
+// Public builders.
+// ---------------------------------------------------------------------------
 
 /**
  * Build the system-prompt addition for an active plan-mode session.
@@ -35,25 +114,57 @@ const PLAN_MODE_SEPARATOR = "═════════════════
  * The output bytes are part of the prompt-cache key (cache hits depend
  * on byte-identical prefix matches). Tests pin this.
  *
- * host_ref: src/agents/pi-embedded-runner/run/attempt.ts:702-732 — the
- *   in-host inline block. Includes header + hard rules +
- *   PLAN_ARCHETYPE_PROMPT (P-7) + PLAN_MODE_REFERENCE_CARD (P-8).
- *   composePromptWithPendingInjections drain queue layered on top by
- *   the runtime's pre-prompt-build pipeline; we emit the static
- *   pieces here.
+ * host_ref: src/agents/pi-embedded-runner/run/attempt.ts:692-732 — the
+ *   in-host inline block when `params.planMode === "plan"`. Restored
+ *   in full by the 2026-05-12 surgical re-port.
  */
-export function buildPlanModeSystemContext(): string {
+export function buildPlanModeActiveSystemContext(): string {
   return [
     PLAN_MODE_HEADER,
+    "",
+    PLAN_MODE_PREAMBLE,
+    "",
+    PLAN_MODE_ACTION_CONTRACT,
+    "",
+    PLAN_MODE_INVESTIGATION_PHASE,
     "",
     PLAN_MODE_HARD_RULES,
     "",
     PLAN_MODE_SEPARATOR,
     "",
+    // PR-10: append the decision-complete plan archetype standard so
+    // the agent produces Opus-quality plans (analysis + assumptions +
+    // risks + verification) instead of bare step lists.
     PLAN_ARCHETYPE_PROMPT,
     "",
+    // Iter-3 D1: append the plan-mode reference card so the agent
+    // ALWAYS sees the state diagram + tool contract + [PLAN_*]: tag
+    // taxonomy + slash-command surface + common pitfalls + debugging
+    // tips on every in-mode turn. Eliminates the 2-turn learning
+    // curve on fresh installs.
     PLAN_MODE_REFERENCE_CARD,
   ].join("\n");
+}
+
+/**
+ * Build the system-prompt addition for a session where plan-mode is
+ * enabled but NOT currently active. Tells the agent it CAN enter
+ * plan mode when the user requests one.
+ *
+ * host_ref: src/agents/pi-embedded-runner/run/attempt.ts:733-749 — the
+ *   in-host inline block when `planMode !== "plan"` and the feature
+ *   flag is enabled.
+ */
+export function buildPlanModeAvailableSystemContext(): string {
+  return PLAN_MODE_AVAILABLE_BODY;
+}
+
+/**
+ * Backward-compat alias for the active-mode builder. Kept so existing
+ * callers (src/index.ts, tests) continue to work.
+ */
+export function buildPlanModeSystemContext(): string {
+  return buildPlanModeActiveSystemContext();
 }
 
 /**
@@ -62,6 +173,10 @@ export function buildPlanModeSystemContext(): string {
  */
 export const _testing = {
   PLAN_MODE_HEADER,
-  PLAN_MODE_HARD_RULES,
   PLAN_MODE_SEPARATOR,
+  PLAN_MODE_PREAMBLE,
+  PLAN_MODE_ACTION_CONTRACT,
+  PLAN_MODE_INVESTIGATION_PHASE,
+  PLAN_MODE_HARD_RULES,
+  PLAN_MODE_AVAILABLE_BODY,
 };

--- a/src/runtime/injection-writer.ts
+++ b/src/runtime/injection-writer.ts
@@ -99,13 +99,31 @@ export async function enqueuePlanDecisionInjection(
 /**
  * Enqueue a `[PLAN_DECISION]: approved` (or `: edited`) injection.
  *
- * Note: in-host, approved/edited carries the FULL approved-plan
- * preamble (the steps list + "mark cancelled if blocked" instruction).
- * For P-11 we ship the one-line opener; the full preamble lands when
- * the session-action handler at P-12 wires the body.
+ * Three ways to specify the injection content (in priority order):
  *
- * host_ref: src/agents/plan-mode/approval.ts:195-244
- *   (buildApprovedPlanInjection — full body to be ported at P-12).
+ *   1. `fullText` — caller has already built the complete injection
+ *      text (e.g. via `buildApprovedPlanInjection(planSteps)` which
+ *      includes the opener + preamble + step list). Used by plan.accept
+ *      and plan.edit handlers to emit the full in-host-parity preamble.
+ *
+ *   2. `bodyText` — caller supplies just the body; we prepend
+ *      `[PLAN_DECISION]: <decision>\n` automatically. Used by callers
+ *      that have user-typed text to splice in (e.g. inline-edited
+ *      plan body).
+ *
+ *   3. Neither — emit the bare one-line opener `[PLAN_DECISION]: approved`.
+ *      Fallback for tests / harness paths that don't need the preamble.
+ *
+ * # In-host parity (surgical-port S5)
+ *
+ * The in-host emits the FULL `buildApprovedPlanInjection(planSteps)`
+ * text — opener + "The user has approved..." + step list. The bare
+ * opener path was a plugin shortcut that dropped the agent's
+ * execution-guidance preamble. plan.accept now uses `fullText` with
+ * the full preamble; the bare-opener path remains as a fallback only.
+ *
+ * host_ref: src/agents/plan-mode/approval.ts:185-238
+ *   (buildApprovedPlanInjection + buildAcceptEditsPlanInjection)
  */
 export async function enqueuePlanApprovedInjection(
   api: OpenClawPluginApi,
@@ -113,15 +131,25 @@ export async function enqueuePlanApprovedInjection(
     sessionKey: string;
     approvalId: string;
     edited?: boolean;
-    /** Optional already-built body text (P-12 wiring); defaults to
-     *  the bare opener for now. */
+    /** Complete pre-built injection text (highest priority). Use this
+     *  to emit `buildApprovedPlanInjection(planSteps)` etc. */
+    fullText?: string;
+    /** Optional body text; we prepend the `[PLAN_DECISION]:` opener.
+     *  Used by inline-edit callers that have user-typed plan text. */
     bodyText?: string;
     ttlMs?: number;
   },
 ): Promise<{ enqueued: boolean; id: string; sessionKey: string }> {
   const decision = input.edited ? "edited" : "approved";
   const opener = `[PLAN_DECISION]: ${decision}`;
-  const text = input.bodyText ? `${opener}\n${input.bodyText}` : opener;
+  let text: string;
+  if (input.fullText !== undefined) {
+    text = input.fullText;
+  } else if (input.bodyText !== undefined) {
+    text = `${opener}\n${input.bodyText}`;
+  } else {
+    text = opener;
+  }
   const idempotencyKey = `smarter-claw:plan_decision:${input.approvalId}:${decision}`;
   return api.session.workflow.enqueueNextTurnInjection({
     sessionKey: input.sessionKey,

--- a/src/ui/session-actions.ts
+++ b/src/ui/session-actions.ts
@@ -43,11 +43,40 @@ import type {
   PluginSessionActionResult,
 } from "openclaw/plugin-sdk/plugin-entry";
 import {
+  buildAcceptEditsPlanInjection,
+  buildApprovedPlanInjection,
+} from "../plan-mode/approval.js";
+import {
   enqueuePlanApprovedInjection,
   enqueuePlanDecisionInjection,
   enqueueQuestionAnswerInjection,
 } from "../runtime/injection-writer.js";
 import type { PlanModeStore } from "../state/store.js";
+import type { PlanStep } from "../types.js";
+
+/**
+ * Format planSteps into the string array consumed by
+ * buildApprovedPlanInjection / buildAcceptEditsPlanInjection. The
+ * in-host builders take `string[]` (each entry is one step) and
+ * emit a numbered list. We project the stored PlanStep[] (which
+ * carries status + activeForm) into that flat-string shape, keeping
+ * status as a parenthetical so the agent retains visibility of
+ * completed/cancelled steps when resuming.
+ *
+ * host_ref: src/agents/plan-mode/approval.ts:187-194 — the in-host's
+ *   `planSteps.map((s, i) => \`${i + 1}. ${s}\`)` rendering.
+ */
+function planStepsToInjectionLines(steps: PlanStep[]): string[] {
+  return steps.map((s) => {
+    // Match in-host's per-step format: "<step> (<status>)" when
+    // status is anything other than the default "pending". Lets
+    // the agent see what's already done when resuming a partial plan.
+    if (s.status === "pending") {
+      return s.step;
+    }
+    return `${s.step} (${s.status})`;
+  });
+}
 
 /**
  * Common error codes returned by `ok: false` results. UI clients can
@@ -219,6 +248,14 @@ export function createPlanModeSessionActions(
       const expectedApprovalId = readStringField(p.value, "approvalId");
       const check = await checkApprovalId(store, sk.sessionKey, expectedApprovalId);
       if (!check.ok) return check.result;
+      // Surgical-port S5 (2026-05-12): read planSteps BEFORE recordApproval
+      // mutates so we can build the full buildApprovedPlanInjection
+      // preamble. The plugin previously emitted only the bare opener
+      // line `[PLAN_DECISION]: approved`, which dropped the
+      // "execute it now without re-planning" guidance + step list
+      // that the in-host injects. Restoring parity here.
+      const snapBefore = await store.readSnapshot(sk.sessionKey);
+      const planSteps = snapBefore?.lastPlanSteps ?? [];
       const persist = await store.recordApproval({
         sessionKey: sk.sessionKey,
         edited: false,
@@ -235,13 +272,23 @@ export function createPlanModeSessionActions(
           `recordApproval skipped: ${persist.reason}`,
         );
       }
+      // Build the full in-host approved-plan injection. Falls back to
+      // the bare opener only when lastPlanSteps is empty (which
+      // shouldn't happen in a real session — exit_plan_mode required
+      // a non-empty plan — but defensive against test paths).
+      const stepLines = planStepsToInjectionLines(planSteps);
+      const fullText =
+        stepLines.length > 0
+          ? buildApprovedPlanInjection(stepLines)
+          : undefined;
       const enqueue = await enqueuePlanApprovedInjection(api, {
         sessionKey: sk.sessionKey,
         approvalId: check.currentApprovalId,
         edited: false,
+        ...(fullText ? { fullText } : {}),
       });
       log.info(
-        `[smarter-claw] plan.accept resolved sessionKey=${sk.sessionKey} approvalId=${check.currentApprovalId} enqueued=${enqueue.enqueued}`,
+        `[smarter-claw] plan.accept resolved sessionKey=${sk.sessionKey} approvalId=${check.currentApprovalId} steps=${stepLines.length} enqueued=${enqueue.enqueued}`,
       );
       return {
         ok: true,
@@ -256,6 +303,22 @@ export function createPlanModeSessionActions(
   };
 
   // ---------- plan.edit ----------
+  // Two semantic variants:
+  //
+  //   (a) Manual inline-edit: `body` field carries the user's edited
+  //       plan text. The agent is instructed to use that body verbatim
+  //       as the approved plan. Used by webchat + sidebar plan-edit UI.
+  //
+  //   (b) Accept-with-edits permission: no `body` field. The user
+  //       clicked the "Accept (edits)" button which grants the AGENT
+  //       acceptEdits permission (≥95%-confidence self-modify). We
+  //       inject the full `buildAcceptEditsPlanInjection(planSteps)`
+  //       preamble, which teaches the agent the acceptEdits contract
+  //       and the 3 hard constraints (no destructive / no self-restart
+  //       / no config changes). Surgical-port S5 (2026-05-12).
+  //
+  // host_ref: src/agents/plan-mode/approval.ts:214-238
+  //   (buildAcceptEditsPlanInjection)
   const editAction: PluginSessionActionRegistration = {
     id: "plan.edit",
     description:
@@ -269,6 +332,8 @@ export function createPlanModeSessionActions(
       const editedBody = readStringField(p.value, "body");
       const check = await checkApprovalId(store, sk.sessionKey, expectedApprovalId);
       if (!check.ok) return check.result;
+      const snapBefore = await store.readSnapshot(sk.sessionKey);
+      const planSteps = snapBefore?.lastPlanSteps ?? [];
       const persist = await store.recordApproval({
         sessionKey: sk.sessionKey,
         edited: true,
@@ -285,14 +350,23 @@ export function createPlanModeSessionActions(
           `recordApproval skipped: ${persist.reason}`,
         );
       }
-      const enqueue = await enqueuePlanApprovedInjection(api, {
+      // Manual inline-edit takes priority — the user typed text and
+      // expects to see THEIR text returned, not the acceptEdits preamble.
+      // No body → acceptEdits permission injection (steps preamble).
+      const stepLines = planStepsToInjectionLines(planSteps);
+      const enqueueOpts: Parameters<typeof enqueuePlanApprovedInjection>[1] = {
         sessionKey: sk.sessionKey,
         approvalId: check.currentApprovalId,
         edited: true,
-        ...(editedBody ? { bodyText: editedBody } : {}),
-      });
+      };
+      if (editedBody) {
+        enqueueOpts.bodyText = editedBody;
+      } else if (stepLines.length > 0) {
+        enqueueOpts.fullText = buildAcceptEditsPlanInjection(stepLines);
+      }
+      const enqueue = await enqueuePlanApprovedInjection(api, enqueueOpts);
       log.info(
-        `[smarter-claw] plan.edit resolved sessionKey=${sk.sessionKey} approvalId=${check.currentApprovalId} enqueued=${enqueue.enqueued}`,
+        `[smarter-claw] plan.edit resolved sessionKey=${sk.sessionKey} approvalId=${check.currentApprovalId} steps=${stepLines.length} editedBody=${editedBody ? "yes" : "no"} enqueued=${enqueue.enqueued}`,
       );
       return {
         ok: true,

--- a/tests/eva-live-smokes/smoke-2-plan-approve-flow.test.ts
+++ b/tests/eva-live-smokes/smoke-2-plan-approve-flow.test.ts
@@ -90,7 +90,16 @@ describe("Eva live-smoke #2 — full plan-approve-execute (P-8)", () => {
       placement: string;
     };
     expect(inj.sessionKey).toBe(SESSION_KEY);
-    expect(inj.text).toBe("[PLAN_DECISION]: approved");
+    // Surgical-port S5 (2026-05-12): plan.accept now emits the FULL
+    // buildApprovedPlanInjection text (opener + "execute it now"
+    // preamble + numbered step list) to match in-host parity. The
+    // prior bare-opener test was pinning a regression.
+    expect(inj.text).toMatch(/^\[PLAN_DECISION\]: approved\n/);
+    expect(inj.text).toMatch(
+      /The user has approved the following plan\. Execute it now without re-planning\./,
+    );
+    expect(inj.text).toMatch(/1\. Update package\.json/);
+    expect(inj.text).toMatch(/2\. Run pnpm install/);
     expect(inj.idempotencyKey).toBe(
       `smarter-claw:plan_decision:${approvalId}:approved`,
     );

--- a/tests/plan-mode/auto-enable.test.ts
+++ b/tests/plan-mode/auto-enable.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Tests for `evaluateAutoEnableForMatch` — surgical-port companion to
+ * `src/plan-mode/auto-enable.ts`.
+ *
+ * **Parity contract**: verbatim port of the in-host
+ * `evaluateAutoEnableForMatch` tests at
+ * `/Volumes/LEXAR/repos/openclaw-pr70071-rebase/src/agents/plan-mode/auto-enable.test.ts`
+ * (commit ea04ea52c7).
+ *
+ * Only adaptation: import path. The behavior + cases are byte-identical.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  evaluateAutoEnableForMatch,
+  __resetCompiledPatternCacheForTests,
+} from "../../src/plan-mode/auto-enable.js";
+
+describe("evaluateAutoEnableForMatch", () => {
+  beforeEach(() => {
+    __resetCompiledPatternCacheForTests();
+  });
+
+  describe("empty / invalid inputs", () => {
+    it("returns false when modelId is undefined", () => {
+      expect(evaluateAutoEnableForMatch(undefined, ["openai/.*"])).toBe(false);
+    });
+
+    it("returns false when modelId is empty string", () => {
+      expect(evaluateAutoEnableForMatch("", ["openai/.*"])).toBe(false);
+    });
+
+    it("returns false when patterns is undefined", () => {
+      expect(evaluateAutoEnableForMatch("openai/gpt-5.4", undefined)).toBe(false);
+    });
+
+    it("returns false when patterns is empty array", () => {
+      expect(evaluateAutoEnableForMatch("openai/gpt-5.4", [])).toBe(false);
+    });
+
+    it("skips non-string entries in patterns array", () => {
+      const patterns: ReadonlyArray<string> = ["openai/.*"];
+      // Defensive: any non-string slipping in (via untyped config) is
+      // silently skipped. We can't construct that easily in TS — the
+      // type guards out the obvious case. But verify the type guard
+      // works when patterns contains an empty string (also skipped).
+      expect(
+        evaluateAutoEnableForMatch("openai/gpt-5.4", ["", ...patterns]),
+      ).toBe(true);
+    });
+  });
+
+  describe("happy-path matches", () => {
+    it("returns true for exact regex match", () => {
+      expect(
+        evaluateAutoEnableForMatch("openai/gpt-5.4", ["openai/gpt-5\\.4"]),
+      ).toBe(true);
+    });
+
+    it("returns true for wildcard regex match", () => {
+      expect(
+        evaluateAutoEnableForMatch("openai/gpt-5.4-preview", ["openai/.*"]),
+      ).toBe(true);
+    });
+
+    it("returns true when ANY pattern matches (OR-semantics)", () => {
+      expect(
+        evaluateAutoEnableForMatch("openai/gpt-5.4", [
+          "anthropic/.*",
+          "openai/.*",
+        ]),
+      ).toBe(true);
+    });
+
+    it("returns false when no pattern matches", () => {
+      expect(
+        evaluateAutoEnableForMatch("openai/gpt-5.4", [
+          "anthropic/.*",
+          "groq/.*",
+        ]),
+      ).toBe(false);
+    });
+  });
+
+  describe("malformed-pattern defense", () => {
+    it("malformed regex pattern is silently skipped (no crash, no match)", () => {
+      // `[invalid` is a syntactically broken regex — RegExp throws.
+      // The helper catches + caches null, returning false.
+      expect(
+        evaluateAutoEnableForMatch("openai/gpt-5.4", ["[invalid"]),
+      ).toBe(false);
+    });
+
+    it("malformed pattern doesn't poison the OR — other patterns still evaluated", () => {
+      expect(
+        evaluateAutoEnableForMatch("openai/gpt-5.4", [
+          "[invalid",
+          "openai/.*",
+        ]),
+      ).toBe(true);
+    });
+  });
+
+  describe("compiled-pattern cache", () => {
+    it("repeated calls with same pattern hit the cache (no re-compilation crash)", () => {
+      // No direct way to observe the cache from the public API, but
+      // repeating the call shouldn't change behavior — and a thrown
+      // RegExp would surface as an unexpected error.
+      for (let i = 0; i < 10; i++) {
+        expect(
+          evaluateAutoEnableForMatch("openai/gpt-5.4", ["openai/.*"]),
+        ).toBe(true);
+      }
+    });
+
+    it("__resetCompiledPatternCacheForTests clears the cache between tests", () => {
+      // First call populates the cache.
+      evaluateAutoEnableForMatch("openai/gpt-5.4", ["openai/.*"]);
+      // Reset clears it. Sanity-check by verifying behavior is unchanged
+      // post-reset (cache-hit-vs-recompile is opaque to the caller, but
+      // a broken reset would surface as a wrong result).
+      __resetCompiledPatternCacheForTests();
+      expect(
+        evaluateAutoEnableForMatch("openai/gpt-5.4", ["openai/.*"]),
+      ).toBe(true);
+    });
+  });
+});

--- a/tests/prompt/plan-mode-injection.test.ts
+++ b/tests/prompt/plan-mode-injection.test.ts
@@ -1,56 +1,98 @@
 /**
- * P-7 plan-mode injection tests.
+ * plan-mode injection tests.
  *
  * Covers the system-prompt fragment composition + byte-identity vs
- * in-host inline injection at attempt.ts:702-732.
+ * in-host inline injection at attempt.ts:689-749.
+ *
+ * Surgical-port S5 (2026-05-12): expanded coverage for the full
+ * in-host block including ACTION CONTRACT, Investigation Phase, and
+ * PLAN MODE AVAILABLE branch.
  */
 
 import { describe, expect, it } from "vitest";
 import {
+  buildPlanModeActiveSystemContext,
+  buildPlanModeAvailableSystemContext,
   buildPlanModeSystemContext,
   _testing,
 } from "../../src/prompt/plan-mode-injection.js";
 import { PLAN_ARCHETYPE_PROMPT } from "../../src/prompt/archetype-prompt.js";
 
-describe("P-7 plan-mode injection — shape", () => {
+describe("plan-mode injection (active) — shape", () => {
   it("returns a non-empty string", () => {
-    const s = buildPlanModeSystemContext();
+    const s = buildPlanModeActiveSystemContext();
     expect(typeof s).toBe("string");
     expect(s.length).toBeGreaterThan(100);
   });
 
   it("contains the PLAN MODE ACTIVE header", () => {
-    expect(buildPlanModeSystemContext()).toContain("═══ PLAN MODE ACTIVE ═══");
+    expect(buildPlanModeActiveSystemContext()).toContain("═══ PLAN MODE ACTIVE ═══");
+  });
+
+  it("contains the 'session IS in plan mode RIGHT NOW' preamble (surgical-port S4 fix)", () => {
+    const s = buildPlanModeActiveSystemContext();
+    expect(s).toContain("This session IS in plan mode RIGHT NOW");
+    expect(s).toContain("Every user message in this session is a plan-mode message");
+  });
+
+  it("contains the ACTION CONTRACT block (surgical-port S4 fix)", () => {
+    const s = buildPlanModeActiveSystemContext();
+    expect(s).toContain("ACTION CONTRACT");
+    expect(s).toContain("Briefly acknowledge in one short sentence");
+    expect(s).toContain(
+      'CALL `exit_plan_mode(title="…", summary="…", plan=[...])` IN THE SAME TURN',
+    );
+    expect(s).toContain("Stop after the tool call");
+    expect(s).toContain(
+      "Treat acknowledgement-without-tool-call as a defect, not as 'staying conversational'",
+    );
+  });
+
+  it("contains the Investigation phase block with LOGS heuristic (surgical-port S4 fix)", () => {
+    const s = buildPlanModeActiveSystemContext();
+    expect(s).toContain("Investigation phase (when needed):");
+    expect(s).toContain("Use read-only tools first");
+    expect(s).toContain("For LOGS: start at the END (tail)");
+    expect(s).toContain("`tail -n 100`");
+    expect(s).toContain(
+      "Use `ask_user_question` ONLY for tradeoffs you can't resolve via local investigation",
+    );
   });
 
   it("contains the hard rules block", () => {
-    const s = buildPlanModeSystemContext();
+    const s = buildPlanModeActiveSystemContext();
     expect(s).toContain("Hard rules:");
     expect(s).toContain("Mutating tools (write, edit, exec/bash");
     expect(s).toContain("Do NOT call enter_plan_mode");
   });
 
   it("contains the full archetype prompt", () => {
-    expect(buildPlanModeSystemContext()).toContain(PLAN_ARCHETYPE_PROMPT);
+    expect(buildPlanModeActiveSystemContext()).toContain(PLAN_ARCHETYPE_PROMPT);
   });
 
-  it("ordering: header, hard rules, separator, archetype", () => {
-    const s = buildPlanModeSystemContext();
+  it("ordering: header, preamble, ACTION CONTRACT, Investigation, hard rules, separator, archetype", () => {
+    const s = buildPlanModeActiveSystemContext();
     const headerIdx = s.indexOf("═══ PLAN MODE ACTIVE ═══");
+    const preambleIdx = s.indexOf("This session IS in plan mode RIGHT NOW");
+    const actionIdx = s.indexOf("ACTION CONTRACT");
+    const investigationIdx = s.indexOf("Investigation phase");
     const rulesIdx = s.indexOf("Hard rules:");
     const sepIdx = s.indexOf("═════════════════════════");
     const archetypeIdx = s.indexOf("## Plan Mode — Decision-Complete Plan Standard");
     expect(headerIdx).toBeGreaterThanOrEqual(0);
-    expect(rulesIdx).toBeGreaterThan(headerIdx);
+    expect(preambleIdx).toBeGreaterThan(headerIdx);
+    expect(actionIdx).toBeGreaterThan(preambleIdx);
+    expect(investigationIdx).toBeGreaterThan(actionIdx);
+    expect(rulesIdx).toBeGreaterThan(investigationIdx);
     expect(sepIdx).toBeGreaterThan(rulesIdx);
     expect(archetypeIdx).toBeGreaterThan(sepIdx);
   });
 });
 
-describe("P-7 plan-mode injection — byte stability (cache-bust prevention)", () => {
+describe("plan-mode injection (active) — byte stability (cache-bust prevention)", () => {
   it("two calls produce IDENTICAL bytes (no per-call drift)", () => {
-    const a = buildPlanModeSystemContext();
-    const b = buildPlanModeSystemContext();
+    const a = buildPlanModeActiveSystemContext();
+    const b = buildPlanModeActiveSystemContext();
     expect(a).toBe(b);
     expect(a.length).toBe(b.length);
   });
@@ -76,9 +118,68 @@ describe("P-7 plan-mode injection — byte stability (cache-bust prevention)", (
     expect(lines[4]).toMatch(/After `exit_plan_mode` in this turn: STOP/);
     expect(lines).toHaveLength(5);
   });
+
+  it("ACTION_CONTRACT bytes pin the 3-step contract + defect clause", () => {
+    const text = _testing.PLAN_MODE_ACTION_CONTRACT;
+    expect(text).toMatch(/^ACTION CONTRACT/);
+    expect(text).toContain("1. Briefly acknowledge in one short sentence");
+    expect(text).toContain("2. CALL `exit_plan_mode(");
+    expect(text).toContain("3. Stop after the tool call");
+    expect(text).toContain(
+      "Treat acknowledgement-without-tool-call as a defect",
+    );
+  });
+
+  it("INVESTIGATION_PHASE bytes pin the read-only tools + LOGS heuristic", () => {
+    const text = _testing.PLAN_MODE_INVESTIGATION_PHASE;
+    expect(text).toMatch(/^Investigation phase \(when needed\):/);
+    expect(text).toContain("read, web_search, web_fetch, lcm_grep");
+    expect(text).toContain("start at the END (tail)");
+    expect(text).toContain("`tail -n 100`");
+  });
 });
 
-describe("P-7 plan-mode injection — PLAN_ARCHETYPE_PROMPT byte-parity", () => {
+describe("plan-mode injection (available) — surgical-port S4 fix", () => {
+  it("returns a non-empty string", () => {
+    const s = buildPlanModeAvailableSystemContext();
+    expect(typeof s).toBe("string");
+    expect(s.length).toBeGreaterThan(100);
+  });
+
+  it("contains the PLAN MODE AVAILABLE header (not the ACTIVE header)", () => {
+    const s = buildPlanModeAvailableSystemContext();
+    expect(s).toContain("═══ PLAN MODE AVAILABLE ═══");
+    expect(s).not.toContain("═══ PLAN MODE ACTIVE ═══");
+  });
+
+  it("instructs the agent to call enter_plan_mode when user requests a plan", () => {
+    const s = buildPlanModeAvailableSystemContext();
+    expect(s).toContain("call `enter_plan_mode`");
+    expect(s).toContain("start a fresh planning cycle");
+  });
+
+  it("warns against re-entering plan mode when already executing", () => {
+    const s = buildPlanModeAvailableSystemContext();
+    expect(s).toContain("do NOT re-enter plan mode");
+    expect(s).toContain("just continue executing the work");
+  });
+
+  it("byte-stable across calls (cache-bust prevention)", () => {
+    expect(buildPlanModeAvailableSystemContext()).toBe(
+      buildPlanModeAvailableSystemContext(),
+    );
+  });
+});
+
+describe("plan-mode injection — backward-compat alias", () => {
+  it("buildPlanModeSystemContext() === buildPlanModeActiveSystemContext()", () => {
+    expect(buildPlanModeSystemContext()).toBe(
+      buildPlanModeActiveSystemContext(),
+    );
+  });
+});
+
+describe("plan-mode injection — PLAN_ARCHETYPE_PROMPT byte-parity", () => {
   // Anti-pattern guard: the archetype prompt is the in-host's PR-10
   // fragment. Bytes matter. Pin individual sections so paraphrases
   // are caught.

--- a/tests/runtime/injection-writer.test.ts
+++ b/tests/runtime/injection-writer.test.ts
@@ -209,6 +209,32 @@ describe("P-11 enqueuePlanApprovedInjection", () => {
     expect(call.text).toBe("[PLAN_DECISION]: edited");
   });
 
+  it("fullText overrides opener+body (surgical-port S5 fix)", async () => {
+    const { api, enqueueNextTurnInjection } = makeStubApi();
+    await enqueuePlanApprovedInjection(api, {
+      sessionKey: SESSION_KEY,
+      approvalId: APPROVAL_ID,
+      fullText:
+        "[PLAN_DECISION]: approved\n\nThe user has approved the following plan. Execute it now.\n\n1. Step one",
+    });
+    const call = enqueueNextTurnInjection.mock.calls[0][0];
+    expect(call.text).toBe(
+      "[PLAN_DECISION]: approved\n\nThe user has approved the following plan. Execute it now.\n\n1. Step one",
+    );
+  });
+
+  it("fullText takes priority over bodyText when both are supplied", async () => {
+    const { api, enqueueNextTurnInjection } = makeStubApi();
+    await enqueuePlanApprovedInjection(api, {
+      sessionKey: SESSION_KEY,
+      approvalId: APPROVAL_ID,
+      fullText: "FULL TEXT WINS",
+      bodyText: "ignored body",
+    });
+    const call = enqueueNextTurnInjection.mock.calls[0][0];
+    expect(call.text).toBe("FULL TEXT WINS");
+  });
+
   it("idempotency-key namespaces by approvalId + 'approved'", async () => {
     const { api, enqueueNextTurnInjection } = makeStubApi();
     await enqueuePlanApprovedInjection(api, {

--- a/tests/ui/session-actions.test.ts
+++ b/tests/ui/session-actions.test.ts
@@ -180,7 +180,7 @@ describe("P-12 session-actions — plan.accept", () => {
     expect(r.code).toBe(SESSION_ACTION_ERROR_CODES.NO_PENDING_APPROVAL);
   });
 
-  it("enqueues an approved injection with the right text + idempotency key", async () => {
+  it("enqueues an approved injection with the right text + idempotency key (no plan steps → bare opener fallback)", async () => {
     await acceptHandler({
       pluginId: "smarter-claw",
       actionId: "plan.accept",
@@ -192,6 +192,52 @@ describe("P-12 session-actions — plan.accept", () => {
     expect(call.idempotencyKey).toBe(
       `smarter-claw:plan_decision:${APPROVAL_ID}:approved`,
     );
+  });
+
+  it("emits the FULL buildApprovedPlanInjection preamble when lastPlanSteps is set (surgical-port S5 fix)", async () => {
+    gw.seed(
+      SESSION_KEY,
+      planModeSession({
+        lastPlanSteps: [
+          { step: "Update package.json", status: "pending" },
+          { step: "Run pnpm install", status: "pending" },
+        ],
+      }),
+    );
+    await acceptHandler({
+      pluginId: "smarter-claw",
+      actionId: "plan.accept",
+      sessionKey: SESSION_KEY,
+    });
+    const call = enqueue.mock.calls[0][0];
+    expect(call.text).toMatch(/^\[PLAN_DECISION\]: approved\n/);
+    expect(call.text).toContain(
+      "The user has approved the following plan. Execute it now without re-planning",
+    );
+    expect(call.text).toContain("1. Update package.json");
+    expect(call.text).toContain("2. Run pnpm install");
+  });
+
+  it("annotates non-pending step statuses in the injection (in-host parity)", async () => {
+    gw.seed(
+      SESSION_KEY,
+      planModeSession({
+        lastPlanSteps: [
+          { step: "Investigation", status: "completed" },
+          { step: "Apply patch", status: "in_progress" },
+          { step: "Run tests", status: "pending" },
+        ],
+      }),
+    );
+    await acceptHandler({
+      pluginId: "smarter-claw",
+      actionId: "plan.accept",
+      sessionKey: SESSION_KEY,
+    });
+    const call = enqueue.mock.calls[0][0];
+    expect(call.text).toContain("1. Investigation (completed)");
+    expect(call.text).toContain("2. Apply patch (in_progress)");
+    expect(call.text).toContain("3. Run tests"); // pending → no annotation
   });
 });
 
@@ -219,7 +265,7 @@ describe("P-12 session-actions — plan.edit", () => {
     );
   });
 
-  it("omits body when not provided (bare opener)", async () => {
+  it("omits body when not provided AND no plan steps stored (bare opener fallback)", async () => {
     const gw = new InMemoryGateway();
     const store = new PlanModeStore(gw);
     const { api, enqueueNextTurnInjection } = makeStubApi();
@@ -235,6 +281,63 @@ describe("P-12 session-actions — plan.edit", () => {
     });
     const call = enqueueNextTurnInjection.mock.calls[0][0];
     expect(call.text).toBe("[PLAN_DECISION]: edited");
+  });
+
+  it("emits the FULL buildAcceptEditsPlanInjection preamble when no body but lastPlanSteps set (surgical-port S5 fix)", async () => {
+    const gw = new InMemoryGateway();
+    const store = new PlanModeStore(gw);
+    const { api, enqueueNextTurnInjection } = makeStubApi();
+    const actions = createPlanModeSessionActions({ api, store });
+    const handler = actions.find((a) => a.id === "plan.edit")!.handler;
+    gw.seed(
+      SESSION_KEY,
+      planModeSession({
+        lastPlanSteps: [
+          { step: "Refactor reconnect logic", status: "pending" },
+          { step: "Add retry test", status: "pending" },
+        ],
+      }),
+    );
+
+    await handler({
+      pluginId: "smarter-claw",
+      actionId: "plan.edit",
+      sessionKey: SESSION_KEY,
+      payload: { approvalId: APPROVAL_ID },
+    });
+    const call = enqueueNextTurnInjection.mock.calls[0][0];
+    expect(call.text).toMatch(/^\[PLAN_DECISION\]: edited\n/);
+    expect(call.text).toContain(
+      "The user has approved the following plan with acceptEdits permission",
+    );
+    expect(call.text).toContain("Hard constraints");
+    expect(call.text).toContain("No destructive actions");
+    expect(call.text).toContain("1. Refactor reconnect logic");
+    expect(call.text).toContain("2. Add retry test");
+  });
+
+  it("body field takes priority over acceptEdits preamble (manual user edit)", async () => {
+    const gw = new InMemoryGateway();
+    const store = new PlanModeStore(gw);
+    const { api, enqueueNextTurnInjection } = makeStubApi();
+    const actions = createPlanModeSessionActions({ api, store });
+    const handler = actions.find((a) => a.id === "plan.edit")!.handler;
+    gw.seed(
+      SESSION_KEY,
+      planModeSession({
+        lastPlanSteps: [{ step: "X", status: "pending" }],
+      }),
+    );
+
+    await handler({
+      pluginId: "smarter-claw",
+      actionId: "plan.edit",
+      sessionKey: SESSION_KEY,
+      payload: { approvalId: APPROVAL_ID, body: "My edited body" },
+    });
+    const call = enqueueNextTurnInjection.mock.calls[0][0];
+    expect(call.text).toBe("[PLAN_DECISION]: edited\nMy edited body");
+    expect(call.text).not.toContain("acceptEdits permission");
   });
 });
 


### PR DESCRIPTION
## Summary

Third of 5 surgical PRs. Re-ports the system-prompt injection and the
approved-plan preamble verbatim from the in-host source-of-truth
(commit `ea04ea52c7`), closing 7 P0 drifts from audit slices S4 + S5.

## What this delivers

1. **Full system-prompt injection** (`src/prompt/plan-mode-injection.ts`)
   restores 4 missing blocks from `attempt.ts:689-749`:
     - "session IS in plan mode RIGHT NOW" preamble
     - ACTION CONTRACT (3-step contract + defect clause)
     - Investigation phase (read-only tools + LOGS heuristic +
       ask_user_question rule)
     - PLAN MODE AVAILABLE branch (for non-plan sessions)

2. **Approved-plan preamble** in `plan.accept` and `plan.edit`
   handlers now uses the full `buildApprovedPlanInjection` /
   `buildAcceptEditsPlanInjection` text (with step list + execution
   guidance) instead of a bare `[PLAN_DECISION]: approved` opener.

3. **fullText parameter** added to `enqueuePlanApprovedInjection`
   for callers that have pre-built the entire injection text.

4. **Auto-enable helper** (`src/plan-mode/auto-enable.ts`) ported
   verbatim — the prerequisite for wiring model-pattern auto-entry
   into session-start in a future PR.

## Closes 7 Wave-1 S4/S5 drifts

| # | Drift | Fix |
|---|---|---|
| S4-P0-1 | ACTION CONTRACT block missing | verbatim port |
| S4-P0-2 | Investigation phase block missing | verbatim port (incl. LOGS heuristic) |
| S4-P0-3 | "session IS in plan mode RIGHT NOW" preamble missing | verbatim port |
| S4-P0-4 | PLAN MODE AVAILABLE branch absent | `buildPlanModeAvailableSystemContext()` |
| S5-P0-1 | plan.accept emitted bare opener (not full preamble) | wired `buildApprovedPlanInjection` |
| S5-P0-2 | plan.edit (no body) emitted bare opener | wired `buildAcceptEditsPlanInjection` |
| S5-P0-3 | no auto-enable matcher | verbatim port |

## Test plan

- [x] Local `pnpm typecheck` clean
- [ ] CI test suite green (629 → ~660 tests with new additions)
- [ ] Eva-live-smoke-2 still passes (test was updated to expect the
      full preamble)
- [ ] Eva-live-smoke-3 still passes (rejection cycle unchanged)
- [ ] Re-audit confirms 7 P0s closed from S4/S5

## Files

- `src/prompt/plan-mode-injection.ts` — major re-port (+101/-15)
- `src/runtime/injection-writer.ts` — fullText param (+27/-13)
- `src/ui/session-actions.ts` — wire full preamble (+58/-12)
- `src/plan-mode/auto-enable.ts` — NEW (97 LOC verbatim)
- `tests/prompt/plan-mode-injection.test.ts` — +83 LOC, 8 new assertions
- `tests/plan-mode/auto-enable.test.ts` — NEW (101 LOC, 13 cases)
- `tests/ui/session-actions.test.ts` — +91 LOC, 4 new tests
- `tests/runtime/injection-writer.test.ts` — +24 LOC, 2 new tests
- `tests/eva-live-smokes/smoke-2-plan-approve-flow.test.ts` — flipped
  bare-opener assertion to expect full preamble

## References

- host_ref: `src/agents/pi-embedded-runner/run/attempt.ts:689-749`
- host_ref: `src/agents/plan-mode/approval.ts:185-238`
- host_ref: `src/agents/plan-mode/auto-enable.ts`
- Wave-1 audits: `docs/audits/wave-1/S4-S5-prompt-archetype-injections.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added plan mode auto-enablement based on configurable model patterns
  * Enhanced plan mode prompts with structured action contracts and detailed investigation guidance
  * Improved plan approval and editing workflows with more comprehensive injection content
  * Added plan mode availability prompts that instruct users when to activate plan mode

* **Tests**
  * Added test coverage for auto-enablement pattern matching and caching behavior
  * Expanded plan mode prompt tests for active and available states
  * Enhanced session action handler tests for plan approval and editing workflows

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/Smarter-Claw/pull/88)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->