### PR TITLE
chore: bump to 1.0.0-port.15 + release notes for 5 surgical PRs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,92 @@
 # Smarter-Claw Release Notes
 
+## 1.0.0-port.15 — surgical re-port to byte-identical in-host parity (2026-05-12)
+
+Five surgical PRs (#86, #87, #88, #89, #90) re-ported load-bearing
+plan-mode code verbatim from in-host commit `ea04ea52c7`, closing
+**32 P0 drifts** identified in the Wave-1 audit. The plugin is now
+byte-identical to the in-host on every model-facing surface
+(tool descriptions, system prompts, retry instructions, approved-plan
+preambles, state-machine transitions).
+
+### Why this version exists
+
+The Wave-1 audit (10 parallel slice reports, 138 unique findings)
+found that the v1.0.0-port.14 baseline had diverged from the in-host
+source-of-truth on multiple critical surfaces — descriptions had been
+paraphrased (~70% drift on enter/exit tool desc), the system-prompt
+inline injection was missing the ACTION CONTRACT and Investigation
+Phase blocks, the approved-plan injection was a bare opener instead
+of the full preamble, the escalating-retry detector had no FIRM/FINAL
+tiers, and the accept-edits trigger over-fired on autoApprove.
+
+This release closes all 32 P0 drifts that could be addressed without
+new SDK seams. Remaining ~10 P0s are either shared bugs in both
+plugin and in-host (would require divergent fix; tracked as upstream
+follow-ups) or gateway-side concerns needing new SDK seams (tracked
+in epic #77 / blocker #78).
+
+### What changed (per PR)
+
+| PR | Slice | Surgical action |
+|---|---|---|
+| #86 | S8 | `resolvePlanApproval` verbatim port (state machine); typed mutators (`recordApproval`, `recordRejection`, new `recordTimeout`) delegate via reference-equality no-op detection |
+| #87 | S1 | `enter_plan_mode` + `exit_plan_mode` description + schema + validation re-port; title required + 80-char clamp + 5 archetype fields + parser + archetype field echoing |
+| #88 | S4/S5 | system-prompt injection verbatim (ACTION CONTRACT + Investigation Phase + PLAN MODE AVAILABLE); `plan.accept` emits full `buildApprovedPlanInjection`; `plan.edit` (no body) emits full `buildAcceptEditsPlanInjection`; auto-enable matcher ported |
+| #89 | S7 | all retry instruction constants + regex constants verbatim; FIRM/FINAL escalation tiers per `resolveEscalatingPlanningRetryInstruction`; COMPLETION_RE guard added |
+| #90 | S12 | accept-edits trigger fixed (drop `autoApprove === true` over-fire — now `approval === "edited"` only, matching in-host `postApprovalPermissions.acceptEdits`); 23 positive tests for coded-but-untested patterns (P0 #4-#10) |
+
+### Confidence assessment
+
+**HIGH (95%+)**: state machine, tool surface, system-prompt, injection
+text, retry instructions, gate algorithm + trigger predicate.
+
+**MODERATE (~70-85%)**: coarse-grained retry detection (the in-host
+inspects toolMetas + replayMetadata; the plugin uses turn-boundary
+signals only — SDK doesn't expose runner internals).
+
+**Needs live-gateway verification**: real LLM behavior under the new
+injection texts; concurrent approval flows under realistic load;
+operator UX with the trigger-predicate fix.
+
+### Test footprint at 1.0.0-port.15
+
+`pnpm test`: **~700 tests pass across 30+ test files** (up from 615
+at 1.0.0-port.14 — 86 new tests pinning in-host parity).
+
+### Recommendation
+
+Per Wave-1.5 audit (`docs/audits/wave-1.5-post-surgical-summary.md`):
+**PROCEED to live-gateway testing.** All audit findings that can be
+fixed without new SDK seams are closed; the plugin is byte-identical
+to in-host on every model-facing surface.
+
+### Known limitations (carried over from 1.0.0-port.14 + new)
+
+1. Same as 1.0.0-port.14 — no persistent grant ledger, no inline UI,
+   plan-clear single-session, etc.
+
+2. **`bash -c "rm -rf"` quoted body bypass**: SHARED with in-host.
+   The gate doesn't analyze command bodies inside quoted strings.
+   Fix requires shell-aware parser; would need to land in-host first
+   to preserve parity.
+
+3. **Trailing-slash path normalization bypass**: SHARED with in-host.
+   `~/.openclaw/` normalizes to `~/.openclaw` which fails the
+   startsWith check against `~/.openclaw/`. Same `normalizeCandidatePath`
+   function in both.
+
+4. **Command-chain bypass**: SHARED with in-host. `ls && rm -rf` etc.
+   not caught — prefix match anchors at start-of-command.
+
+5. **Gateway-side toolMeta detection gaps**: the in-host's retry
+   detector uses `EmbeddedRunAttemptResult.toolMetas` to count
+   plan-only vs real tool calls. SDK doesn't expose this; the plugin
+   uses coarser turn-boundary signals. Documented in
+   `src/runtime/escalating-retry.ts` file-level docstring.
+
+---
+
 ## 1.0.0-port.14 — v0.x internal-release prep (2026-05-12)
 
 End of the backend-first ladder (P-1 through P-14). The plugin is

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@electricsheephq/smarter-claw",
-  "version": "1.0.0-port.14",
+  "version": "1.0.0-port.15",
   "description": "Smarter-Claw — Plan-Mode plugin for OpenClaw. v1 port (P-14 v0.x internal-release prep). Source-of-truth parity at openclaw-pr70071-rebase tip ea04ea52c7. v1.0 public release gated on upstream chat-stream SDK seam.",
   "type": "module",
   "main": "dist/src/index.js",


### PR DESCRIPTION
## Summary

Housekeeping: bumps version `1.0.0-port.14 → 1.0.0-port.15` and adds a
release-notes section documenting the 5 surgical PRs that closed 32
Wave-1 P0 drifts.

## What this captures

- Wave-1 audit findings + Wave-1.5 closure roll-up
- Per-PR surgical action summary (#86 through #90)
- HIGH / MODERATE / live-gateway-needed confidence breakdown
- Test footprint: 615 → ~700 tests (86 new tests pinning in-host parity)
- Known shared limitations (bash -c bypass, trailing-slash, command-chain)
  documented with their upstream-fix path

## After this merges

The `v1.0.0-port.15` git tag + GitHub pre-release will be created so
operators can pin to a stable version that includes the surgical-port
work.

## Test plan

- [x] Local \`pnpm typecheck\` clean
- [ ] CI test suite green
- [ ] Pre-release tag + GitHub release notes follow this PR's merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Release notes for version 1.0.0-port.15 added, documenting byte-identical parity achievement, closed issues, test coverage assessment, and known limitations.

* **Chores**
  * Package version bumped to 1.0.0-port.15.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/Smarter-Claw/pull/92)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->