### PR TITLE
Surgical PR #5: fix accept-edits trigger predicate + S12 coverage backfill

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -385,19 +385,31 @@ export default definePluginEntry({
       // Layer 2: accept-edits constraint gate (fail-OPEN).
       // Fires AFTER plan approval, when the agent is in the
       // post-approval execution phase with acceptEdits permission.
-      // We approximate "acceptEdits granted" via:
-      //   - autoApprove === true (operator pre-toggled auto-mode), OR
-      //   - approval === "edited" (user inline-edited + approved with edits)
-      // Either signal indicates the runtime is in a "permissive
-      // execution" phase where the 3 hard constraints (destructive,
-      // self-restart, config-change) need explicit re-confirmation.
       //
-      // host_ref: gates/accept-edits-gate.ts (layer 2 of the two-layer
-      // defense; the prompt-layer teaching landed in approval-prompt.ts
-      // not yet ported in P-13 — for P-13 we ship layer 2 alone, which
-      // is the actual enforcement boundary).
-      const isAcceptEditsPhase =
-        autoApprove === true || approval === "edited";
+      // **Surgical-port S12 (2026-05-12)**: the trigger predicate
+      // matches in-host semantics at sessions-patch.ts:982-993:
+      //   - action === "edit" → SETS postApprovalPermissions.acceptEdits=true
+      //   - action === "approve" → EXPLICITLY CLEARS acceptEdits (verbatim
+      //     execution; user did NOT opt into edits)
+      //
+      // So the gate fires ONLY when approval === "edited" (the plugin's
+      // equivalent of in-host's postApprovalPermissions.acceptEdits=true).
+      //
+      // Prior plugin trigger was `autoApprove === true || approval === "edited"`
+      // which over-fired on autoApprove (operator pre-toggled auto-mode).
+      // The in-host autoApprove field is a separate runtime concept that
+      // auto-resolves plan submission to action === "approve" (NOT to
+      // "edit"), so an autoApprove session emits approval === "approved"
+      // and should NOT trigger the gate. The over-fire was a UX regression
+      // for operators who toggled autoApprove for convenience — they got
+      // destructive-action blocks even when the agent was executing in
+      // normal mode without an approval cycle.
+      //
+      // host_ref: gates/accept-edits-gate.ts (layer 2 algorithm; byte-identical)
+      // host_ref: sessions-patch.ts:982-993 (acceptEdits set/clear lifecycle)
+      // host_ref: pi-tools.before-tool-call.ts:324 (trigger predicate at
+      //   `latestPlanMode === "normal" && getLatestAcceptEdits?.()`)
+      const isAcceptEditsPhase = approval === "edited";
       if (!isAcceptEditsPhase) return undefined;
 
       // Extract filePath for write/edit/apply_patch tools.

--- a/tests/eva-live-smokes/smoke-4-accept-edits-adversarial.test.ts
+++ b/tests/eva-live-smokes/smoke-4-accept-edits-adversarial.test.ts
@@ -3,11 +3,12 @@
  *
  * Scenario:
  *   1. Plugin loads.
- *   2. Operator enables autoApprove (which lazy-inits a normal-mode
- *      state with autoApprove=true — same condition the runtime
- *      checks for "post-approval acceptEdits execution phase").
- *   3. Agent (in normal mode) tries 30 adversarial commands across
- *      the 3 hard-constraint categories:
+ *   2. Session enters the acceptEdits-permission phase via the
+ *      enter → exit → plan.edit workflow (the only path that grants
+ *      acceptEdits per in-host sessions-patch.ts:982-993 — plain
+ *      "Accept" explicitly does NOT grant acceptEdits).
+ *   3. Agent (now in normal mode with approval="edited") tries 30
+ *      adversarial commands across the 3 hard-constraint categories:
  *        - Destructive (rm -rf, DROP TABLE, FLUSHALL, ...)
  *        - Self-restart (launchctl unload, pkill openclaw, ...)
  *        - Configuration changes (writes to ~/.openclaw/*, openclaw config set)
@@ -19,6 +20,10 @@
  * `tests/gates/accept-edits-gate.test.ts` against the pure function;
  * this smoke validates the hook plumbing routes inputs to that gate
  * correctly via the WIRED before_tool_call path in index.ts.
+ *
+ * Surgical-port S12 (2026-05-12): updated setup to use the in-host-
+ * parity acceptEdits trigger (approval === "edited") rather than the
+ * prior autoApprove proxy which over-fired the gate.
  */
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -26,19 +31,46 @@ import { createHarness } from "./harness.js";
 
 const SESSION_KEY = "agent:main:main";
 
+interface ToolFactory {
+  (ctx: { sessionKey?: string }): {
+    execute: (
+      callId: string,
+      args: unknown,
+    ) => Promise<{
+      details: { status?: string; approvalId?: string };
+    }>;
+  };
+}
+
 describe("Eva live-smoke #4 — accept-edits gate via before_tool_call (P-13)", () => {
   let harness: ReturnType<typeof createHarness>;
 
   beforeEach(async () => {
     harness = createHarness({ forceInMemory: true });
-    // Lazy-init the session into normal-mode + autoApprove=true.
-    // This matches the runtime's "post-approval execution phase" — the
-    // gate fires on the autoApprove signal.
-    const r = (await harness.invokeAction("plan.auto.toggle", {
+    // Drive the session through enter → exit → plan.edit to grant
+    // acceptEdits permission. The plugin's `isAcceptEditsPhase`
+    // predicate fires on `approval === "edited"` — the same as
+    // in-host's `postApprovalPermissions.acceptEdits === true` per
+    // sessions-patch.ts:982-993.
+    const enter = harness.findTool("enter_plan_mode") as ToolFactory;
+    await enter({ sessionKey: SESSION_KEY }).execute("enter-1", {});
+    const exit = harness.findTool("exit_plan_mode") as ToolFactory;
+    const exitResult = await exit({ sessionKey: SESSION_KEY }).execute(
+      "exit-1",
+      {
+        title: "Setup for accept-edits gate smoke",
+        plan: [{ step: "execute carefully", status: "pending" }],
+      },
+    );
+    const approvalId = exitResult.details.approvalId!;
+    const edit = (await harness.invokeAction("plan.edit", {
       sessionKey: SESSION_KEY,
-      payload: { enabled: true },
+      payload: { approvalId, body: "Edited plan body" },
     })) as { ok: boolean };
-    expect(r.ok).toBe(true);
+    expect(edit.ok).toBe(true);
+    // Reset injection captures so the gate-block tests don't see
+    // the approval-injection from the setup.
+    harness.captures.enqueuedInjections.length = 0;
   });
 
   afterEach(() => {

--- a/tests/gates/accept-edits-gate.test.ts
+++ b/tests/gates/accept-edits-gate.test.ts
@@ -634,3 +634,231 @@ describe("extractApplyPatchTargetPaths — `*** Move to:` grammar (Codex #68939 
     expect(extractApplyPatchTargetPaths(42)).toEqual([]);
   });
 });
+
+// ===========================================================================
+// Surgical-port S12 (2026-05-12): positive tests for coded-but-untested
+// patterns identified in the Wave-1 audit (P0 #4-#10). These tests pin
+// the existing patterns so a future refactor that drops or breaks any of
+// them is caught immediately. None of these required code changes — the
+// patterns ARE in the gate; they just had zero positive test coverage.
+// ===========================================================================
+
+describe("checkAcceptEditsConstraint — coverage backfill (audit S12 P0 #4: find-exec alternates)", () => {
+  it("blocks `find ... -execdir rm` (-execdir variant)", () => {
+    const r = checkAcceptEditsConstraint({
+      toolName: "Bash",
+      execCommand: "find /tmp -name '*.bak' -execdir rm {} +",
+    });
+    expect(r.blocked).toBe(true);
+    expect(r.constraint).toBe("destructive");
+  });
+
+  it("blocks `find ... -execdir rmdir`", () => {
+    const r = checkAcceptEditsConstraint({
+      toolName: "Bash",
+      execCommand: "find /tmp/dirs -type d -execdir rmdir {} \\;",
+    });
+    expect(r.blocked).toBe(true);
+  });
+
+  it("blocks `find ... -execdir unlink`", () => {
+    const r = checkAcceptEditsConstraint({
+      toolName: "Bash",
+      execCommand: "find /tmp -name '*.tmp' -execdir unlink {} +",
+    });
+    expect(r.blocked).toBe(true);
+  });
+
+  it("blocks `find ... -execdir shred`", () => {
+    const r = checkAcceptEditsConstraint({
+      toolName: "Bash",
+      execCommand: "find /tmp/secrets -execdir shred -u {} +",
+    });
+    expect(r.blocked).toBe(true);
+  });
+
+  it("blocks `find ... -execdir truncate`", () => {
+    const r = checkAcceptEditsConstraint({
+      toolName: "Bash",
+      execCommand: "find /tmp/logs -execdir truncate -s 0 {} +",
+    });
+    expect(r.blocked).toBe(true);
+  });
+
+  it("blocks `find ... -exec rmdir` (alternate verb)", () => {
+    const r = checkAcceptEditsConstraint({
+      toolName: "Bash",
+      execCommand: "find /tmp/empty -type d -exec rmdir {} +",
+    });
+    expect(r.blocked).toBe(true);
+  });
+
+  it("blocks `find ... -exec unlink` (alternate verb)", () => {
+    const r = checkAcceptEditsConstraint({
+      toolName: "Bash",
+      execCommand: "find /tmp -name '*.tmp' -exec unlink {} +",
+    });
+    expect(r.blocked).toBe(true);
+  });
+
+  it("blocks `find ... -exec truncate` (alternate verb)", () => {
+    const r = checkAcceptEditsConstraint({
+      toolName: "Bash",
+      execCommand: "find /tmp -name '*.log' -exec truncate -s 0 {} +",
+    });
+    expect(r.blocked).toBe(true);
+  });
+});
+
+describe("checkAcceptEditsConstraint — coverage backfill (audit S12 P0 #5: killall openclaw)", () => {
+  it("blocks `killall openclaw`", () => {
+    const r = checkAcceptEditsConstraint({
+      toolName: "Bash",
+      execCommand: "killall openclaw",
+    });
+    expect(r.blocked).toBe(true);
+    expect(r.constraint).toBe("self_restart");
+  });
+
+  it("blocks `killall openclaw-gateway` (suffix variant)", () => {
+    const r = checkAcceptEditsConstraint({
+      toolName: "Bash",
+      execCommand: "killall openclaw-gateway",
+    });
+    expect(r.blocked).toBe(true);
+  });
+});
+
+describe("checkAcceptEditsConstraint — coverage backfill (audit S12 P0 #6: restart alternates)", () => {
+  it("blocks `launchctl unload` on ai.openclaw.*", () => {
+    const r = checkAcceptEditsConstraint({
+      toolName: "Bash",
+      execCommand:
+        "launchctl unload ~/Library/LaunchAgents/ai.openclaw.gateway.plist",
+    });
+    expect(r.blocked).toBe(true);
+    expect(r.constraint).toBe("self_restart");
+  });
+
+  it("blocks `launchctl stop` on ai.openclaw.*", () => {
+    const r = checkAcceptEditsConstraint({
+      toolName: "Bash",
+      execCommand: "launchctl stop ai.openclaw.gateway",
+    });
+    expect(r.blocked).toBe(true);
+  });
+
+  it("blocks `systemctl stop openclaw*`", () => {
+    const r = checkAcceptEditsConstraint({
+      toolName: "Bash",
+      execCommand: "systemctl stop openclaw-gateway.service",
+    });
+    expect(r.blocked).toBe(true);
+  });
+
+  it("blocks `systemctl kill openclaw*`", () => {
+    const r = checkAcceptEditsConstraint({
+      toolName: "Bash",
+      execCommand: "systemctl kill openclaw-gateway.service",
+    });
+    expect(r.blocked).toBe(true);
+  });
+});
+
+describe("checkAcceptEditsConstraint — coverage backfill (audit S12 P0 #7: openclaw config unset)", () => {
+  it("blocks `openclaw config unset`", () => {
+    const r = checkAcceptEditsConstraint({
+      toolName: "Bash",
+      execCommand: "openclaw config unset plugins.entries.evil",
+    });
+    expect(r.blocked).toBe(true);
+    expect(r.constraint).toBe("config_change");
+  });
+});
+
+describe("checkAcceptEditsConstraint — coverage backfill (audit S12 P0 #8: diskutil)", () => {
+  it("blocks `diskutil erasedisk` (macOS destructive primitive)", () => {
+    const r = checkAcceptEditsConstraint({
+      toolName: "Bash",
+      execCommand: "diskutil erasedisk APFS Untitled /dev/disk2",
+    });
+    expect(r.blocked).toBe(true);
+    expect(r.constraint).toBe("destructive");
+  });
+
+  it("blocks `diskutil eraseall` (macOS destructive primitive)", () => {
+    const r = checkAcceptEditsConstraint({
+      toolName: "Bash",
+      execCommand: "diskutil eraseall /dev/disk2",
+    });
+    expect(r.blocked).toBe(true);
+  });
+});
+
+describe("checkAcceptEditsConstraint — coverage backfill (audit S12 P0 #9: apply_patch additionalPaths)", () => {
+  it("blocks `apply_patch` with additionalPaths into ~/.openclaw/*", () => {
+    const r = checkAcceptEditsConstraint({
+      toolName: "apply_patch",
+      additionalPaths: ["~/.openclaw/config.toml"],
+    });
+    expect(r.blocked).toBe(true);
+    expect(r.constraint).toBe("config_change");
+  });
+
+  it("blocks `apply_patch` with one safe + one protected path (any protected = block)", () => {
+    const r = checkAcceptEditsConstraint({
+      toolName: "apply_patch",
+      filePath: "src/safe.ts",
+      additionalPaths: ["src/safe.ts", "/etc/openclaw/config.toml"],
+    });
+    expect(r.blocked).toBe(true);
+  });
+
+  it("allows `apply_patch` with only safe additionalPaths", () => {
+    const r = checkAcceptEditsConstraint({
+      toolName: "apply_patch",
+      filePath: "src/a.ts",
+      additionalPaths: ["src/a.ts", "src/b.ts", "src/c.ts"],
+    });
+    expect(r.blocked).toBe(false);
+  });
+});
+
+describe("checkAcceptEditsConstraint — coverage backfill (audit S12 P0 #10: create/delete tools)", () => {
+  it("blocks `create` tool targeting ~/.openclaw/*", () => {
+    const r = checkAcceptEditsConstraint({
+      toolName: "create",
+      filePath: "~/.openclaw/new-config.toml",
+    });
+    expect(r.blocked).toBe(true);
+    expect(r.constraint).toBe("config_change");
+  });
+
+  it("blocks `delete` tool targeting protected paths", () => {
+    const r = checkAcceptEditsConstraint({
+      toolName: "delete",
+      filePath: "/etc/openclaw/settings.json",
+    });
+    expect(r.blocked).toBe(true);
+  });
+
+  it("allows `create` tool targeting non-protected paths", () => {
+    const r = checkAcceptEditsConstraint({
+      toolName: "create",
+      filePath: "/Users/me/repo/src/new.ts",
+    });
+    expect(r.blocked).toBe(false);
+  });
+});
+
+// ===========================================================================
+// Surgical-port S12 (2026-05-12): trigger predicate test — the plugin
+// fires the gate ONLY when `approval === "edited"` (matching in-host's
+// `postApprovalPermissions.acceptEdits === true` lifecycle at
+// sessions-patch.ts:982-993). Prior over-fire on `autoApprove === true`
+// was a UX regression — operators who toggled autoApprove for
+// convenience got destructive-action blocks even outside an approval
+// cycle. The trigger-predicate level (isAcceptEditsPhase in index.ts)
+// is tested via smoke-4-accept-edits-adversarial which now uses the
+// edit-approval workflow as its setup.
+// ===========================================================================


### PR DESCRIPTION
## Summary

Fifth and final surgical PR. Two changes, both closing Wave-1 audit
slice S12 P0 findings.

## 1. Trigger predicate fix

Plugin's accept-edits gate fired on:
\`autoApprove === true || approval === \"edited\"\`

In-host fires on:
\`latestPlanMode === \"normal\" && getLatestAcceptEdits()\`

where \`getLatestAcceptEdits\` reads \`postApprovalPermissions.acceptEdits\`
from disk, set ONLY on \`action === \"edit\"\` per sessions-patch.ts:982-993.

The \`autoApprove === true\` clause was an over-fire UX bug —
operators who toggled autoApprove for convenience got destructive-
action blocks even outside any approval cycle. Removed.

After this fix, trigger matches in-host: gate fires only when the
user explicitly took the edit path (which grants acceptEdits).

## 2. Coverage backfill (23 new positive tests)

7 patterns were coded in the gate but had ZERO positive test
coverage — a refactor dropping them would pass the suite silently:

| # | Patterns | Tests added |
|---|---|---|
| P0 #4 | \`find -execdir/exec\` alternate verbs (rmdir/unlink/shred/truncate) | 8 |
| P0 #5 | \`killall openclaw\` / \`killall openclaw-gateway\` | 2 |
| P0 #6 | \`launchctl unload/stop\`, \`systemctl stop/kill\` | 4 |
| P0 #7 | \`openclaw config unset\` | 1 |
| P0 #8 | \`diskutil erasedisk/eraseall\` | 2 |
| P0 #9 | \`apply_patch\` with \`additionalPaths\` | 3 |
| P0 #10 | \`create\` / \`delete\` tools targeting protected paths | 3 |

## Known shared limitations (NOT fixed)

These are SHARED bugs in both plugin and in-host. Per the surgical-
port principle, fixing them in plugin alone would introduce
divergence; documented as upstream follow-ups:

- S12 P0 #1: trailing-slash normalization bypass
- S12 P0 #3: \`bash -c \"rm -rf\"\` quoted body bypass
- S12 P1 #1: command-chain bypass

## Closes 8 Wave-1 S12 drifts

- 1 trigger-predicate bug (autoApprove over-fire)
- 7 coverage-gap items (P0 #4-#10)

## Test plan

- [x] Local \`pnpm typecheck\` clean
- [ ] CI test suite green
- [ ] smoke-4 passes with updated setup (enter → exit → plan.edit
      instead of plan.auto.toggle)
- [ ] Re-audit S12 confirms 8 P0s closed

## Files

- \`src/index.ts\` — trigger predicate fix (~5 LOC change + 18-LOC
  comment with in-host parity references)
- \`tests/eva-live-smokes/smoke-4-accept-edits-adversarial.test.ts\` —
  setup uses enter → exit → plan.edit (the path that grants
  acceptEdits per in-host)
- \`tests/gates/accept-edits-gate.test.ts\` — 23 new positive cases

## References

- host_ref: \`src/gateway/sessions-patch.ts:982-993\` (acceptEdits set/clear lifecycle)
- host_ref: \`src/agents/pi-tools.before-tool-call.ts:324\` (in-host trigger)
- host_ref: \`src/agents/plan-mode/accept-edits-gate.ts\` (algorithm — byte-identical)
- Wave-1 audit: \`docs/audits/wave-1/S12-shell-escape-accept-edits.md\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the accept-edits approval mechanism trigger to properly align with system lifecycle behavior

* **Tests**
  * Expanded test coverage for approval and permission workflows, including adversarial scenarios
  * Added comprehensive constraint protection tests covering various operation types and edge cases
  * Updated approval workflow verification tests to match corrected behavior

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/Smarter-Claw/pull/90)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->