### PR TITLE
Surgical PR #4: re-port escalating-retry instructions + escalation tiers (Wave-1 S7)

### DIFF
--- a/src/runtime/escalating-retry-constants.ts
+++ b/src/runtime/escalating-retry-constants.ts
@@ -1,0 +1,299 @@
+/**
+ * Escalating-retry detection CONSTANTS — verbatim port from in-host.
+ *
+ * **Parity contract**: byte-identical port of the relevant exports +
+ * private constants from
+ * `/Users/lume/repos/openclaw-pr70071-rebase/src/agents/pi-embedded-runner/run/incomplete-turn.ts:66-267`
+ * (commit `ea04ea52c7`).
+ *
+ * # Why split this out
+ *
+ * The in-host's `incomplete-turn.ts` is ~1070 LOC because it interrogates
+ * `EmbeddedRunAttemptResult` (toolMetas, replayMetadata, itemLifecycle)
+ * — internals the runner owns but the plugin SDK doesn't expose. The
+ * plugin's detection operates at the COARSE turn boundary
+ * (`before_agent_finalize` event). Porting the whole 1070 LOC would
+ * fail to compile against the SDK surface, and most of it (toolMeta
+ * inspection, replayMetadata side-effect tracking) is gateway-internal.
+ *
+ * What DOES translate cleanly: the instruction strings (the bytes the
+ * agent sees), the regex constants (planning-narration patterns), and
+ * the escalation-level mapping (retry-count → instruction-tier). All
+ * three live here as VERBATIM exports so:
+ *   - Tests can pin them against the in-host source-of-truth
+ *   - Future parity-harness Layer-1 diffs catch drift surgically
+ *   - The plugin's coarse detector picks the right escalation tier
+ *
+ * # Surgical-port rationale (2026-05-12)
+ *
+ * Wave-1 audit slice S7 found the plugin had only THREE ad-hoc
+ * instruction strings (one per detector, no escalation tiers). The
+ * in-host has FIRM and FINAL escalations for PLANNING_RETRY and
+ * PLAN_ACK_ONLY and PLAN_YIELD — these are the gradient that makes
+ * the retry effective rather than nagging.
+ *
+ * host_ref: src/agents/pi-embedded-runner/run/incomplete-turn.ts:66-267
+ */
+
+// ---------------------------------------------------------------------------
+// Regex constants for narration detection.
+// Byte-identical to in-host lines 66-80.
+// ---------------------------------------------------------------------------
+
+export const PLANNING_ONLY_PROMISE_RE =
+  /\b(?:i(?:'ll| will)|let me|i(?:'m| am)\s+going to|first[, ]+i(?:'ll| will)|next[, ]+i(?:'ll| will)|i can do that)\b/i;
+
+export const PLANNING_ONLY_COMPLETION_RE =
+  /\b(?:done|finished|implemented|updated|fixed|changed|ran|verified|found|here(?:'s| is) what|blocked by|the blocker is)\b/i;
+
+export const PLANNING_ONLY_HEADING_RE = /^(?:plan|steps?|next steps?)\s*:/i;
+
+export const PLANNING_ONLY_BULLET_RE = /^(?:[-*•]\s+|\d+[.)]\s+)/u;
+
+export const PLANNING_ONLY_MAX_VISIBLE_TEXT = 700;
+
+export const PLANNING_ONLY_ACTION_VERB_RE =
+  /\b(?:inspect|investigate|check|look(?:\s+into|\s+at)?|read|search|find|debug|fix|patch|update|change|edit|write|implement|run|test|verify|review|analy(?:s|z)e|summari(?:s|z)e|explain|answer|show|share|report|prepare|capture|take|refactor|restart|deploy|ship)\b/i;
+
+// ---------------------------------------------------------------------------
+// Retry-limit defaults — byte-identical to in-host lines 96-101, 245, 267.
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_PLANNING_ONLY_RETRY_LIMIT = 1;
+export const STRICT_AGENTIC_PLANNING_ONLY_RETRY_LIMIT = 3;
+export const DEFAULT_REASONING_ONLY_RETRY_LIMIT = 2;
+export const DEFAULT_EMPTY_RESPONSE_RETRY_LIMIT = 1;
+export const DEFAULT_PLAN_MODE_ACK_ONLY_RETRY_LIMIT = 2;
+export const DEFAULT_PLAN_APPROVED_YIELD_RETRY_LIMIT = 2;
+
+// ---------------------------------------------------------------------------
+// PLANNING_RETRY instructions (outside plan mode — agent narrated only).
+// Byte-identical to in-host lines 151-156.
+// ---------------------------------------------------------------------------
+
+export const PLANNING_ONLY_RETRY_INSTRUCTION =
+  "[PLANNING_RETRY]: The previous assistant turn only described the plan. Do not restate the plan. Act now: take the first concrete tool action you can. If a real blocker prevents action, reply with the exact blocker in one sentence.";
+
+export const PLANNING_ONLY_RETRY_INSTRUCTION_FIRM =
+  "[PLANNING_RETRY]: CRITICAL: You have described the plan multiple times without acting. You MUST call a tool in this turn. No more planning or narration. If a real blocker prevents action, state the exact blocker in one sentence. Otherwise, call the first tool NOW.";
+
+export const PLANNING_ONLY_RETRY_INSTRUCTION_FINAL =
+  "[PLANNING_RETRY]: Final reminder: this is the third planning-only turn. Please call a tool now to make progress. If a real blocker prevents action, state the exact blocker in one sentence so the user can unblock you.";
+
+// ---------------------------------------------------------------------------
+// REASONING_ONLY / EMPTY_RESPONSE instructions (no PLAN_* tag — outside
+// plan-mode tag taxonomy). Byte-identical to in-host lines 157-160.
+// ---------------------------------------------------------------------------
+
+export const REASONING_ONLY_RETRY_INSTRUCTION =
+  "The previous assistant turn recorded reasoning but did not produce a user-visible answer. Continue from that partial turn and produce the visible answer now. Do not restate the reasoning or restart from scratch.";
+
+export const EMPTY_RESPONSE_RETRY_INSTRUCTION =
+  "The previous attempt did not produce a user-visible answer. Continue from the current state and produce the visible answer now. Do not restart from scratch.";
+
+// ---------------------------------------------------------------------------
+// ACK_EXECUTION / AUTO_CONTINUE fast-path instructions. Byte-identical
+// to in-host lines 161-166.
+// ---------------------------------------------------------------------------
+
+export const ACK_EXECUTION_FAST_PATH_INSTRUCTION =
+  "The latest user message is a short approval to proceed. Do not recap or restate the plan. Start with the first concrete tool action immediately. Keep any user-facing follow-up brief and natural.";
+
+export const AUTO_CONTINUE_FAST_PATH_INSTRUCTION =
+  "The system is auto-continuing. Do not recap or restate the plan. Start with the first concrete tool action immediately. Keep any user-facing follow-up brief and natural.";
+
+export const STRICT_AGENTIC_BLOCKED_TEXT =
+  "Agent stopped after repeated plan-only turns without taking a concrete action. No concrete tool action or external side effect advanced the task.";
+
+// ---------------------------------------------------------------------------
+// PLAN_ACK_ONLY instructions (in plan mode, agent narrated without
+// calling exit_plan_mode or an investigative tool).
+// Byte-identical to in-host lines 226-243.
+// ---------------------------------------------------------------------------
+
+export const PLAN_MODE_ACK_ONLY_RETRY_INSTRUCTION =
+  "[PLAN_ACK_ONLY]: Plan mode is active and you're still in the PLANNING phase (no user " +
+  "approval yet). Your previous response stopped without calling " +
+  "exit_plan_mode OR a read-only investigative tool. Brief progress " +
+  "updates are fine, but they must NOT end the turn — keep calling tools " +
+  "after them. The next response MUST either: (a) continue planning " +
+  "investigation with a read-only tool (read, lcm_grep, lcm_describe, " +
+  "lcm_expand_query, grep, glob, ls, find, web_search, web_fetch, " +
+  "update_plan), or (b) call exit_plan_mode(title=..., plan=[...]) " +
+  "with the proposed plan. A status line followed by another tool call " +
+  "is the right pattern; a status line alone is treated as yielding " +
+  "without acting.";
+
+export const PLAN_MODE_ACK_ONLY_RETRY_INSTRUCTION_FIRM =
+  "[PLAN_ACK_ONLY]: CRITICAL: plan mode is active and you have acknowledged twice without calling " +
+  "exit_plan_mode. You MUST call exit_plan_mode(plan=[...]) in this turn. No more " +
+  "chat-only acknowledgements. If a real blocker prevents producing a plan, state " +
+  "the exact blocker in one sentence so the user can unblock you.";
+
+// ---------------------------------------------------------------------------
+// PLAN_APPROVED_YIELD instructions (post-approval, agent yielded the
+// turn without main-lane execution). Byte-identical to in-host lines
+// 254-265.
+// ---------------------------------------------------------------------------
+
+export const PLAN_APPROVED_YIELD_RETRY_INSTRUCTION =
+  "[PLAN_YIELD]: Your plan was just approved and mutating tools were unlocked. You yielded the turn " +
+  "without taking any main-lane action — but the approval flow explicitly told you to " +
+  "continue through every step without pausing. Continue executing the plan now. Only " +
+  "yield if you actually need a subagent's result for the next step you are about to " +
+  "take, AND state in one sentence which step is blocked on which result.";
+
+export const PLAN_APPROVED_YIELD_RETRY_INSTRUCTION_FIRM =
+  "[PLAN_YIELD]: CRITICAL: you yielded again immediately after plan approval. Continue main-lane " +
+  "execution of the approved plan. If a subagent result is genuinely required for the " +
+  "next step, perform that step's prerequisite reads inline instead of orchestrating. " +
+  "Do not yield unless a real blocker requires the user to intervene.";
+
+// ---------------------------------------------------------------------------
+// Investigative-tool catalog. When the agent calls one of these in plan
+// mode, the PLAN_ACK_ONLY detector should NOT fire (the agent IS
+// investigating, just doing it without exit_plan_mode yet — fine).
+//
+// Byte-identical to in-host lines 203-217 (PLAN_MODE_INVESTIGATIVE_TOOL_NAMES).
+// ---------------------------------------------------------------------------
+
+export const PLAN_MODE_INVESTIGATIVE_TOOL_NAMES: ReadonlySet<string> = new Set([
+  "read",
+  "lcm_grep",
+  "lcm_describe",
+  "lcm_expand_query",
+  "lcm_expand",
+  "grep",
+  "glob",
+  "ls",
+  "find",
+  "web_search",
+  "web_fetch",
+  "update_plan",
+  "enter_plan_mode",
+]);
+
+// ---------------------------------------------------------------------------
+// Escalation resolver — picks the right instruction tier based on
+// attempt index. Byte-identical to in-host
+// `resolveEscalatingPlanningRetryInstruction` at lines 731-739.
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns an escalating retry instruction based on the current attempt number.
+ * Attempt 0 = first retry (standard), 1 = firm, 2+ = final warning.
+ *
+ * host_ref: src/agents/pi-embedded-runner/run/incomplete-turn.ts:731-739
+ */
+export function resolveEscalatingPlanningRetryInstruction(
+  attemptIndex: number,
+): string {
+  if (attemptIndex <= 0) {
+    return PLANNING_ONLY_RETRY_INSTRUCTION;
+  }
+  if (attemptIndex === 1) {
+    return PLANNING_ONLY_RETRY_INSTRUCTION_FIRM;
+  }
+  return PLANNING_ONLY_RETRY_INSTRUCTION_FINAL;
+}
+
+/**
+ * PLAN_ACK_ONLY escalation. Attempt 0 = standard, 1+ = firm.
+ *
+ * host_ref: in-host pattern at incomplete-turn.ts (the FIRM variant is
+ *   used after the standard has been tried — see DEFAULT_PLAN_MODE_ACK_ONLY_RETRY_LIMIT
+ *   = 2 which implies a 2-step escalation).
+ */
+export function resolveEscalatingPlanAckOnlyInstruction(
+  attemptIndex: number,
+): string {
+  if (attemptIndex <= 0) {
+    return PLAN_MODE_ACK_ONLY_RETRY_INSTRUCTION;
+  }
+  return PLAN_MODE_ACK_ONLY_RETRY_INSTRUCTION_FIRM;
+}
+
+/**
+ * PLAN_YIELD escalation. Attempt 0 = standard, 1+ = firm.
+ *
+ * host_ref: DEFAULT_PLAN_APPROVED_YIELD_RETRY_LIMIT = 2 implies
+ *   2-step escalation (standard → firm).
+ */
+export function resolveEscalatingPlanYieldInstruction(
+  attemptIndex: number,
+): string {
+  if (attemptIndex <= 0) {
+    return PLAN_APPROVED_YIELD_RETRY_INSTRUCTION;
+  }
+  return PLAN_APPROVED_YIELD_RETRY_INSTRUCTION_FIRM;
+}
+
+// ---------------------------------------------------------------------------
+// Detection helpers — coarse-grained narration detectors using the in-host
+// regex constants. The full in-host detector also interrogates toolMetas
+// and replayMetadata; those are gateway-side and don't translate. We
+// use just the text-based signals here.
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true when text matches the in-host's structured-planning
+ * heuristic: heading + planning cue, OR 2+ bullet lines + planning cue.
+ *
+ * host_ref: incomplete-turn.ts:644-656 (hasStructuredPlanningOnlyFormat).
+ */
+export function hasStructuredPlanningOnlyFormat(text: string): boolean {
+  const lines = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (lines.length === 0) {
+    return false;
+  }
+  const bulletLineCount = lines.filter((line) =>
+    PLANNING_ONLY_BULLET_RE.test(line),
+  ).length;
+  const hasPlanningCueLine = lines.some((line) =>
+    PLANNING_ONLY_PROMISE_RE.test(line),
+  );
+  const hasPlanningHeading = PLANNING_ONLY_HEADING_RE.test(lines[0] ?? "");
+  return (
+    (hasPlanningHeading && hasPlanningCueLine) ||
+    (bulletLineCount >= 2 && hasPlanningCueLine)
+  );
+}
+
+/**
+ * Returns true when the text is planning-narration — agent describing
+ * what they're going to do without acting. The text-only signals from
+ * the in-host detector at incomplete-turn.ts:792-808.
+ *
+ * Returns false when:
+ *   - text is empty / too long (skip walls)
+ *   - text contains a code block (likely the agent IS executing)
+ *   - text doesn't match PLANNING_ONLY_PROMISE_RE AND lacks structured format
+ *   - text doesn't match an action verb (e.g. "I'll think about this")
+ *   - text matches the COMPLETION_RE (e.g. "done", "fixed it")
+ *
+ * host_ref: incomplete-turn.ts:792-808 (resolvePlanningOnlyRetryInstruction
+ *   text-checking branch).
+ */
+export function isPlanningOnlyNarrationText(
+  text: string | undefined,
+): boolean {
+  if (!text) return false;
+  const trimmed = text.trim();
+  if (!trimmed) return false;
+  if (trimmed.length > PLANNING_ONLY_MAX_VISIBLE_TEXT) return false;
+  if (trimmed.includes("```")) return false;
+  const hasStructuredFormat = hasStructuredPlanningOnlyFormat(trimmed);
+  if (!PLANNING_ONLY_PROMISE_RE.test(trimmed) && !hasStructuredFormat) {
+    return false;
+  }
+  if (!hasStructuredFormat && !PLANNING_ONLY_ACTION_VERB_RE.test(trimmed)) {
+    return false;
+  }
+  if (PLANNING_ONLY_COMPLETION_RE.test(trimmed)) {
+    return false;
+  }
+  return true;
+}

--- a/src/runtime/escalating-retry.ts
+++ b/src/runtime/escalating-retry.ts
@@ -26,19 +26,51 @@
  *
  * # Escalation levels (max 3 retries per cycle)
  *
- * The SDK's `before_agent_finalize` result accepts `maxAttempts`. We
- * use `idempotencyKey` keyed on (sessionKey, detector, lastAssistant
- * truncated hash) so the host counts retries for the same logical
- * situation and stops at level 3.
+ * Each detector picks an escalating instruction tier based on the
+ * SDK's per-key attempt counter. Tiers are byte-identical to in-host:
  *
- * host_ref: in-host escalating-retry semantics from PR-7 + iter-3 D2
- * landed across pi-embedded-runner/run/incomplete-turn.ts +
- * thinking.ts. Plugin port encodes the BEHAVIORAL contract; the
- * algorithmic details (toolMeta inspection, etc.) are runner-internal
- * and don't translate.
+ *   - PLANNING_RETRY: standard (0) → firm (1) → final (2+)
+ *   - PLAN_ACK_ONLY: standard (0) → firm (1+)
+ *   - PLAN_YIELD: standard (0) → firm (1+)
+ *
+ * Instruction strings + regex constants + escalation resolvers live in
+ * `./escalating-retry-constants.ts` so a future parity-harness Layer-1
+ * diff catches drift surgically.
+ *
+ * # Surgical-port rationale (2026-05-12)
+ *
+ * Wave-1 audit slice S7 found:
+ *   - Plugin had 3 ad-hoc instruction strings (no FIRM/FINAL tiers)
+ *   - Plugin's narration detection was a naive `["I'll ", "Let me "]`
+ *     array — missing the in-host's nuanced regex + structured-format
+ *     heuristic
+ *   - No PLANNING_ONLY_COMPLETION_RE guard (don't retry when agent
+ *     says "done" / "fixed")
+ *   - No max-length guard (retry on walls of text)
+ *   - No code-block bypass (retry when agent IS showing code)
+ *
+ * This PR re-ports the BYTES + escalation tiers + nuanced regex
+ * detection. The full toolMeta-level analysis (which Counts plan-only
+ * tool calls vs real ones) stays gateway-side because the SDK seam
+ * doesn't expose that signal. Documented as the remaining gap.
+ *
+ * host_ref: in-host escalating-retry from PR-7 + iter-3 D2 at
+ *   pi-embedded-runner/run/incomplete-turn.ts (instruction constants
+ *   verbatim; toolMeta detection deferred to gateway).
  */
 
 import type { PlanMode } from "../types.js";
+import {
+  isPlanningOnlyNarrationText,
+  PLANNING_ONLY_COMPLETION_RE,
+  resolveEscalatingPlanAckOnlyInstruction,
+  resolveEscalatingPlanningRetryInstruction,
+  resolveEscalatingPlanYieldInstruction,
+  PLAN_MODE_ACK_ONLY_RETRY_INSTRUCTION,
+  PLAN_APPROVED_YIELD_RETRY_INSTRUCTION,
+  DEFAULT_PLAN_MODE_ACK_ONLY_RETRY_LIMIT,
+  DEFAULT_PLAN_APPROVED_YIELD_RETRY_LIMIT,
+} from "./escalating-retry-constants.js";
 
 /**
  * Coarse-grained turn signal extracted from the
@@ -60,6 +92,12 @@ export interface TurnSignal {
   /** True if the immediately-prior turn was a [PLAN_DECISION]: approved
    *  injection (so a yield here is the "PLAN_YIELD" antipattern). */
   isPostApprovalTurn: boolean;
+  /** Optional: number of times THIS detector has fired for this cycle.
+   *  Drives the FIRM/FINAL escalation. The host's
+   *  before_agent_finalize counter is queried by idempotencyKey; the
+   *  plugin reads it through the prior-decision metadata. When
+   *  undefined, treats as 0 (first attempt). */
+  attemptIndex?: number;
 }
 
 export type RetryDetector = "PLAN_ACK_ONLY" | "PLAN_YIELD" | "PLANNING_RETRY";
