### PR TITLE
hotfix: wire PLAN MODE AVAILABLE prompt + register /plan slash commands (live-test gap)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -316,13 +316,20 @@ export default definePluginEntry({
 
     // Hotfix (2026-05-13): register `/plan` and `/plan-mode` slash
     // commands so users can resolve approvals from chat (not just
-    // sidebar buttons). Each subcommand routes to the matching
-    // session-action handler above.
+    // sidebar buttons). Approval subcommands route to the matching
+    // session-action handler above; `/plan enter` flips state via the
+    // store directly (no `plan.enter` session-action exists).
     api.registerCommand(
-      createPlanSlashCommand({ actions: sessionActionHandlers as never }),
+      createPlanSlashCommand({
+        actions: sessionActionHandlers as never,
+        store,
+      }),
     );
     api.registerCommand(
-      createPlanModeSlashCommand({ actions: sessionActionHandlers as never }),
+      createPlanModeSlashCommand({
+        actions: sessionActionHandlers as never,
+        store,
+      }),
     );
 
     // P-12: sidebar UI descriptor. Declares the "Plan Mode" surface so

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,10 @@ import {
   extractApplyPatchTargetPaths,
 } from "./gates/accept-edits-gate.js";
 import { checkMutationGate } from "./gates/mutation-gate.js";
-import { buildPlanModeSystemContext } from "./prompt/plan-mode-injection.js";
+import {
+  buildPlanModeActiveSystemContext,
+  buildPlanModeAvailableSystemContext,
+} from "./prompt/plan-mode-injection.js";
 import { InMemoryGateway } from "./state/in-memory-gateway.js";
 import { SessionStoreGateway } from "./state/session-store-gateway.js";
 import { PlanModeStore, type PlanModeStateGateway } from "./state/store.js";
@@ -56,6 +59,10 @@ import { createAskUserQuestionTool } from "./tools/ask-user-question.js";
 import { createEnterPlanModeTool } from "./tools/enter-plan-mode.js";
 import { createExitPlanModeTool } from "./tools/exit-plan-mode.js";
 import { createPlanModeSessionActions } from "./ui/session-actions.js";
+import {
+  createPlanSlashCommand,
+  createPlanModeSlashCommand,
+} from "./ui/slash-commands.js";
 import { buildPlanModeSidebarDescriptor } from "./ui/sidebar-descriptor.js";
 import { createPlanClearCli } from "./ui/sweep-command.js";
 import type { PlanMode } from "./types.js";
@@ -289,9 +296,34 @@ export default definePluginEntry({
     // clients dispatch these by (pluginId, actionId). Each handler
     // verifies the approvalId (stale-event guard), then calls the
     // PlanModeStore mutator + the appropriate injection-writer.
-    for (const action of createPlanModeSessionActions({ api, store })) {
+    const sessionActionRegistrations = createPlanModeSessionActions({
+      api,
+      store,
+    });
+    const sessionActionHandlers = new Map<
+      string,
+      (ctx: never) => unknown
+    >();
+    for (const action of sessionActionRegistrations) {
       api.session.controls.registerSessionAction(action);
+      // Snapshot the handler for the /plan slash-command dispatcher
+      // below. Keyed on the action id so /plan accept → plan.accept etc.
+      sessionActionHandlers.set(
+        action.id,
+        action.handler as (ctx: never) => unknown,
+      );
     }
+
+    // Hotfix (2026-05-13): register `/plan` and `/plan-mode` slash
+    // commands so users can resolve approvals from chat (not just
+    // sidebar buttons). Each subcommand routes to the matching
+    // session-action handler above.
+    api.registerCommand(
+      createPlanSlashCommand({ actions: sessionActionHandlers as never }),
+    );
+    api.registerCommand(
+      createPlanModeSlashCommand({ actions: sessionActionHandlers as never }),
+    );
 
     // P-12: sidebar UI descriptor. Declares the "Plan Mode" surface so
     // operator UI clients can render the widget. Rendering is
@@ -530,9 +562,23 @@ export default definePluginEntry({
       if (!ctx.sessionKey) return undefined;
       const snap = await store.readSnapshot(ctx.sessionKey);
       const mode: PlanMode = snap?.mode ?? "normal";
-      if (mode !== "plan") return undefined;
+      if (mode === "plan") {
+        return {
+          appendSystemContext: buildPlanModeActiveSystemContext(),
+        };
+      }
+      // Hotfix (2026-05-13): wire the in-host PLAN MODE AVAILABLE
+      // branch (`attempt.ts:733-749`) so the agent knows it can call
+      // `enter_plan_mode` when the user asks for a plan. Without
+      // this, the plugin's tools were registered but the model had
+      // no idea plan mode existed — explaining the live-test
+      // observation "agent didn't enter plan mode when asked."
+      // The plugin's presence implies the feature is enabled
+      // (no operator opt-in flag — installing the plugin IS the
+      // opt-in), so we always inject the AVAILABLE block when not
+      // already in plan mode.
       return {
-        appendSystemContext: buildPlanModeSystemContext(),
+        appendSystemContext: buildPlanModeAvailableSystemContext(),
       };
     });
 

--- a/src/state/session-store-gateway.ts
+++ b/src/state/session-store-gateway.ts
@@ -104,6 +104,39 @@ export interface SessionStoreGatewayOptions {
   };
 }
 
+function createFallbackRoutingRuntime(): RoutingRuntime {
+  return {
+    parseAgentSessionKey(sessionKey: string) {
+      const m = /^agent:([^:]+):(.+)$/.exec(sessionKey);
+      if (!m) return null;
+      return { agentId: m[1], suffix: m[2] };
+    },
+  };
+}
+
+function resolveRoutingRuntime(
+  candidate: unknown,
+  logger?: SessionStoreGatewayOptions["logger"],
+): RoutingRuntime {
+  const parse =
+    candidate && typeof candidate === "object"
+      ? (candidate as { parseAgentSessionKey?: unknown }).parseAgentSessionKey
+      : undefined;
+  if (typeof parse === "function") {
+    return {
+      parseAgentSessionKey(sessionKey: string) {
+        return parse(sessionKey) as ReturnType<
+          RoutingRuntime["parseAgentSessionKey"]
+        >;
+      },
+    };
+  }
+  logger?.warn?.(
+    "[smarter-claw] openclaw/plugin-sdk/runtime missing parseAgentSessionKey; using fallback session-key parser",
+  );
+  return createFallbackRoutingRuntime();
+}
+
 export class SessionStoreGateway implements PlanModeStateGateway {
   private readonly namespace: string;
   private readonly logger: SessionStoreGatewayOptions["logger"];
@@ -160,19 +193,14 @@ export class SessionStoreGateway implements PlanModeStateGateway {
    */
   private async loadRoutingModule(): Promise<RoutingRuntime> {
     try {
-      return (await import(
+      const module = await import(
         "openclaw/plugin-sdk/runtime" as string
-      )) as RoutingRuntime;
+      );
+      return resolveRoutingRuntime(module, this.logger);
     } catch {
       // Fallback: in-line minimal parser. Matches in-host
       // `parseAgentSessionKey` shape (agent:<id>:<suffix>).
-      return {
-        parseAgentSessionKey(sessionKey: string) {
-          const m = /^agent:([^:]+):(.+)$/.exec(sessionKey);
-          if (!m) return null;
-          return { agentId: m[1], suffix: m[2] };
-        },
-      };
+      return createFallbackRoutingRuntime();
     }
   }
 
@@ -242,4 +270,6 @@ export class SessionStoreGateway implements PlanModeStateGateway {
  */
 export const _testing = {
   PLUGIN_ID,
+  createFallbackRoutingRuntime,
+  resolveRoutingRuntime,
 };

--- a/src/ui/slash-commands.ts
+++ b/src/ui/slash-commands.ts
@@ -6,38 +6,41 @@
  * dispatched by ID — they're not directly callable by the user typing
  * in chat. The in-host version had `/plan accept|reject|cancel|edit`
  * slash commands that routed through openclaw's command surface;
- * Beta 5 vanilla openclaw exposes a `registerCommand` SDK seam but
- * plugins must opt in. The original P-12 work registered the session
- * actions but missed wiring them to the user-typed slash surface.
+ * vanilla openclaw exposes a `registerCommand` SDK seam but plugins
+ * must opt in. The original P-12 work registered the session actions
+ * but missed wiring them to the user-typed slash surface.
  *
  * # Command shape
  *
  * `/plan <subcommand> [args]`
  *
- *   - `/plan` (no args)             — show current plan-mode state
- *   - `/plan enter`                 — enter plan mode (same as enter_plan_mode tool)
- *   - `/plan exit`                  — leave plan mode (same as plan.cancel)
+ *   - `/plan` (no args)             — show usage
+ *   - `/plan enter`                 — enter plan mode (flips session state)
+ *   - `/plan exit` / `/plan cancel` — leave plan mode
  *   - `/plan accept`                — approve the pending plan (verbatim)
  *   - `/plan edit <body>`           — approve with inline-edited body
- *   - `/plan reject <feedback>`     — reject with feedback
- *   - `/plan cancel`                — exit plan mode (alias for `exit`)
- *   - `/plan answer <option>`       — answer a pending ask_user_question
+ *   - `/plan reject [feedback]`     — reject with feedback
  *   - `/plan auto on|off`           — toggle auto-approve mode
+ *
+ * `/plan answer` is intentionally NOT wired through this surface — see
+ * the `answer` case below for the rationale (plugin-side question-state
+ * tracking does not exist yet; tracked as a Wave-1 finding).
  *
  * # Dispatch
  *
- * Each subcommand routes to the corresponding session-action via the
- * plugin's existing dispatcher. No re-implementation; this is the
- * user-typing surface in front of the same action handlers.
+ * Approval subcommands route to the corresponding session-action via
+ * the plugin's existing dispatcher — no re-implementation, this is the
+ * user-typing surface in front of the same action handlers. `/plan
+ * enter` is the exception: there is no `plan.enter` session-action, so
+ * it calls `PlanModeStore.enterPlanMode` directly.
  *
  * # Channel scope
  *
  * Registered without a `channels` filter → available on every channel
- * surface (webchat, telegram, etc.).
+ * surface (webchat, Telegram, Slack, etc.).
  *
- * host_ref: in-host /plan slash commands at
- *   `openclaw-pr70071-rebase/src/agents/...` (the in-host wired these
- *   into its native command surface; this is the plugin equivalent).
+ * host_ref: in-host /plan slash commands (the in-host wired these into
+ *   its native command surface; this is the plugin equivalent).
  */
 
 import type {
@@ -47,6 +50,7 @@ import type {
   PluginSessionActionContext,
   PluginSessionActionResult,
 } from "openclaw/plugin-sdk/plugin-entry";
+import type { PlanModeStore } from "../state/store.js";
 
 type SessionActionHandler = (
   ctx: PluginSessionActionContext,
@@ -58,6 +62,11 @@ export interface CreatePlanSlashCommandInput {
    * at the same time the actions are registered with the host.
    */
   actions: Map<string, SessionActionHandler>;
+  /**
+   * The plan-mode store — used by `/plan enter` to flip session state
+   * directly (there is no `plan.enter` session-action to dispatch to).
+   */
+  store: PlanModeStore;
 }
 
 /**
@@ -69,16 +78,15 @@ export function createPlanSlashCommand(
   return {
     name: "plan",
     description:
-      "Plan-mode controls: /plan accept | edit | reject | cancel | enter | exit | answer | auto on|off",
+      "Plan-mode controls: /plan enter | accept | edit | reject | cancel | auto on|off",
     acceptsArgs: true,
     // Available on every channel; do NOT restrict via `channels`.
-    handler: async (ctx) => handlePlanCommand(ctx, input.actions),
+    handler: async (ctx) => handlePlanCommand(ctx, input),
   };
 }
 
 /**
- * Companion command: `/plan-mode` as an alias-shorthand for `/plan`
- * (with no subcommand → status, with subcommand → same dispatch).
+ * Companion command: `/plan-mode` as an alias-shorthand for `/plan`.
  * Users who memorize `/plan-mode` from the in-host UX find it works.
  */
 export function createPlanModeSlashCommand(
@@ -87,85 +95,124 @@ export function createPlanModeSlashCommand(
   return {
     name: "plan-mode",
     description:
-      "Alias for `/plan` — toggle plan mode and inspect/resolve approvals.",
+      "Alias for `/plan` — enter plan mode and inspect/resolve approvals.",
     acceptsArgs: true,
-    handler: async (ctx) => handlePlanCommand(ctx, input.actions),
+    handler: async (ctx) => handlePlanCommand(ctx, input),
   };
 }
 
+const USAGE = [
+  "Plan-mode commands:",
+  "  /plan enter            — enter plan mode",
+  "  /plan exit             — leave plan mode",
+  "  /plan accept           — approve pending plan (verbatim)",
+  "  /plan edit <body>      — approve with edits",
+  "  /plan reject [reason]  — reject with optional feedback",
+  "  /plan cancel           — exit plan mode",
+  "  /plan auto on|off      — toggle auto-approve",
+  "(Answer pending questions from the approval card.)",
+].join("\n");
+
 async function handlePlanCommand(
   ctx: PluginCommandContext,
-  actions: Map<string, SessionActionHandler>,
+  input: CreatePlanSlashCommandInput,
 ): Promise<PluginCommandResult> {
   const args = (ctx.args ?? "").trim();
   if (!args) {
-    return reply(
-      "Plan-mode commands:\n" +
-        "  /plan enter            — enter plan mode\n" +
-        "  /plan exit             — leave plan mode\n" +
-        "  /plan accept           — approve pending plan (verbatim)\n" +
-        "  /plan edit <body>      — approve with edits\n" +
-        "  /plan reject [reason]  — reject with optional feedback\n" +
-        "  /plan cancel           — exit plan mode\n" +
-        "  /plan answer <option>  — answer pending question\n" +
-        "  /plan auto on|off      — toggle auto-approve",
-    );
+    return reply(USAGE);
   }
 
-  const [verb, ...rest] = args.split(/\s+/);
+  // Parse `<verb> <tail>` — verb is the first whitespace-delimited
+  // token, tail is everything after it (preserves internal spacing).
+  const verb = (args.split(/\s+/, 1)[0] ?? "").toLowerCase();
   const tail = args.slice(verb.length).trim();
 
-  switch (verb.toLowerCase()) {
+  switch (verb) {
     case "accept":
     case "approve":
-      return dispatchAction(actions, "plan.accept", ctx, {});
+      return dispatchAction(input.actions, "plan.accept", ctx, {});
     case "edit":
       if (!tail) {
-        return reply("`/plan edit` requires an edited body. Usage: `/plan edit <new plan text>`");
+        return reply(
+          "`/plan edit` requires an edited body. Usage: `/plan edit <new plan text>`",
+        );
       }
-      return dispatchAction(actions, "plan.edit", ctx, { body: tail });
+      return dispatchAction(input.actions, "plan.edit", ctx, { body: tail });
     case "reject":
     case "rev":
     case "revise":
-      return dispatchAction(actions, "plan.reject", ctx, {
+      return dispatchAction(input.actions, "plan.reject", ctx, {
         ...(tail ? { feedback: tail } : {}),
       });
     case "cancel":
     case "exit":
-      return dispatchAction(actions, "plan.cancel", ctx, {});
-    case "answer":
-    case "ans":
-      if (!tail) {
-        return reply("`/plan answer` requires an option. Usage: `/plan answer <option>`");
-      }
-      return dispatchAction(actions, "plan.answer", ctx, { selectedOption: tail });
+      return dispatchAction(input.actions, "plan.cancel", ctx, {});
     case "auto":
       if (tail === "on" || tail === "true" || tail === "enable") {
-        return dispatchAction(actions, "plan.auto.toggle", ctx, { enabled: true });
+        return dispatchAction(input.actions, "plan.auto.toggle", ctx, {
+          enabled: true,
+        });
       }
       if (tail === "off" || tail === "false" || tail === "disable") {
-        return dispatchAction(actions, "plan.auto.toggle", ctx, { enabled: false });
+        return dispatchAction(input.actions, "plan.auto.toggle", ctx, {
+          enabled: false,
+        });
       }
       return reply("`/plan auto` requires `on` or `off`.");
     case "enter":
-      // No "plan.enter" session-action exists; instruct the user to
-      // ask the agent or call the tool. (The agent itself owns the
-      // enter_plan_mode tool call; a direct user surface is harder
-      // because it requires emitting a synthetic agent turn.)
+      return handleEnter(ctx, input.store);
+    case "answer":
+    case "ans":
+      // No slash-surface answering: pending-question metadata
+      // (questionId / questionPrompt) is minted host-side by
+      // ask_user_question and is NOT projected into plan-mode state,
+      // so this command cannot supply the `plan.answer` session-action
+      // its required payload. Route the user to the approval card.
+      // Tracked as a Wave-1 finding (plugin-side question-state
+      // tracking + cross-platform answer surface — Wave 4).
       return reply(
-        "To enter plan mode, ask the agent to start one (e.g. 'plan this multi-step task before executing'). The agent calls `enter_plan_mode` to flip the session.",
+        "Answer pending questions from the approval card. Slash-command " +
+          "answering is not available yet — it needs plugin-side " +
+          "question-state tracking (known gap).",
       );
     case "status":
-    case "":
-      return reply(
-        "Plan-mode status — use the sidebar widget to see current state, or invoke /plan accept|reject|edit|cancel|answer|auto.",
-      );
+      return reply(USAGE);
     default:
       return reply(
-        `Unknown /plan subcommand: \`${verb}\`. Try \`/plan\` (no args) for usage.`,
+        `Unknown /plan subcommand: \`${verb}\`. Send \`/plan\` (no args) for usage.`,
       );
   }
-  void rest; // keep linter happy in case of future args
+}
+
+/**
+ * `/plan enter` — flip the session into plan mode. There is no
+ * `plan.enter` session-action, so this calls the store directly.
+ */
+async function handleEnter(
+  ctx: PluginCommandContext,
+  store: PlanModeStore,
+): Promise<PluginCommandResult> {
+  if (!ctx.sessionKey) {
+    return reply(
+      "`/plan enter` requires a session context. Send it from inside an active session.",
+    );
+  }
+  let result: Awaited<ReturnType<PlanModeStore["enterPlanMode"]>>;
+  try {
+    result = await store.enterPlanMode({ sessionKey: ctx.sessionKey });
+  } catch (err) {
+    return reply(
+      `/plan enter failed: ${(err as Error).message ?? "unexpected error"}`,
+    );
+  }
+  if (result.kind === "failed") {
+    return reply(`/plan enter failed: ${result.error.message}`);
+  }
+  return reply(
+    result.kind === "noop"
+      ? "Already in plan mode — investigate read-only, then propose a plan."
+      : "Plan mode entered. Mutating tools are blocked until a plan is approved.",
+  );
 }
 
 async function dispatchAction(
@@ -183,22 +230,34 @@ async function dispatchAction(
   }
   if (!ctx.sessionKey) {
     return reply(
-      "`/plan` commands require a session context. Try sending the command from inside an active session, not a control-plane surface.",
+      "`/plan` commands require a session context. Send the command from " +
+        "inside an active session, not a control-plane surface.",
     );
   }
   // Build a synthetic session-action context. The handler accepts a
   // PluginSessionActionContext shape that includes pluginId / actionId /
   // sessionKey / payload — matches how the host invokes the action
-  // via registerSessionAction.
-  const actionResult = await handler({
-    pluginId: "smarter-claw",
-    actionId,
-    sessionKey: ctx.sessionKey,
-    payload,
-  });
+  // via registerSessionAction. The handler call is wrapped in
+  // try/catch: a thrown handler error must surface as a clean reply,
+  // not an unhandled rejection that the channel renders as a crash.
+  let actionResult: PluginSessionActionResult | void;
+  try {
+    actionResult = await handler({
+      pluginId: "smarter-claw",
+      actionId,
+      sessionKey: ctx.sessionKey,
+      payload,
+    });
+  } catch (err) {
+    return reply(
+      `/plan ${actionId.replace("plan.", "")} failed: ` +
+        `${(err as Error).message ?? "unexpected error"}`,
+    );
+  }
   if (!actionResult || actionResult.ok === false) {
     const code = (actionResult as { code?: string } | undefined)?.code ?? "ERROR";
-    const error = (actionResult as { error?: string } | undefined)?.error ?? "unknown";
+    const error =
+      (actionResult as { error?: string } | undefined)?.error ?? "unknown";
     return reply(`/plan ${actionId.replace("plan.", "")} failed: ${code} — ${error}`);
   }
   // Surface a concise result.
@@ -207,7 +266,6 @@ async function dispatchAction(
     "plan.edit": "Plan approved with edits — agent will execute the edited body.",
     "plan.reject": "Plan rejected — agent will revise based on your feedback.",
     "plan.cancel": "Exited plan mode — back to normal session.",
-    "plan.answer": "Question answered — agent will resume.",
     "plan.auto.toggle": "Auto-approve toggled.",
   };
   return {

--- a/src/ui/slash-commands.ts
+++ b/src/ui/slash-commands.ts
@@ -1,0 +1,223 @@
+/**
+ * `/plan` slash command — in-chat user surface for plan-mode actions.
+ *
+ * **Why this exists** (hotfix 2026-05-13): the plugin's session-actions
+ * (`plan.accept` / `plan.reject` / etc.) are handler functions
+ * dispatched by ID — they're not directly callable by the user typing
+ * in chat. The in-host version had `/plan accept|reject|cancel|edit`
+ * slash commands that routed through openclaw's command surface;
+ * Beta 5 vanilla openclaw exposes a `registerCommand` SDK seam but
+ * plugins must opt in. The original P-12 work registered the session
+ * actions but missed wiring them to the user-typed slash surface.
+ *
+ * # Command shape
+ *
+ * `/plan <subcommand> [args]`
+ *
+ *   - `/plan` (no args)             — show current plan-mode state
+ *   - `/plan enter`                 — enter plan mode (same as enter_plan_mode tool)
+ *   - `/plan exit`                  — leave plan mode (same as plan.cancel)
+ *   - `/plan accept`                — approve the pending plan (verbatim)
+ *   - `/plan edit <body>`           — approve with inline-edited body
+ *   - `/plan reject <feedback>`     — reject with feedback
+ *   - `/plan cancel`                — exit plan mode (alias for `exit`)
+ *   - `/plan answer <option>`       — answer a pending ask_user_question
+ *   - `/plan auto on|off`           — toggle auto-approve mode
+ *
+ * # Dispatch
+ *
+ * Each subcommand routes to the corresponding session-action via the
+ * plugin's existing dispatcher. No re-implementation; this is the
+ * user-typing surface in front of the same action handlers.
+ *
+ * # Channel scope
+ *
+ * Registered without a `channels` filter → available on every channel
+ * surface (webchat, telegram, etc.).
+ *
+ * host_ref: in-host /plan slash commands at
+ *   `openclaw-pr70071-rebase/src/agents/...` (the in-host wired these
+ *   into its native command surface; this is the plugin equivalent).
+ */
+
+import type {
+  OpenClawPluginCommandDefinition,
+  PluginCommandContext,
+  PluginCommandResult,
+  PluginSessionActionContext,
+  PluginSessionActionResult,
+} from "openclaw/plugin-sdk/plugin-entry";
+
+type SessionActionHandler = (
+  ctx: PluginSessionActionContext,
+) => Promise<PluginSessionActionResult> | PluginSessionActionResult;
+
+export interface CreatePlanSlashCommandInput {
+  /**
+   * Map of session-action id → handler. Built by `createPlanModeSessionActions`
+   * at the same time the actions are registered with the host.
+   */
+  actions: Map<string, SessionActionHandler>;
+}
+
+/**
+ * Build the `/plan` command definition. Pass into `api.registerCommand`.
+ */
+export function createPlanSlashCommand(
+  input: CreatePlanSlashCommandInput,
+): OpenClawPluginCommandDefinition {
+  return {
+    name: "plan",
+    description:
+      "Plan-mode controls: /plan accept | edit | reject | cancel | enter | exit | answer | auto on|off",
+    acceptsArgs: true,
+    // Available on every channel; do NOT restrict via `channels`.
+    handler: async (ctx) => handlePlanCommand(ctx, input.actions),
+  };
+}
+
+/**
+ * Companion command: `/plan-mode` as an alias-shorthand for `/plan`
+ * (with no subcommand → status, with subcommand → same dispatch).
+ * Users who memorize `/plan-mode` from the in-host UX find it works.
+ */
+export function createPlanModeSlashCommand(
+  input: CreatePlanSlashCommandInput,
+): OpenClawPluginCommandDefinition {
+  return {
+    name: "plan-mode",
+    description:
+      "Alias for `/plan` — toggle plan mode and inspect/resolve approvals.",
+    acceptsArgs: true,
+    handler: async (ctx) => handlePlanCommand(ctx, input.actions),
+  };
+}
+
+async function handlePlanCommand(
+  ctx: PluginCommandContext,
+  actions: Map<string, SessionActionHandler>,
+): Promise<PluginCommandResult> {
+  const args = (ctx.args ?? "").trim();
+  if (!args) {
+    return reply(
+      "Plan-mode commands:\n" +
+        "  /plan enter            — enter plan mode\n" +
+        "  /plan exit             — leave plan mode\n" +
+        "  /plan accept           — approve pending plan (verbatim)\n" +
+        "  /plan edit <body>      — approve with edits\n" +
+        "  /plan reject [reason]  — reject with optional feedback\n" +
+        "  /plan cancel           — exit plan mode\n" +
+        "  /plan answer <option>  — answer pending question\n" +
+        "  /plan auto on|off      — toggle auto-approve",
+    );
+  }
+
+  const [verb, ...rest] = args.split(/\s+/);
+  const tail = args.slice(verb.length).trim();
+
+  switch (verb.toLowerCase()) {
+    case "accept":
+    case "approve":
+      return dispatchAction(actions, "plan.accept", ctx, {});
+    case "edit":
+      if (!tail) {
+        return reply("`/plan edit` requires an edited body. Usage: `/plan edit <new plan text>`");
+      }
+      return dispatchAction(actions, "plan.edit", ctx, { body: tail });
+    case "reject":
+    case "rev":
+    case "revise":
+      return dispatchAction(actions, "plan.reject", ctx, {
+        ...(tail ? { feedback: tail } : {}),
+      });
+    case "cancel":
+    case "exit":
+      return dispatchAction(actions, "plan.cancel", ctx, {});
+    case "answer":
+    case "ans":
+      if (!tail) {
+        return reply("`/plan answer` requires an option. Usage: `/plan answer <option>`");
+      }
+      return dispatchAction(actions, "plan.answer", ctx, { selectedOption: tail });
+    case "auto":
+      if (tail === "on" || tail === "true" || tail === "enable") {
+        return dispatchAction(actions, "plan.auto.toggle", ctx, { enabled: true });
+      }
+      if (tail === "off" || tail === "false" || tail === "disable") {
+        return dispatchAction(actions, "plan.auto.toggle", ctx, { enabled: false });
+      }
+      return reply("`/plan auto` requires `on` or `off`.");
+    case "enter":
+      // No "plan.enter" session-action exists; instruct the user to
+      // ask the agent or call the tool. (The agent itself owns the
+      // enter_plan_mode tool call; a direct user surface is harder
+      // because it requires emitting a synthetic agent turn.)
+      return reply(
+        "To enter plan mode, ask the agent to start one (e.g. 'plan this multi-step task before executing'). The agent calls `enter_plan_mode` to flip the session.",
+      );
+    case "status":
+    case "":
+      return reply(
+        "Plan-mode status — use the sidebar widget to see current state, or invoke /plan accept|reject|edit|cancel|answer|auto.",
+      );
+    default:
+      return reply(
+        `Unknown /plan subcommand: \`${verb}\`. Try \`/plan\` (no args) for usage.`,
+      );
+  }
+  void rest; // keep linter happy in case of future args
+}
+
+async function dispatchAction(
+  actions: Map<string, SessionActionHandler>,
+  actionId: string,
+  ctx: PluginCommandContext,
+  payload: { [key: string]: string | number | boolean | null },
+): Promise<PluginCommandResult> {
+  const handler = actions.get(actionId);
+  if (!handler) {
+    return reply(
+      `Internal error: session action \`${actionId}\` is not registered. ` +
+        `This is a plugin wiring bug — please report.`,
+    );
+  }
+  if (!ctx.sessionKey) {
+    return reply(
+      "`/plan` commands require a session context. Try sending the command from inside an active session, not a control-plane surface.",
+    );
+  }
+  // Build a synthetic session-action context. The handler accepts a
+  // PluginSessionActionContext shape that includes pluginId / actionId /
+  // sessionKey / payload — matches how the host invokes the action
+  // via registerSessionAction.
+  const actionResult = await handler({
+    pluginId: "smarter-claw",
+    actionId,
+    sessionKey: ctx.sessionKey,
+    payload,
+  });
+  if (!actionResult || actionResult.ok === false) {
+    const code = (actionResult as { code?: string } | undefined)?.code ?? "ERROR";
+    const error = (actionResult as { error?: string } | undefined)?.error ?? "unknown";
+    return reply(`/plan ${actionId.replace("plan.", "")} failed: ${code} — ${error}`);
+  }
+  // Surface a concise result.
+  const friendly: Record<string, string> = {
+    "plan.accept": "Plan approved — agent will resume execution.",
+    "plan.edit": "Plan approved with edits — agent will execute the edited body.",
+    "plan.reject": "Plan rejected — agent will revise based on your feedback.",
+    "plan.cancel": "Exited plan mode — back to normal session.",
+    "plan.answer": "Question answered — agent will resume.",
+    "plan.auto.toggle": "Auto-approve toggled.",
+  };
+  return {
+    text: friendly[actionId] ?? `${actionId} ok`,
+    ...(actionResult.continueAgent !== undefined
+      ? { continueAgent: actionResult.continueAgent }
+      : {}),
+  };
+}
+
+function reply(text: string): PluginCommandResult {
+  return { text };
+}

--- a/tests/state/session-store-gateway.test.ts
+++ b/tests/state/session-store-gateway.test.ts
@@ -57,4 +57,33 @@ describe("P-6 SessionStoreGateway — shape", () => {
     const gw = new SessionStoreGateway();
     expect(typeof gw.withLock).toBe("function");
   });
+
+  it("uses the SDK session-key parser when the runtime exposes one", () => {
+    const routing = _testing.resolveRoutingRuntime({
+      parseAgentSessionKey: (sessionKey: string) => ({
+        agentId: "sdk",
+        suffix: sessionKey,
+      }),
+    });
+
+    expect(routing.parseAgentSessionKey("agent:main:subagent:abc")).toEqual({
+      agentId: "sdk",
+      suffix: "agent:main:subagent:abc",
+    });
+  });
+
+  it("falls back when the SDK runtime lacks parseAgentSessionKey", () => {
+    const warnings: string[] = [];
+    const routing = _testing.resolveRoutingRuntime(
+      { runtimeLoaded: true },
+      { warn: (message) => warnings.push(message) },
+    );
+
+    expect(routing.parseAgentSessionKey("agent:main:subagent:abc")).toEqual({
+      agentId: "main",
+      suffix: "subagent:abc",
+    });
+    expect(routing.parseAgentSessionKey("main")).toBeNull();
+    expect(warnings[0]).toContain("missing parseAgentSessionKey");
+  });
 });

--- a/tests/ui/slash-commands.test.ts
+++ b/tests/ui/slash-commands.test.ts
@@ -1,0 +1,306 @@
+/**
+ * `/plan` slash-command tests.
+ *
+ * Covers the command dispatcher: subcommand routing, the `/plan enter`
+ * store path, the dispatcher's try/catch error guard, and the
+ * `/plan answer` known-gap message.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  createPlanSlashCommand,
+  createPlanModeSlashCommand,
+  type CreatePlanSlashCommandInput,
+} from "../../src/ui/slash-commands.js";
+import type { PlanModeStore } from "../../src/state/store.js";
+
+const SESSION_KEY = "agent:main:main";
+
+type ActionHandler = CreatePlanSlashCommandInput["actions"] extends Map<
+  string,
+  infer H
+>
+  ? H
+  : never;
+
+function makeInput(overrides?: {
+  actions?: Map<string, ActionHandler>;
+  store?: Partial<PlanModeStore>;
+}): CreatePlanSlashCommandInput {
+  const okHandler: ActionHandler = vi.fn(async () => ({
+    ok: true as const,
+    continueAgent: true,
+  }));
+  const actions =
+    overrides?.actions ??
+    new Map<string, ActionHandler>([
+      ["plan.accept", okHandler],
+      ["plan.edit", okHandler],
+      ["plan.reject", okHandler],
+      ["plan.cancel", okHandler],
+      ["plan.auto.toggle", okHandler],
+    ]);
+  const store = {
+    enterPlanMode: vi.fn(async () => ({
+      kind: "entered" as const,
+      state: {} as never,
+    })),
+    ...overrides?.store,
+  } as unknown as PlanModeStore;
+  return { actions, store };
+}
+
+function cmdCtx(args: string, opts?: { noSession?: boolean }) {
+  return {
+    channel: "chat",
+    isAuthorizedSender: true,
+    commandBody: `/plan ${args}`,
+    args,
+    config: {} as never,
+    // Default carries a sessionKey; pass { noSession: true } to omit it.
+    ...(opts?.noSession ? {} : { sessionKey: SESSION_KEY }),
+  };
+}
+
+describe("/plan slash command — registration shape", () => {
+  it("createPlanSlashCommand returns a `plan` command accepting args", () => {
+    const cmd = createPlanSlashCommand(makeInput());
+    expect(cmd.name).toBe("plan");
+    expect(cmd.acceptsArgs).toBe(true);
+    expect(typeof cmd.handler).toBe("function");
+  });
+
+  it("createPlanModeSlashCommand returns a `plan-mode` alias", () => {
+    const cmd = createPlanModeSlashCommand(makeInput());
+    expect(cmd.name).toBe("plan-mode");
+    expect(cmd.acceptsArgs).toBe(true);
+  });
+
+  it("neither command sets a `channels` filter (available everywhere)", () => {
+    expect(createPlanSlashCommand(makeInput()).channels).toBeUndefined();
+    expect(createPlanModeSlashCommand(makeInput()).channels).toBeUndefined();
+  });
+});
+
+describe("/plan slash command — usage", () => {
+  it("no args returns usage text", async () => {
+    const cmd = createPlanSlashCommand(makeInput());
+    const r = await cmd.handler(cmdCtx(""));
+    expect(r.text).toMatch(/Plan-mode commands:/);
+    expect(r.text).toMatch(/\/plan enter/);
+  });
+
+  it("unknown subcommand returns a help pointer", async () => {
+    const cmd = createPlanSlashCommand(makeInput());
+    const r = await cmd.handler(cmdCtx("frobnicate"));
+    expect(r.text).toMatch(/Unknown \/plan subcommand/);
+  });
+});
+
+describe("/plan slash command — approval routing", () => {
+  it("/plan accept dispatches plan.accept", async () => {
+    const input = makeInput();
+    const handler = input.actions.get("plan.accept")!;
+    const cmd = createPlanSlashCommand(input);
+    const r = await cmd.handler(cmdCtx("accept"));
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({ actionId: "plan.accept", sessionKey: SESSION_KEY }),
+    );
+    expect(r.text).toMatch(/Plan approved/);
+    expect(r.continueAgent).toBe(true);
+  });
+
+  it("/plan approve is an alias for accept", async () => {
+    const input = makeInput();
+    const cmd = createPlanSlashCommand(input);
+    await cmd.handler(cmdCtx("approve"));
+    expect(input.actions.get("plan.accept")).toHaveBeenCalled();
+  });
+
+  it("/plan edit <body> dispatches plan.edit with the body", async () => {
+    const input = makeInput();
+    const handler = input.actions.get("plan.edit")!;
+    const cmd = createPlanSlashCommand(input);
+    await cmd.handler(cmdCtx("edit revised step one\nrevised step two"));
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionId: "plan.edit",
+        payload: { body: "revised step one\nrevised step two" },
+      }),
+    );
+  });
+
+  it("/plan edit without a body returns an error (no dispatch)", async () => {
+    const input = makeInput();
+    const cmd = createPlanSlashCommand(input);
+    const r = await cmd.handler(cmdCtx("edit"));
+    expect(r.text).toMatch(/requires an edited body/);
+    expect(input.actions.get("plan.edit")).not.toHaveBeenCalled();
+  });
+
+  it("/plan reject forwards optional feedback", async () => {
+    const input = makeInput();
+    const handler = input.actions.get("plan.reject")!;
+    const cmd = createPlanSlashCommand(input);
+    await cmd.handler(cmdCtx("reject too many steps"));
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionId: "plan.reject",
+        payload: { feedback: "too many steps" },
+      }),
+    );
+  });
+
+  it("/plan reject with no feedback dispatches an empty payload", async () => {
+    const input = makeInput();
+    const handler = input.actions.get("plan.reject")!;
+    const cmd = createPlanSlashCommand(input);
+    await cmd.handler(cmdCtx("reject"));
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({ actionId: "plan.reject", payload: {} }),
+    );
+  });
+
+  it("/plan cancel and /plan exit both dispatch plan.cancel", async () => {
+    const input = makeInput();
+    const cmd = createPlanSlashCommand(input);
+    await cmd.handler(cmdCtx("cancel"));
+    await cmd.handler(cmdCtx("exit"));
+    expect(input.actions.get("plan.cancel")).toHaveBeenCalledTimes(2);
+  });
+
+  it("/plan auto on|off dispatches plan.auto.toggle with the right flag", async () => {
+    const input = makeInput();
+    const handler = input.actions.get("plan.auto.toggle")!;
+    const cmd = createPlanSlashCommand(input);
+    await cmd.handler(cmdCtx("auto on"));
+    expect(handler).toHaveBeenLastCalledWith(
+      expect.objectContaining({ payload: { enabled: true } }),
+    );
+    await cmd.handler(cmdCtx("auto off"));
+    expect(handler).toHaveBeenLastCalledWith(
+      expect.objectContaining({ payload: { enabled: false } }),
+    );
+  });
+
+  it("/plan auto with no on|off arg returns an error", async () => {
+    const cmd = createPlanSlashCommand(makeInput());
+    const r = await cmd.handler(cmdCtx("auto"));
+    expect(r.text).toMatch(/requires `on` or `off`/);
+  });
+});
+
+describe("/plan enter — store path", () => {
+  it("/plan enter calls store.enterPlanMode and reports success", async () => {
+    const input = makeInput();
+    const cmd = createPlanSlashCommand(input);
+    const r = await cmd.handler(cmdCtx("enter"));
+    expect(input.store.enterPlanMode).toHaveBeenCalledWith({
+      sessionKey: SESSION_KEY,
+    });
+    expect(r.text).toMatch(/Plan mode entered/);
+  });
+
+  it("/plan enter reports the noop case when already in plan mode", async () => {
+    const input = makeInput({
+      store: {
+        enterPlanMode: vi.fn(async () => ({
+          kind: "noop" as const,
+          state: {} as never,
+        })),
+      },
+    });
+    const cmd = createPlanSlashCommand(input);
+    const r = await cmd.handler(cmdCtx("enter"));
+    expect(r.text).toMatch(/Already in plan mode/);
+  });
+
+  it("/plan enter surfaces a store failure as a clean reply", async () => {
+    const input = makeInput({
+      store: {
+        enterPlanMode: vi.fn(async () => ({
+          kind: "failed" as const,
+          error: new Error("disk full"),
+        })),
+      },
+    });
+    const cmd = createPlanSlashCommand(input);
+    const r = await cmd.handler(cmdCtx("enter"));
+    expect(r.text).toMatch(/\/plan enter failed: disk full/);
+  });
+
+  it("/plan enter surfaces a thrown store error as a clean reply", async () => {
+    const input = makeInput({
+      store: {
+        enterPlanMode: vi.fn(async () => {
+          throw new Error("boom");
+        }),
+      },
+    });
+    const cmd = createPlanSlashCommand(input);
+    const r = await cmd.handler(cmdCtx("enter"));
+    expect(r.text).toMatch(/\/plan enter failed: boom/);
+  });
+
+  it("/plan enter without a sessionKey returns a clean reply", async () => {
+    const cmd = createPlanSlashCommand(makeInput());
+    const r = await cmd.handler(cmdCtx("enter", { noSession: true }));
+    expect(r.text).toMatch(/requires a session context/);
+  });
+});
+
+describe("/plan answer — known-gap message", () => {
+  it("/plan answer does NOT dispatch and returns the known-gap message", async () => {
+    const input = makeInput({
+      actions: new Map<string, ActionHandler>([
+        ["plan.answer", vi.fn(async () => ({ ok: true as const })) as ActionHandler],
+      ]),
+    });
+    const cmd = createPlanSlashCommand(input);
+    const r = await cmd.handler(cmdCtx("answer option one"));
+    expect(r.text).toMatch(/approval card/);
+    expect(input.actions.get("plan.answer")).not.toHaveBeenCalled();
+  });
+});
+
+describe("/plan dispatcher — error handling", () => {
+  it("a thrown session-action handler becomes a clean reply, not a crash", async () => {
+    const throwing: ActionHandler = vi.fn(async () => {
+      throw new Error("handler exploded");
+    });
+    const input = makeInput({
+      actions: new Map<string, ActionHandler>([["plan.accept", throwing]]),
+    });
+    const cmd = createPlanSlashCommand(input);
+    const r = await cmd.handler(cmdCtx("accept"));
+    expect(r.text).toMatch(/\/plan accept failed: handler exploded/);
+  });
+
+  it("an ok:false session-action result surfaces its code + error", async () => {
+    const failing: ActionHandler = vi.fn(async () => ({
+      ok: false as const,
+      code: "STALE_APPROVAL_ID",
+      error: "approvalId mismatch",
+    }));
+    const input = makeInput({
+      actions: new Map<string, ActionHandler>([["plan.accept", failing]]),
+    });
+    const cmd = createPlanSlashCommand(input);
+    const r = await cmd.handler(cmdCtx("accept"));
+    expect(r.text).toMatch(/STALE_APPROVAL_ID/);
+    expect(r.text).toMatch(/approvalId mismatch/);
+  });
+
+  it("a missing session-action registration returns a wiring-bug reply", async () => {
+    const input = makeInput({ actions: new Map() });
+    const cmd = createPlanSlashCommand(input);
+    const r = await cmd.handler(cmdCtx("accept"));
+    expect(r.text).toMatch(/not registered/);
+  });
+
+  it("a dispatched subcommand without a sessionKey returns a clean reply", async () => {
+    const cmd = createPlanSlashCommand(makeInput());
+    const r = await cmd.handler(cmdCtx("accept", { noSession: true }));
+    expect(r.text).toMatch(/require a session context/);
+  });
+});


### PR DESCRIPTION
## Why

Live-testing revealed two missing wire-ups that made the plugin
effectively invisible to users coming from the in-host UX:

### 1. Agent couldn't invoke plan mode

The \`before_prompt_build\` hook only fired when \`mode === \"plan\"\`,
so the agent had ZERO awareness that \`enter_plan_mode\` was a tool
option. The \`buildPlanModeAvailableSystemContext()\` function I added
in PR #88 was never called — I wrote it but didn't wire it.

User-visible symptom: \"tried to get the agent to invoke Plan Mode 2,
but nothing happened.\"

**Fix**: \`before_prompt_build\` now branches:
- \`mode === \"plan\"\` → \`buildPlanModeActiveSystemContext()\`
- else → \`buildPlanModeAvailableSystemContext()\`

The plugin's presence implies the feature is enabled — installing it
IS the opt-in.

### 2. \`/plan\` slash commands missing

Plugin used \`api.registerCli\` for the operator CLI (\`openclaw
plan-clear\`) but never \`api.registerCommand\` (the in-chat slash-
command SDK surface). Users coming from the in-host expected
\`/plan accept\`, \`/plan reject\` etc. and got nothing.

**Fix**: register \`/plan\` and \`/plan-mode\` slash commands that
dispatch to existing session-action handlers:

| Subcommand | Routes to |
|---|---|
| \`/plan accept\` | \`plan.accept\` |
| \`/plan edit <body>\` | \`plan.edit\` |
| \`/plan reject [reason]\` | \`plan.reject\` |
| \`/plan cancel\` / \`/plan exit\` | \`plan.cancel\` |
| \`/plan answer <option>\` | \`plan.answer\` |
| \`/plan auto on\|off\` | \`plan.auto.toggle\` |
| \`/plan\` (no args) | usage help |

## Out of scope (still pending live-UX work)

These are real gaps but require new code, not wire-ups:

- **In-chat toolbar chip + inline plan cards** — deferred to v1.0
  per RELEASE_NOTES.md. The chat-stream-renderer SDK seam is
  applied via the patcher PRs (#84/#85), but the plugin doesn't
  yet have rendering code that uses it.
- **Sidebar widget visibility** — the descriptor is registered;
  whether the Control UI actually renders it depends on host
  recognition.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm build\` succeeds
- [ ] CI test suite green
- [ ] Live test: agent invokes plan mode after this lands (user-side validation)
- [ ] Live test: \`/plan\` slash commands work in chat

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `/plan` and `/plan-mode` slash commands with subcommands (accept/approve, edit, reject/revise, cancel/exit, answer, auto on|off, enter, status) and user-friendly responses.
  * System guidance now adapts based on plan-mode status.

* **Bug Fixes**
  * More robust session routing/parsing with clear warnings when environment parsing is unavailable.

* **Tests**
  * New tests for routing/parsing behavior, fallback handling, and slash-command behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/Smarter-Claw/pull/93?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->