@@ -77,6 +115,10 @@ export interface RetryDecision {
  *
  * Priority order: PLAN_YIELD > PLAN_ACK_ONLY > PLANNING_RETRY. Higher
  * is more specific; only one detector fires per turn.
+ *
+ * host_ref: in-host's incomplete-turn.ts dispatch — PLAN_YIELD checked
+ *   first via post-approval grace window, then PLAN_ACK_ONLY for in-
+ *   mode chat-only, then PLANNING_RETRY for the normal-mode case.
  */
 export function decideEscalatingRetry(
   sessionKey: string | undefined,
@@ -84,8 +126,12 @@ export function decideEscalatingRetry(
 ): RetryDecision | undefined {
   if (!sessionKey) return undefined;
 
+  const attemptIndex = signal.attemptIndex ?? 0;
+
   // PLAN_YIELD: post-approval turn that yielded with no execution.
-  // Most specific — check first.
+  // Most specific — check first. The in-host has a grace window
+  // (POST_APPROVAL_YIELD_GRACE_MS) AND a toolMeta check; we use the
+  // coarse "no tool call + no assistant text" signal here.
   if (
     signal.isPostApprovalTurn &&
     !signal.madeToolCall &&
@@ -93,84 +139,48 @@ export function decideEscalatingRetry(
   ) {
     return {
       detector: "PLAN_YIELD",
-      instruction:
-        "[PLAN_YIELD]: Approval was granted but you didn't begin execution. " +
-        "Continue with the plan — start the first pending step now.",
+      instruction: resolveEscalatingPlanYieldInstruction(attemptIndex),
       idempotencyKey: idempotencyKey(sessionKey, "PLAN_YIELD"),
-      maxAttempts: 3,
+      maxAttempts: DEFAULT_PLAN_APPROVED_YIELD_RETRY_LIMIT,
     };
   }
 
   // PLAN_ACK_ONLY: in plan mode, agent narrated without acting.
+  // Skip when text says "done" / "fixed" etc. — the agent may have
+  // ended the work via reasoning and the retry would be a nag.
   if (
     signal.planMode === "plan" &&
     !signal.madeToolCall &&
-    !!signal.lastAssistantMessage?.trim()
+    !!signal.lastAssistantMessage?.trim() &&
+    !PLANNING_ONLY_COMPLETION_RE.test(signal.lastAssistantMessage)
   ) {
     return {
       detector: "PLAN_ACK_ONLY",
-      instruction:
-        "[PLAN_ACK_ONLY]: You're in plan mode but your last turn was chat without a tool call. " +
-        "Take the next concrete action: investigate (read/grep/web_search), update_plan, " +
-        "ask_user_question, or exit_plan_mode with your proposal. Don't narrate without acting.",
+      instruction: resolveEscalatingPlanAckOnlyInstruction(attemptIndex),
       idempotencyKey: idempotencyKey(sessionKey, "PLAN_ACK_ONLY"),
-      maxAttempts: 3,
+      maxAttempts: DEFAULT_PLAN_MODE_ACK_ONLY_RETRY_LIMIT,
     };
   }
 
   // PLANNING_RETRY: outside plan mode, agent narrated planning-only
-  // turn (chat text but no tool call). Suggests the agent SHOULD have
-  // entered plan mode for a non-trivial task.
+  // turn (chat text but no tool call). Uses the in-host's nuanced
+  // detector: requires PLANNING_ONLY_PROMISE_RE match (or structured
+  // format with bullets + heading) + an action verb + not a
+  // completion signal + not a code block + not too long.
   if (
     signal.planMode === "normal" &&
     !signal.madeToolCall &&
-    isPlanningNarration(signal.lastAssistantMessage)
+    isPlanningOnlyNarrationText(signal.lastAssistantMessage)
   ) {
     return {
       detector: "PLANNING_RETRY",
-      instruction:
-        "[PLANNING_RETRY]: Your last turn was narration about what you're going to do without taking action. " +
-        "For non-trivial tasks consider enter_plan_mode and submitting a plan; " +
-        "for trivial tasks, just call the appropriate tool. Don't describe the work — do it (or plan it first).",
+      instruction: resolveEscalatingPlanningRetryInstruction(attemptIndex),
       idempotencyKey: idempotencyKey(sessionKey, "PLANNING_RETRY"),
       maxAttempts: 3,
     };
   }
 
   return undefined;
-}
-
-/**
- * Heuristic: is the assistant message planning-only narration? Looks
- * for phrases like "I'll", "Let me", "First I'll" etc. without any
- * concrete action signals (no code blocks, no specific file paths
- * with file extensions, no tool-result style content).
- *
- * Intentionally conservative — false-negative (skipping a retry) is
- * better than false-positive (annoying the user with a retry on
- * a legitimately-narrative reply).
- */
-function isPlanningNarration(text: string | undefined): boolean {
-  if (!text) return false;
-  const t = text.trim();
-  if (t.length === 0 || t.length > 2000) return false; // skip empty + walls of text
-  const planningStarters = [
-    /^I'll /i,
-    /^I will /i,
-    /^Let me /i,
-    /^First[,\s]/i,
-    /^Here's my plan/i,
-    /^My plan /i,
-    /^The plan /i,
-  ];
-  const hasPlanningStart = planningStarters.some((re) => re.test(t));
-  if (!hasPlanningStart) return false;
-  // Heuristic anti-false-positive: don't retry if the message
-  // contains a code block — likely the agent IS executing.
-  if (/```/.test(t)) return false;
-  // Don't retry on Q-style messages that end with a question mark.
-  if (t.endsWith("?")) return false;
-  return true;
 }
 
 function idempotencyKey(sessionKey: string, detector: RetryDetector): string {
@@ -180,3 +190,10 @@ function idempotencyKey(sessionKey: string, detector: RetryDetector): string {
   // and "I'll handle Y" both count toward the cap).
   return `smarter-claw:${detector}:${sessionKey}`;
 }
+
+// Re-export the constants so callers can pin them in tests without
+// reaching into the constants module directly.
+export {
+  PLAN_MODE_ACK_ONLY_RETRY_INSTRUCTION,
+  PLAN_APPROVED_YIELD_RETRY_INSTRUCTION,
+} from "./escalating-retry-constants.js";

--- a/tests/runtime/escalating-retry.test.ts
+++ b/tests/runtime/escalating-retry.test.ts
@@ -1,21 +1,48 @@
 /**
- * P-10 escalating-retry decision tests.
+ * Escalating-retry decision tests.
  *
  * Covers the 3 detectors (PLAN_YIELD, PLAN_ACK_ONLY, PLANNING_RETRY)
- * + their precedence + idempotency-key shape.
+ * + their precedence + idempotency-key shape + escalation tiers.
  *
- * Full corpus (59 host-internal cases) deferred to Eva live-smoke #3
- * + a P-10.5 follow-up; the in-host's `incomplete-turn.ts` 1070-LOC
- * detection pipeline integrates with runner internals that the
- * SDK abstracts away.
+ * Surgical-port S7 (2026-05-12): expanded coverage for the verbatim-
+ * ported in-host instruction constants + FIRM/FINAL escalation tiers
+ * + nuanced planning-narration regex.
+ *
+ * Full in-host corpus (59 cases) deferred to live-smoke #3 + a future
+ * gateway-side PR; the in-host's `incomplete-turn.ts` 1070-LOC
+ * detection pipeline integrates with runner internals (toolMetas,
+ * replayMetadata) that the SDK abstracts away.
+ *
+ * Parity contract:
+ *   - Instruction strings are byte-identical to in-host
+ *     (incomplete-turn.ts:151-265).
+ *   - Regex constants are byte-identical (incomplete-turn.ts:66-74).
+ *   - Escalation thresholds match in-host
+ *     (DEFAULT_PLAN_APPROVED_YIELD_RETRY_LIMIT = 2,
+ *      DEFAULT_PLAN_MODE_ACK_ONLY_RETRY_LIMIT = 2).
  */
 
 import { describe, expect, it } from "vitest";
-import { decideEscalatingRetry } from "../../src/runtime/escalating-retry.js";
+import {
+  decideEscalatingRetry,
+  PLAN_APPROVED_YIELD_RETRY_INSTRUCTION,
+  PLAN_MODE_ACK_ONLY_RETRY_INSTRUCTION,
+} from "../../src/runtime/escalating-retry.js";
+import {
+  isPlanningOnlyNarrationText,
+  PLANNING_ONLY_RETRY_INSTRUCTION,
+  PLANNING_ONLY_RETRY_INSTRUCTION_FINAL,
+  PLANNING_ONLY_RETRY_INSTRUCTION_FIRM,
+  PLAN_APPROVED_YIELD_RETRY_INSTRUCTION_FIRM,
+  PLAN_MODE_ACK_ONLY_RETRY_INSTRUCTION_FIRM,
+  resolveEscalatingPlanAckOnlyInstruction,
+  resolveEscalatingPlanYieldInstruction,
+  resolveEscalatingPlanningRetryInstruction,
+} from "../../src/runtime/escalating-retry-constants.js";
 
 const SESSION_KEY = "agent:main:main";
 
-describe("P-10 escalating-retry — PLAN_YIELD detector", () => {
+describe("escalating-retry — PLAN_YIELD detector", () => {
   it("fires when post-approval turn yielded with no text + no tool call", () => {
     const d = decideEscalatingRetry(SESSION_KEY, {
       planMode: "normal",
@@ -25,23 +52,38 @@ describe("P-10 escalating-retry — PLAN_YIELD detector", () => {
     });
     expect(d?.detector).toBe("PLAN_YIELD");
     expect(d?.instruction).toMatch(/\[PLAN_YIELD\]:/);
-    expect(d?.maxAttempts).toBe(3);
+    // Surgical-port S7: maxAttempts now matches in-host
+    // DEFAULT_PLAN_APPROVED_YIELD_RETRY_LIMIT = 2.
+    expect(d?.maxAttempts).toBe(2);
+  });
+
+  it("attempt 0 → standard instruction (byte-identical to in-host)", () => {
+    const d = decideEscalatingRetry(SESSION_KEY, {
+      planMode: "normal",
+      lastAssistantMessage: "",
+      madeToolCall: false,
+      isPostApprovalTurn: true,
+      attemptIndex: 0,
+    });
+    expect(d?.instruction).toBe(PLAN_APPROVED_YIELD_RETRY_INSTRUCTION);
+  });
+
+  it("attempt 1+ → firm instruction (escalation)", () => {
+    const d = decideEscalatingRetry(SESSION_KEY, {
+      planMode: "normal",
+      lastAssistantMessage: "",
+      madeToolCall: false,
+      isPostApprovalTurn: true,
+      attemptIndex: 1,
+    });
+    expect(d?.instruction).toBe(PLAN_APPROVED_YIELD_RETRY_INSTRUCTION_FIRM);
+    expect(d?.instruction).toContain("CRITICAL");
   });
 
   it("does NOT fire when post-approval turn made a tool call", () => {
     const d = decideEscalatingRetry(SESSION_KEY, {
       planMode: "normal",
       lastAssistantMessage: "",
-      madeToolCall: true,
-      isPostApprovalTurn: true,
-    });
-    expect(d).toBeUndefined();
-  });
-
-  it("does NOT fire when post-approval turn emitted text + tool call", () => {
-    const d = decideEscalatingRetry(SESSION_KEY, {
-      planMode: "normal",
-      lastAssistantMessage: "Starting execution",
       madeToolCall: true,
       isPostApprovalTurn: true,
     });
@@ -59,7 +101,7 @@ describe("P-10 escalating-retry — PLAN_YIELD detector", () => {
   });
 });
 
-describe("P-10 escalating-retry — PLAN_ACK_ONLY detector", () => {
+describe("escalating-retry — PLAN_ACK_ONLY detector", () => {
   it("fires in plan mode + chat-only turn", () => {
     const d = decideEscalatingRetry(SESSION_KEY, {
       planMode: "plan",
@@ -69,6 +111,52 @@ describe("P-10 escalating-retry — PLAN_ACK_ONLY detector", () => {
     });
     expect(d?.detector).toBe("PLAN_ACK_ONLY");
     expect(d?.instruction).toMatch(/\[PLAN_ACK_ONLY\]:/);
+    expect(d?.maxAttempts).toBe(2); // DEFAULT_PLAN_MODE_ACK_ONLY_RETRY_LIMIT
+  });
+
+  it("attempt 0 → standard instruction (byte-identical to in-host)", () => {
+    const d = decideEscalatingRetry(SESSION_KEY, {
+      planMode: "plan",
+      lastAssistantMessage: "I'm thinking about it.",
+      madeToolCall: false,
+      isPostApprovalTurn: false,
+      attemptIndex: 0,
+    });
+    expect(d?.instruction).toBe(PLAN_MODE_ACK_ONLY_RETRY_INSTRUCTION);
+  });
+
+  it("attempt 1+ → firm instruction (escalation)", () => {
+    const d = decideEscalatingRetry(SESSION_KEY, {
+      planMode: "plan",
+      lastAssistantMessage: "I'm thinking about it.",
+      madeToolCall: false,
+      isPostApprovalTurn: false,
+      attemptIndex: 1,
+    });
+    expect(d?.instruction).toBe(PLAN_MODE_ACK_ONLY_RETRY_INSTRUCTION_FIRM);
+    expect(d?.instruction).toContain("CRITICAL");
+  });
+
+  it("does NOT fire when text matches COMPLETION_RE (e.g. 'done', 'fixed') — surgical-port S7", () => {
+    // The in-host's PLANNING_ONLY_COMPLETION_RE guard prevents the
+    // retry from firing on "done" / "fixed" / etc. — these signal the
+    // agent has ended the work via reasoning, retrying would nag.
+    for (const text of [
+      "Done.",
+      "Fixed the bug.",
+      "Verified all paths.",
+      "Found the issue.",
+      "Implemented the change.",
+      "Blocked by missing credentials.",
+    ]) {
+      const d = decideEscalatingRetry(SESSION_KEY, {
+        planMode: "plan",
+        lastAssistantMessage: text,
+        madeToolCall: false,
+        isPostApprovalTurn: false,
+      });
+      expect(d, `text=${JSON.stringify(text)} should not fire`).toBeUndefined();
+    }
   });
 
   it("does NOT fire in plan mode when a tool call was made", () => {
@@ -82,8 +170,6 @@ describe("P-10 escalating-retry — PLAN_ACK_ONLY detector", () => {
   });
 
   it("does NOT fire in plan mode with no assistant text + no tool call (different antipattern)", () => {
-    // Empty turn in plan mode is its own bug; PLAN_ACK_ONLY requires
-    // actual chat. (PLAN_YIELD covers the post-approval-empty case.)
     const d = decideEscalatingRetry(SESSION_KEY, {
       planMode: "plan",
       lastAssistantMessage: "",
@@ -101,14 +187,14 @@ describe("P-10 escalating-retry — PLAN_ACK_ONLY detector", () => {
       isPostApprovalTurn: false,
     });
     // Normal mode + acknowledgment text is fine OR triggers PLANNING_RETRY
-    // depending on planning-narration heuristic. "OK I understand" doesn't
-    // match planning-narration starters, so undefined.
+    // depending on in-host narration heuristic. "OK I understand" doesn't
+    // match PLANNING_ONLY_PROMISE_RE, so no retry.
     expect(d).toBeUndefined();
   });
 });
 
-describe("P-10 escalating-retry — PLANNING_RETRY detector", () => {
-  it("fires on planning narration in normal mode (no tool call)", () => {
+describe("escalating-retry — PLANNING_RETRY detector (in-host regex parity)", () => {
+  it("fires on planning narration in normal mode (no tool call) — promise + action verb", () => {
     const d = decideEscalatingRetry(SESSION_KEY, {
       planMode: "normal",
       lastAssistantMessage:
@@ -118,17 +204,40 @@ describe("P-10 escalating-retry — PLANNING_RETRY detector", () => {
     });
     expect(d?.detector).toBe("PLANNING_RETRY");
     expect(d?.instruction).toMatch(/\[PLANNING_RETRY\]:/);
+    expect(d?.maxAttempts).toBe(3);
   });
 
-  it("fires on multiple planning starters", () => {
+  it("attempt 0 → standard, 1 → firm, 2+ → final (3-tier escalation)", () => {
+    const base = {
+      planMode: "normal" as const,
+      lastAssistantMessage: "I'll read the file then update the schema.",
+      madeToolCall: false,
+      isPostApprovalTurn: false,
+    };
+    expect(
+      decideEscalatingRetry(SESSION_KEY, { ...base, attemptIndex: 0 })
+        ?.instruction,
+    ).toBe(PLANNING_ONLY_RETRY_INSTRUCTION);
+    expect(
+      decideEscalatingRetry(SESSION_KEY, { ...base, attemptIndex: 1 })
+        ?.instruction,
+    ).toBe(PLANNING_ONLY_RETRY_INSTRUCTION_FIRM);
+    expect(
+      decideEscalatingRetry(SESSION_KEY, { ...base, attemptIndex: 2 })
+        ?.instruction,
+    ).toBe(PLANNING_ONLY_RETRY_INSTRUCTION_FINAL);
+    expect(
+      decideEscalatingRetry(SESSION_KEY, { ...base, attemptIndex: 99 })
+        ?.instruction,
+    ).toBe(PLANNING_ONLY_RETRY_INSTRUCTION_FINAL);
+  });
+
+  it("fires on planning starters that pair with an action verb", () => {
     for (const text of [
-      "I'll do this thing.",
-      "I will start with the easy bit.",
       "Let me check the config first.",
       "First, I'll read the source.",
-      "Here's my plan: walk the tree.",
-      "My plan is to refactor",
-      "The plan involves three steps.",
+      "I will inspect the auth config.",
+      "I'm going to investigate the failures.",
     ]) {
       const d = decideEscalatingRetry(SESSION_KEY, {
         planMode: "normal",
@@ -136,8 +245,22 @@ describe("P-10 escalating-retry — PLANNING_RETRY detector", () => {
         madeToolCall: false,
         isPostApprovalTurn: false,
       });
-      expect(d?.detector).toBe("PLANNING_RETRY");
+      expect(d?.detector, `text=${JSON.stringify(text)}`).toBe(
+        "PLANNING_RETRY",
+      );
     }
+  });
+
+  it("does NOT fire on promise without action verb (surgical-port S7 — in-host rejects)", () => {
+    // "I'll do this" matches PROMISE_RE but "do" is too vague — not
+    // in PLANNING_ONLY_ACTION_VERB_RE. In-host returns null; we match.
+    const d = decideEscalatingRetry(SESSION_KEY, {
+      planMode: "normal",
+      lastAssistantMessage: "I'll do this thing.",
+      madeToolCall: false,
+      isPostApprovalTurn: false,
+    });
+    expect(d).toBeUndefined();
   });
 
   it("does NOT fire when a tool call was made", () => {
@@ -161,17 +284,6 @@ describe("P-10 escalating-retry — PLANNING_RETRY detector", () => {
     expect(d).toBeUndefined();
   });
 
-  it("does NOT fire when message ends with a question (it's a clarifying question)", () => {
-    const d = decideEscalatingRetry(SESSION_KEY, {
-      planMode: "normal",
-      lastAssistantMessage:
-        "I'll do X, but should I also do Y?",
-      madeToolCall: false,
-      isPostApprovalTurn: false,
-    });
-    expect(d).toBeUndefined();
-  });
-
   it("does NOT fire for short non-planning messages", () => {
     const d = decideEscalatingRetry(SESSION_KEY, {
       planMode: "normal",
@@ -182,9 +294,10 @@ describe("P-10 escalating-retry — PLANNING_RETRY detector", () => {
     expect(d).toBeUndefined();
   });
 
-  it("does NOT fire for walls-of-text (>2000 chars; likely substantive)", () => {
-    const longText =
-      "I'll start by " + "a".repeat(2100);
+  it("does NOT fire for walls-of-text > 700 chars (in-host PLANNING_ONLY_MAX_VISIBLE_TEXT)", () => {
+    // Surgical-port S7: in-host caps at 700 (not 2000). Tightening to
+    // match.
+    const longText = "I'll start by reading the file. " + "a".repeat(750);
     const d = decideEscalatingRetry(SESSION_KEY, {
       planMode: "normal",
       lastAssistantMessage: longText,
@@ -193,13 +306,21 @@ describe("P-10 escalating-retry — PLANNING_RETRY detector", () => {
     });
     expect(d).toBeUndefined();
   });
+
+  it("does NOT fire when text matches COMPLETION_RE (e.g. 'done', 'fixed')", () => {
+    const d = decideEscalatingRetry(SESSION_KEY, {
+      planMode: "normal",
+      lastAssistantMessage:
+        "I'll just confirm: I fixed the auth bug and verified all paths.",
+      madeToolCall: false,
+      isPostApprovalTurn: false,
+    });
+    expect(d).toBeUndefined();
+  });
 });
 
-describe("P-10 escalating-retry — detector precedence", () => {
+describe("escalating-retry — detector precedence", () => {
   it("PLAN_YIELD wins over PLAN_ACK_ONLY when both conditions could fire", () => {
-    // Post-approval turn + plan mode + chat without tool call: this
-    // is exactly the PLAN_YIELD specific case. PLAN_YIELD's empty-text
-    // condition wins by being more specific.
     const d = decideEscalatingRetry(SESSION_KEY, {
       planMode: "plan",
       lastAssistantMessage: "",
@@ -220,11 +341,11 @@ describe("P-10 escalating-retry — detector precedence", () => {
   });
 });
 
-describe("P-10 escalating-retry — idempotency keys", () => {
+describe("escalating-retry — idempotency keys", () => {
   it("key includes sessionKey + detector for host counter scoping", () => {
     const d = decideEscalatingRetry(SESSION_KEY, {
       planMode: "plan",
-      lastAssistantMessage: "I understand.",
+      lastAssistantMessage: "I understand and will proceed.",
       madeToolCall: false,
       isPostApprovalTurn: false,
     });
@@ -236,7 +357,7 @@ describe("P-10 escalating-retry — idempotency keys", () => {
   it("different detectors → different keys (so counters are independent)", () => {
     const a = decideEscalatingRetry(SESSION_KEY, {
       planMode: "plan",
-      lastAssistantMessage: "I understand.",
+      lastAssistantMessage: "I understand and will proceed.",
       madeToolCall: false,
       isPostApprovalTurn: false,
     });
@@ -252,13 +373,13 @@ describe("P-10 escalating-retry — idempotency keys", () => {
   it("different sessions → different keys (isolation)", () => {
     const a = decideEscalatingRetry("agent:main:main", {
       planMode: "plan",
-      lastAssistantMessage: "I will do this.",
+      lastAssistantMessage: "I will read this.",
       madeToolCall: false,
       isPostApprovalTurn: false,
     });
     const b = decideEscalatingRetry("agent:other:abc", {
       planMode: "plan",
-      lastAssistantMessage: "I will do this.",
+      lastAssistantMessage: "I will read this.",
       madeToolCall: false,
       isPostApprovalTurn: false,
     });
@@ -266,14 +387,121 @@ describe("P-10 escalating-retry — idempotency keys", () => {
   });
 });
 
-describe("P-10 escalating-retry — defensive", () => {
+describe("escalating-retry — defensive", () => {
   it("returns undefined when no sessionKey", () => {
     const d = decideEscalatingRetry(undefined, {
       planMode: "plan",
-      lastAssistantMessage: "I will do this.",
+      lastAssistantMessage: "I will read this.",
       madeToolCall: false,
       isPostApprovalTurn: false,
     });
     expect(d).toBeUndefined();
+  });
+});
+
+// ===========================================================================
+// Surgical-port S7: in-host instruction-tier resolvers (verbatim parity).
+// ===========================================================================
+
+describe("resolveEscalatingPlanningRetryInstruction (in-host parity)", () => {
+  it("attempt 0 returns the standard instruction", () => {
+    expect(resolveEscalatingPlanningRetryInstruction(0)).toBe(
+      PLANNING_ONLY_RETRY_INSTRUCTION,
+    );
+  });
+
+  it("attempt 1 returns the firm instruction", () => {
+    expect(resolveEscalatingPlanningRetryInstruction(1)).toBe(
+      PLANNING_ONLY_RETRY_INSTRUCTION_FIRM,
+    );
+  });
+
+  it("attempt 2+ returns the final instruction", () => {
+    expect(resolveEscalatingPlanningRetryInstruction(2)).toBe(
+      PLANNING_ONLY_RETRY_INSTRUCTION_FINAL,
+    );
+    expect(resolveEscalatingPlanningRetryInstruction(99)).toBe(
+      PLANNING_ONLY_RETRY_INSTRUCTION_FINAL,
+    );
+  });
+
+  it("negative attempt clamps to standard", () => {
+    expect(resolveEscalatingPlanningRetryInstruction(-1)).toBe(
+      PLANNING_ONLY_RETRY_INSTRUCTION,
+    );
+  });
+});
+
+describe("resolveEscalatingPlanAckOnlyInstruction (in-host parity)", () => {
+  it("attempt 0 → standard, 1+ → firm (2-tier)", () => {
+    expect(resolveEscalatingPlanAckOnlyInstruction(0)).toBe(
+      PLAN_MODE_ACK_ONLY_RETRY_INSTRUCTION,
+    );
+    expect(resolveEscalatingPlanAckOnlyInstruction(1)).toBe(
+      PLAN_MODE_ACK_ONLY_RETRY_INSTRUCTION_FIRM,
+    );
+    expect(resolveEscalatingPlanAckOnlyInstruction(99)).toBe(
+      PLAN_MODE_ACK_ONLY_RETRY_INSTRUCTION_FIRM,
+    );
+  });
+});
+
+describe("resolveEscalatingPlanYieldInstruction (in-host parity)", () => {
+  it("attempt 0 → standard, 1+ → firm (2-tier)", () => {
+    expect(resolveEscalatingPlanYieldInstruction(0)).toBe(
+      PLAN_APPROVED_YIELD_RETRY_INSTRUCTION,
+    );
+    expect(resolveEscalatingPlanYieldInstruction(1)).toBe(
+      PLAN_APPROVED_YIELD_RETRY_INSTRUCTION_FIRM,
+    );
+  });
+});
+
+describe("isPlanningOnlyNarrationText (in-host text-only signal)", () => {
+  it("returns true for promise + action verb", () => {
+    expect(
+      isPlanningOnlyNarrationText("I'll inspect the auth config."),
+    ).toBe(true);
+    expect(
+      isPlanningOnlyNarrationText("Let me check the schema first."),
+    ).toBe(true);
+  });
+
+  it("returns false for empty / undefined / whitespace", () => {
+    expect(isPlanningOnlyNarrationText(undefined)).toBe(false);
+    expect(isPlanningOnlyNarrationText("")).toBe(false);
+    expect(isPlanningOnlyNarrationText("   ")).toBe(false);
+  });
+
+  it("returns false for text > PLANNING_ONLY_MAX_VISIBLE_TEXT (700 chars)", () => {
+    const long = "I'll inspect the file. " + "x".repeat(800);
+    expect(isPlanningOnlyNarrationText(long)).toBe(false);
+  });
+
+  it("returns false when code block is present", () => {
+    expect(
+      isPlanningOnlyNarrationText("I'll check this:\n```sh\nls\n```"),
+    ).toBe(false);
+  });
+
+  it("returns false when completion-signal is present", () => {
+    expect(
+      isPlanningOnlyNarrationText(
+        "I'll just note I fixed it and verified all paths.",
+      ),
+    ).toBe(false);
+  });
+
+  it("returns true for structured plan format (heading + bullets + promise)", () => {
+    const text = [
+      "Plan:",
+      "- I'll inspect the config",
+      "- Then update the schema",
+    ].join("\n");
+    expect(isPlanningOnlyNarrationText(text)).toBe(true);
+  });
+
+  it("returns false when promise but no action verb (in-host's filter)", () => {
+    expect(isPlanningOnlyNarrationText("I'll do this thing.")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Fourth of 5 surgical PRs. Re-ports the in-host escalating-retry
instruction constants, regex constants, and escalation-tier
resolvers verbatim from `incomplete-turn.ts:66-267` (commit
`ea04ea52c7`), closing 6 P0 drifts from audit slice S7.

## Why this matters

The plugin's `escalating-retry.ts` was 183 LOC vs the in-host's
1070 LOC = ~17% feature parity. Critical drifts:

- 3 ad-hoc instruction strings (no FIRM/FINAL tiers)
- Naive `["I'll ", "Let me "]` narration array
- No COMPLETION_RE guard (retried on "done" / "fixed")
- 2000-char max-length (in-host is 700)
- No code-block bypass
- PLAN_YIELD maxAttempts was 3 (in-host is 2)

This PR makes the model see the SAME BYTES as the in-host on every
retry, with the SAME escalation gradient.

## What's surgical about it

**Verbatim** what translates cleanly:
- All instruction strings (PLANNING_ONLY_*, PLAN_MODE_ACK_ONLY_*,
  PLAN_APPROVED_YIELD_*, REASONING_ONLY_*, EMPTY_RESPONSE_*,
  ACK_EXECUTION_*, AUTO_CONTINUE_*, STRICT_AGENTIC_BLOCKED_TEXT)
- Regex constants (PLANNING_ONLY_PROMISE_RE,
  PLANNING_ONLY_COMPLETION_RE, PLANNING_ONLY_HEADING_RE,
  PLANNING_ONLY_BULLET_RE, PLANNING_ONLY_ACTION_VERB_RE)
- Retry-limit defaults (DEFAULT_PLANNING_ONLY_RETRY_LIMIT,
  DEFAULT_PLAN_MODE_ACK_ONLY_RETRY_LIMIT, etc.)
- PLAN_MODE_INVESTIGATIVE_TOOL_NAMES set
- Escalation resolvers (resolveEscalatingPlanning/AckOnly/YieldInstruction)
- Text-only signal `isPlanningOnlyNarrationText`

**Stays gateway-side** (documented as known boundary; needs new SDK
seams to close — tracked in epic #77 / blocker #78):
- toolMeta-level counting (countPlanOnlyToolMetas etc.)
- replayMetadata side-effect tracking
- lastAssistant stopReason inspection
- itemLifecycle.startedCount comparison
- Gemini-specific incomplete-turn provider detection
- ACTIONABLE_PROMPT_DIRECTIVE_RE / actionability heuristic

## Closes 6 Wave-1 S7 drifts

| # | Drift | Fix |
|---|---|---|
| S7-P0-1 | 3 ad-hoc instruction strings | verbatim in-host strings |
| S7-P0-2 | no escalation tiers | 3-tier (PLANNING_RETRY) + 2-tier (ACK_ONLY/YIELD) |
| S7-P0-3 | naive narration regex | full in-host regex set |
| S7-P0-4 | no COMPLETION_RE guard | added |
| S7-P0-5 | max-length 2000 → 700 | matches in-host PLANNING_ONLY_MAX_VISIBLE_TEXT |
| S7-P0-6 | PLAN_YIELD maxAttempts=3 | corrected to 2 (DEFAULT_PLAN_APPROVED_YIELD_RETRY_LIMIT) |

## Test plan

- [x] Local `pnpm typecheck` clean
- [ ] CI test suite green (659 → ~675 tests with new additions)
- [ ] Re-audit Wave-1 S7 confirms 6 P0s closed
- [ ] Eva live-smoke #3 (rejection cycle) still passes

## Files

- `src/runtime/escalating-retry-constants.ts` — NEW (231 LOC) — all
  constants + 3 escalation resolvers + 2 detection helpers
- `src/runtime/escalating-retry.ts` — modified (+78/-78) — uses
  imported constants + resolvers, adds `attemptIndex` to TurnSignal
- `tests/runtime/escalating-retry.test.ts` — expanded (16 → 32 cases)
  + 4 new describes for the in-host parity assertions

## References

- host_ref: `src/agents/pi-embedded-runner/run/incomplete-turn.ts:66-74` (regex)
- host_ref: `src/agents/pi-embedded-runner/run/incomplete-turn.ts:151-267` (instructions)
- host_ref: `src/agents/pi-embedded-runner/run/incomplete-turn.ts:731-739` (escalating resolver)
- host_ref: `src/agents/pi-embedded-runner/run/incomplete-turn.ts:792-808` (text-only signal)
- Wave-1 audit: `docs/audits/wave-1/S7-escalating-retry.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced retry escalation logic for incomplete responses with progressive instruction tightening across retry attempts.
  * Improved detection of planning-only narration to better distinguish incomplete planning stages from actual response failures.
  * Refined handling of acknowledgment-only and yield-only scenarios in planning workflows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/Smarter-Claw/pull/89)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->