### PR TITLE
Wave 1: parity re-audit + build-specs + Codex/Claude Code benchmark

### DIFF
--- a/docs/audits/parity-refresh/benchmark-codex-claude-code.md
+++ b/docs/audits/parity-refresh/benchmark-codex-claude-code.md
@@ -1,0 +1,270 @@
+# Benchmark: Smarter-Claw Plan Mode vs Codex CLI & Claude Code
+
+**Date**: 2026-05-19
+**Author**: parity-refresh audit
+**Scope**: formal feature-by-feature comparison of the Smarter-Claw plan-mode
+plugin (`1.0.0-port.15`, against `openclaw@2026.5.10-beta.5`+) against the two
+industry references — **Codex CLI plan mode** and **Claude Code plan mode** —
+both as of May 2026.
+**Quality bar (operator)**: "as good as Codex's built-in plan mode, or Claude
+Code's plan mode — if not better."
+
+This document is deliberately adversarial. The goal is to find the rows where
+the references genuinely beat Smarter-Claw, not to flatter the plugin. Every
+`⚠️` / `❌` carries a concrete finding feeding the Wave-1 catalog.
+
+---
+
+## Method & sources
+
+- **Smarter-Claw**: read of the plugin source (`src/tools/*`, `src/gates/*`,
+  `src/prompt/*`, `src/runtime/escalating-retry.ts`, `src/plan-mode/*`,
+  `src/ui/*`), `README.md`, `RELEASE_NOTES.md`, and the
+  `docs/audits/wave-1.5-post-surgical-summary.md` feature roll-up.
+- **Codex CLI**: `developers.openai.com/codex/cli/features`,
+  `developers.openai.com/codex/changelog`, the SmartScope and danielvaughan
+  plan-mode write-ups, OpenAI mobile/Slack release notes (see Sources).
+- **Claude Code**: `code.claude.com/docs/en/permission-modes` (authoritative),
+  plus the anyonebuilds 2026 guide.
+
+A caveat on the references: Codex plan mode is **prompt-level only — there is
+no runtime sandbox** that physically blocks mutations (documented explicitly
+in the OpenAI-community/SmartScope material). Claude Code plan mode IS
+runtime-enforced (`plan` permission mode, reads-only, protected paths). This
+asymmetry matters for several rows below.
+
+---
+
+## Comparison matrix
+
+Legend: ✅ = Smarter-Claw at-or-above parity · ⚠️ = present but weaker ·
+❌ = missing.
+
+| # | Capability | Smarter-Claw | Codex CLI | Claude Code | SC verdict |
+|---|---|---|---|---|---|
+| 1 | **Plan entry** | `enter_plan_mode` tool (agent-driven) + `/plan enter` + `/plan-mode` slash + model-pattern auto-enable (`autoEnableFor`) | `/plan [desc]` slash + `Shift+Tab` cycle (Plan/Pair/Execute) | `Shift+Tab` cycle + `/plan` prefix + `--permission-mode plan` + `defaultMode` | ✅ |
+| 2 | **Read-only investigation phase** | Mutation gate enforces it in code; system prompt names allowed read tools + a logs-investigation heuristic | Read-only/consultative; up to ~4 rounds of clarifying questions; **prompt-level only** | `plan` mode: reads + exploratory shell allowed, no source edits; runtime-enforced | ✅ |
+| 3 | **Mutation blocking (enforcement)** | `checkMutationGate` — fail-closed allowlist + suffix patterns + read-only exec-prefix list + dangerous-flag regex + shell-operator block; 116 adversarial cases | **None** — plan mode is a prompt instruction, no runtime block | Runtime: `plan` mode is reads-only; protected paths never auto-approved | ✅ |
+| 4 | **Plan presentation / format** | Structured `exit_plan_mode(title, plan[], summary, analysis, assumptions, risks[], verification[], references[])` — a decision-complete archetype | Structured plan (steps, files, acceptance criteria) rendered in a dedicated TUI view | Numbered plain-English plan in the terminal | ✅ |
+| 5 | **Approval UX (approve / edit / reject)** | Approve / Edit / Reject / Cancel via sidebar + `/plan accept\|edit\|reject\|cancel`; stale-event guard; terminal-state guard | Approve / edit / reject inline in the TUI plan view; can approve/reject steps inline | Approve (3 sub-modes) / keep-planning / reject; `Ctrl+G` opens plan in `$EDITOR` | ⚠️ |
+| 6 | **Plan-mode nudges / incomplete-turn retry** | `escalating-retry.ts` — 3 detectors (PLAN_ACK_ONLY / PLAN_YIELD / PLANNING_RETRY), 2–3 escalation tiers, completion-guard | Plan-mode nudges + "action-required" terminal titles (added 2026) | No documented automatic retry/nudge; relies on prompt + user | ✅ |
+| 7 | **Clarifying questions** | `ask_user_question` (2–6 options, optional freetext); stays in plan mode; answer arrives as `[QUESTION_ANSWER]:` | Native clarifying-question rounds (~4) before plan; first-class in the loop | Claude can ask in chat; no structured option-button tool in `plan` mode | ⚠️ |
+| 8 | **Idle / action-required notification** | None — no idle nudge fires while an approval is pending; no surface-side "needs you" signal | "Action-required" terminal title + plan-mode nudges; mobile push to approve/deny | Terminal bell / OS notification on completion (Claude Code general); plan prompt is in-terminal | ❌ |
+| 9 | **Plan persistence** | None — plan lives in session-extension state only; no markdown file is written despite the prompt/reference-card promising `plan-YYYY-MM-DD-<slug>.md` | Session-only; teams hand-roll a `PLANS.md`. No automatic persisted artifact either | Session-only; "close and reopen, plan mode is off"; **but** approving a plan auto-names the session from plan content | ⚠️ |
+| 10 | **Auto-approve mode** | `autoApprove` flag + `/plan auto on\|off` + `setAutoApprove` mutator; gate reads it. Runtime that actually *fires* auto-approve on `exit_plan_mode` is **not wired** (RELEASE_NOTES known-limitation #3) | Approval modes (`/permissions`): auto / read-only / full-access | `auto` mode with a separate classifier model; approve-into-auto from the plan prompt | ⚠️ |
+| 11 | **Archetype / quality steering** | `PLAN_ARCHETYPE_PROMPT` (decision-complete standard) + `PLAN_MODE_REFERENCE_CARD` (state diagram, tool contract, pitfalls) injected every in-mode turn | Recommended plan templates A/B/C in docs — guidance, not enforced/injected | No injected archetype; relies on base model + user spec quality | ✅ |
+| 12 | **Post-approval constraint gate** | `checkAcceptEditsGate` — 3 hard constraints (destructive / self-restart / config-change) override `acceptEdits`; shell-escape detection; 72 adversarial cases | None specific to plan execution — governed by the general approval mode | `acceptEdits` mode + protected-path list + (in `auto`) a safety classifier | ✅ |
+| 13 | **Rejection-cycle handling** | `rejectionCount` tracked; `[PLAN_DECISION]: rejected` injection carries feedback; de-escalation hint at ≥3 rejections | Reject + iterate; no documented cycle counter or escalating guidance | Type feedback → Claude revises → re-presents; no documented cycle counter | ✅ |
+| 14 | **Cross-platform / multi-surface (Telegram, Slack, web, mobile)** | `/plan` registered with no channel filter (works on every channel); but approval **buttons** are sidebar-only — Telegram/Slack get text commands, no inline buttons; no mobile push | Slack integration (mention `@Codex`); ChatGPT mobile app — approve/deny pending commands, view diffs, from phone | Web (`claude.ai/code`), Desktop, VS Code, JetBrains, mobile, Remote Control — plan mode in mode selector across all | ❌ |
+| 15 | **Plan-tier model override** | `planTierModel` config routes plan-mode turns to a stronger model (`before_model_resolve`) | Not a documented feature | Not a documented feature (single `/model` per session) | ✅ |
+| 16 | **In-chat / inline plan card UI** | None in v0.x — sidebar widget only. Inline plan cards, mode-switcher chip, input-bar suppression all deferred to v1.0 (upstream SDK seam blocked) | Dedicated inline TUI plan view; inline step approval | Plan presented inline in the terminal/IDE; mode shown in status bar | ❌ |
+
+---
+
+## Matrix verdict
+
+**16 rows scored**: **8 ✅** · **5 ⚠️** · **3 ❌**.
+
+The plugin's *enforcement core* is its genuine strength — rows 2, 3, 6, 11,
+12, 13, 15 are all at-or-above parity, and several (3, 12, 15) are things
+neither reference offers at all. Where it falls down is the **delivery and
+last-mile surface**: notification (row 8), persistence (row 9), multi-surface
+parity (row 14), and inline UI (row 16). Those are exactly the things a user
+*sees and touches*, which is why the operator's "as good as, if not better"
+bar is not yet met despite a stronger backend.
+
+---
+
+## Findings — where the references genuinely beat Smarter-Claw
+
+### F1 — No "action-required" notification when an approval is pending (row 8) — `❌`
+
+**What the references do.** Codex CLI added **plan-mode nudges and
+"action-required" terminal titles** specifically so a user who walked away
+knows the agent is *blocked on them*. The Codex mobile app pushes a
+notification to approve/deny from a phone. Claude Code rings the terminal bell
+/ fires an OS notification.
+
+**Smarter-Claw today.** When `exit_plan_mode` fires, the plan sits in
+`approval: "pending"` indefinitely (timeout default 600s only flips state, it
+does not *alert*). The reference card even documents that `[PLAN_NUDGE]:` is
+**suppressed when pending** — i.e. the plugin deliberately goes *quiet* exactly
+when the user most needs poking. There is no terminal-title change, no bell,
+no channel ping.
+
+**Recommendation: ADOPT.** Highest-leverage, lowest-risk gap. (a) Set an
+"action-required" terminal/window title or emit an OS bell on
+`persistApprovalRequest`. (b) On channel surfaces (Telegram/Slack), send a
+short "Plan ready for your approval — /plan accept | reject" message when the
+approval is persisted. This needs no new SDK seam — the session-action layer
+already knows the moment the plan goes pending. **Wave-1 priority: P0.**
+
+### F2 — Plan is never persisted to a file, despite the prompt promising it (row 9) — `⚠️`
+
+**What the references do.** Both references are *also* session-only — so this
+is not "the references have persistence and we don't." The finding is sharper:
+Smarter-Claw's own `PLAN_ARCHETYPE_PROMPT` and `PLAN_MODE_REFERENCE_CARD` tell
+the model the `title` "becomes the persisted markdown filename
+(`plan-YYYY-MM-DD-<slug>.md`)" — **but no code writes that file.** The plugin
+ships a prompt contract it does not honor.
+
+Separately, Claude Code does one persistence-adjacent thing the plugin lacks:
+**approving a plan auto-names the session from the plan content.**
+
+**Recommendation: ADOPT (partial).** Either (a) actually write the
+`plan-YYYY-MM-DD-<slug>.md` artifact on approval so the prompt is truthful, or
+(b) remove the persisted-filename claim from the archetype prompt and reference
+card so the model is not lied to (a model that believes a file exists may
+reference it). (b) is a 5-minute honesty fix and should land immediately; (a)
+is the better long-term answer. Also adopt Claude Code's **auto-name-session-
+from-plan-title** on `plan.accept` — cheap, the `title` is already in state.
+**Wave-1 priority: P1 (prompt-honesty sub-fix is P0).**
+
+### F3 — No multi-surface parity: approval buttons are sidebar-only (rows 14, 16) — `❌`
+
+**What the references do.** Codex runs plan approval in **Slack** (`@Codex`
+mention) and the **ChatGPT mobile app** (approve/deny, view diffs from a
+phone). Claude Code exposes plan mode across **web, Desktop, VS Code,
+JetBrains, mobile, and Remote Control** — the mode selector and plan prompt
+render natively on each.
+
+**Smarter-Claw today.** `/plan` slash commands are channel-agnostic (good),
+but the *approval card with Approve/Edit/Reject buttons* is a **sidebar widget
+only**. On Telegram or Slack a user gets text and must type `/plan accept`.
+Inline plan cards, the mode-switcher chip, and input-bar suppression are all
+deferred to v1.0 behind an upstream `registerChatStreamRenderer` SDK seam.
+
+**Recommendation: ADOPT, but acknowledge the blocker.** True inline-card
+parity is genuinely upstream-blocked — that part is honest. But two things can
+ship *now* without the seam: (a) when an approval goes pending, push a
+channel message on Telegram/Slack with the plan summary and the literal
+`/plan accept` / `/plan reject` commands (overlaps F1); (b) make the
+text-command fallback *discoverable* — today a Telegram user has no signal
+that a plan is even waiting. Track inline cards as a v1.0 item but stop
+treating "sidebar only" as acceptable for non-webchat surfaces.
+**Wave-1 priority: P1.**
+
+### F4 — Auto-approve is a flag with no runtime (row 10) — `⚠️`
+
+**What the references do.** Codex's `/permissions` auto mode and Claude Code's
+`auto` mode are *fully wired* — the user picks the mode and the agent actually
+proceeds without a prompt (Claude Code even runs a safety classifier on each
+action).
+
+**Smarter-Claw today.** `autoApprove` is a real flag with a real mutator and
+`/plan auto on|off`, and the accept-edits gate reads it — but RELEASE_NOTES
+known-limitation #3 is explicit: "the runtime side that actually FIRES
+auto-approve on `exit_plan_mode` (skipping the pending state) lands at P-final."
+So today a user can *toggle* auto-approve and it does **nothing** to the
+approval flow. That is worse than not having the toggle — it is a control that
+lies about its effect.
+
+**Recommendation: ADOPT or HIDE.** Either wire the runtime (on
+`persistApprovalRequest`, if `autoApprove` is set, immediately resolve via
+`recordApproval` and emit `buildApprovedPlanInjection` — the accept-edits gate
+already backstops the 3 hard constraints), or hide/disable the `/plan auto`
+command and the sidebar toggle until the runtime exists. A non-functional
+safety-relevant toggle is a bug. **Wave-1 priority: P1.**
+
+### F5 — Clarifying questions are not as natural as Codex's loop (row 7) — `⚠️`
+
+**What Codex does.** Codex treats clarifying questions as a **first-class
+phase**: it asks up to ~4 rounds of questions *before* it proposes a plan, and
+the loop ("describe → questions → answer/proceed → plan") is the documented
+default UX.
+
+**Smarter-Claw today.** `ask_user_question` is good — structured 2–6 options,
+optional freetext, non-blocking, clean `[QUESTION_ANSWER]:` round-trip — and
+arguably *better* than free-text Q&A in isolation. But: (a) the archetype
+prompt pushes the model *away* from asking ("Do not ask the user for facts you
+can discover locally", "exhaust the read-only investigation surface"), which is
+correct for fact-finding but can suppress genuine tradeoff questions; and
+(b) `/plan answer` is **not wired** on the slash surface at all
+(`slash-commands.ts` explicitly routes the user to the approval card; plugin-
+side question-state tracking does not exist) — so on Telegram/Slack a pending
+question is *unanswerable* without the sidebar.
+
+**Recommendation: ADOPT the wiring, keep the discipline.** The
+"investigate-before-asking" steering is a deliberate quality choice and should
+stay. But (b) is a real gap: build plugin-side question-state tracking so
+`/plan answer <text>` works cross-surface. Until then a Telegram user hitting
+an `ask_user_question` is stuck. **Wave-1 priority: P1.**
+
+---
+
+## Findings — where Smarter-Claw genuinely beats the references
+
+### E1 — Real runtime mutation enforcement (rows 2, 3, 12)
+
+This is the plugin's strongest, most defensible edge. **Codex plan mode is
+prompt-level only — there is no sandbox.** Smarter-Claw's `checkMutationGate`
+is a *fail-closed* runtime gate: explicit allowlist, mutation/read-only suffix
+patterns, a read-only exec-prefix allowlist, shell-operator blocking,
+word-boundary dangerous-flag regex — 116 adversarial test cases. On top of
+that, `checkAcceptEditsGate` adds three hard constraints (destructive /
+self-restart / config-change) that override `acceptEdits` *even at 95%
+confidence*, including shell-escape-vector detection (env-var indirection,
+subshells, quote concatenation, byte escapes) — 72 more adversarial cases.
+Claude Code's `plan` mode is runtime-enforced too, but it has no equivalent of
+the post-approval 3-constraint gate. Smarter-Claw is the only one of the three
+with defense-in-depth at *both* the plan phase and the execution phase.
+
+### E2 — Escalating incomplete-turn retry (row 6)
+
+Smarter-Claw actively *repairs* the most common plan-mode failure modes.
+`escalating-retry.ts` ships three detectors — PLAN_ACK_ONLY (model narrated a
+plan as chat instead of calling `exit_plan_mode`), PLAN_YIELD (model yielded
+immediately after approval without executing), PLANNING_RETRY (planning-only
+narration outside plan mode) — each with 2–3 escalating instruction tiers and
+a completion-signal guard so it does not nag a model that legitimately
+finished. Codex's "plan-mode nudges" are real but shallower (a terminal-title
+hint); Claude Code has no documented automatic retry — a model that edits
+without leaving plan mode is a known open Claude Code issue with no
+auto-correction. This is a meaningful reliability edge.
+
+### E3 — Injected decision-complete archetype + reference card (row 11)
+
+Every in-plan-mode turn, Smarter-Claw injects `PLAN_ARCHETYPE_PROMPT` (a
+decision-complete-plan standard: required fields, quality bar, explicit
+anti-patterns) and `PLAN_MODE_REFERENCE_CARD` (state diagram, tool contract,
+tag taxonomy, pitfalls). Codex documents plan *templates* but does not inject
+or enforce them — they are advice in a docs page. Claude Code relies on the
+base model plus the user's spec quality. Smarter-Claw is the only one that
+*systematically* steers the model toward a high-quality plan shape rather than
+hoping for it — and `planTierModel` (row 15) can additionally route the
+planning turn to a stronger model, which neither reference can do.
+
+---
+
+## Wave-1 catalog hand-off
+
+Five findings (F1–F5) feed the Wave-1 catalog. Suggested priority:
+
+| ID | Finding | Adopt? | Priority | SDK-blocked? |
+|---|---|---|---|---|
+| F1 | Action-required notification on pending approval | Yes | **P0** | No |
+| F2 | Persist plan to file *or* stop the prompt promising it | Yes (honesty sub-fix P0) | P0 / P1 | No |
+| F3 | Multi-surface approval — channel ping + discoverable fallback | Yes (inline cards v1.0) | P1 | Partly |
+| F4 | Wire auto-approve runtime, or hide the dead toggle | Yes | P1 | No |
+| F5 | Cross-surface `/plan answer` + question-state tracking | Yes | P1 | No |
+
+The encouraging read: **four of the five gaps need no new SDK seam.** F1, F2,
+F4, and F5 are all fixable inside the existing plugin surface (the
+session-action layer, the prompt strings, the store). The plugin's backend is
+ahead of both references; closing the last-mile delivery gap is mostly wiring,
+not architecture.
+
+---
+
+## Sources
+
+- [Features – Codex CLI | OpenAI Developers](https://developers.openai.com/codex/cli/features)
+- [Command line options – Codex CLI | OpenAI Developers](https://developers.openai.com/codex/cli/reference)
+- [Changelog – Codex | OpenAI Developers](https://developers.openai.com/codex/changelog)
+- [Complete Guide to Codex Plan Mode (2026) – SmartScope](https://smartscope.blog/en/generative-ai/chatgpt/codex-plan-mode-complete-guide/)
+- [Planning Mode in Practice – Codex Blog (danielvaughan)](https://codex.danielvaughan.com/2026/03/27/planning-mode-in-practice/)
+- [Use Codex in Slack | OpenAI Developers](https://developers.openai.com/codex/integrations/slack)
+- [OpenAI Codex Is Now on Mobile – buildfastwithai](https://www.buildfastwithai.com/blogs/openai-codex-mobile-chatgpt-app-2026)
+- [Choose a permission mode – Claude Code Docs](https://code.claude.com/docs/en/permission-modes)
+- [Claude Code Plan Mode: The Complete 2026 Guide – anyonebuilds](https://www.anyonebuilds.com/guides/claude-code-plan-mode)
+- [Claude Code Plan Mode 2026: Complete Guide With Shortcuts – Get AI Perks](https://www.getaiperks.com/en/ai/claude-code-plan-mode)

--- a/docs/audits/parity-refresh/buildspec-S16-channel-native.md
+++ b/docs/audits/parity-refresh/buildspec-S16-channel-native.md
@@ -1,0 +1,218 @@
+# Build-Spec S16 — Channel-Native Plan Approval
+
+**Slice:** S16 (channel-native approval rendering)
+**Target plugin:** Smarter-Claw (`/Users/lume/repos/Smarter-Claw`)
+**Target host:** OpenClaw `2026.5.18`
+**In-host source-of-truth:** `rebase/pr70071-onto-main-2026-04-25` @ `ea04ea52c7` in `/Volumes/LEXAR/repos/openclaw-pr70071-rebase`
+**Date:** 2026-05-19
+**Status:** SPEC — not implemented
+
+> This is a **build-spec**, not a parity audit. The plugin has zero channel-native
+> approval rendering today; this document specifies how to add it.
+
+---
+
+## 0. TL;DR / Verdict
+
+| Question | Answer |
+|---|---|
+| Does the in-host PR-70071 system render native Approve/Reject **buttons** on Telegram/Slack? | **No.** It never did. PR-13 (native interactive buttons) was explicitly **deferred**. PR-14 shipped a **read-only markdown document attachment** + universal `/plan` **text-command** resolution. |
+| Does OpenClaw `2026.5.18` SDK expose a `ChannelApprovalCapability` registration seam a plugin could use? | **Partially — and not for this use case.** `ChannelApprovalCapability` exists but is (a) the **exec/tool-approval** subsystem, `approvalKind: "exec" \| "plugin"` — *no `"plan"` kind*; and (b) only attachable via `ChannelPlugin.approvalCapability`, i.e. only when the plugin **owns the channel plugin**. Telegram/Slack are built-in channels the plugin does not own. **There is no plugin seam to add native interactive buttons to a built-in channel.** |
+| Can native Approve/Reject buttons ship in the plugin today? | **No** — not as true inline buttons. The SDK exposes no inbound interactive-callback hook (`callback_query` / Slack `block_actions`) for plugins. Two viable paths exist (§3); the recommended path is a **slash-command UX wrapper + a clarified attachment**, with the true-button path filed as an upstream PR. |
+| Does the plan-resume "continue" leak exist on non-web channels? | **No — verified false.** The visible-`continue`-message risk is **webchat-only** and even there `deliver: false` suppresses it. Non-web channels never send a resume message. See §4. |
+| LOC estimate (recommended path) | **~260–340 LOC** plugin code across 3 sub-PRs. True-button path adds an upstream PR of unknown size (host-side). |
+
+---
+
+## 1. In-host mechanism — how plan approval works end-to-end
+
+The in-host PR-70071 plan-mode approval flow, traced through the source:
+
+### 1a. Event emission (`exit_plan_mode` → approval event)
+
+`src/agents/pi-embedded-subscribe.handlers.tools.ts` (the `toolName === "exit_plan_mode"` branch, ~line 1838):
+
+1. Agent calls `exit_plan_mode(title, plan, analysis, assumptions, risks, …)`.
+2. Runtime mints an `approvalId` via `newPlanApprovalId()` (`crypto.randomUUID()`, ~122 bits — security token).
+3. `persistPlanApprovalRequest()` writes `approvalId` + `title` + `lastPlanSteps` **synchronously** to `SessionEntry.planMode` *before* emitting the event (race-fix `1081067476` — eliminates empty-injection race; also de-dupes via `lastPlanPayloadHash`).
+4. Runtime emits an `AgentApprovalEventData` with `kind: "plugin"`, `phase: "requested"`, `status: "pending"`, the `approvalId`, the full plan + archetype fields. This is delivered two ways:
+   - `emitAgentApprovalEvent(...)` → the structured agent-event bus (webchat / Control-UI overlay subscribe here).
+   - `ctx.params.onAgentEvent?.({ stream: "approval", data })` → the inline run-event stream.
+
+> **Plan approval rides the `kind:"plugin"` approval channel, NOT the `kind:"exec"` channel.** The two are distinct: exec-approval is the tool/command-permission subsystem; plan-approval reuses the *event envelope* but is resolved through a different RPC (`sessions.patch { planApproval }`, not the exec-approval gateway).
+
+### 1b. Channel render — **attachment, not buttons**
+
+`src/agents/plan-mode/plan-archetype-bridge.ts` (`dispatchPlanArchetypeAttachment`, void-fired from the same `exit_plan_mode` branch, PR-14):
+
+1. `renderFullPlanArchetypeMarkdown(details)` → a full markdown document.
+2. `persistPlanArchetypeMarkdown()` → writes to `~/.openclaw/agents/<agentId>/plans/` (durable audit trail).
+3. If the originating session is on a file-attachment-capable channel (**Telegram today; Discord/Slack "later" — never built**), uploads the markdown as a **document attachment** with a short caption.
+4. The caption (`buildPlanAttachmentCaption`) is **plain text** ending with:
+   `Resolve with: /plan accept | /plan accept edits | /plan revise <feedback>`
+
+The bridge header is explicit: *"Resolution stays text-based via PR-11's universal `/plan` slash commands. This bridge is read-only (visibility), no approval-id translator required — sidesteps the dual-id problem documented in the PR-13 deferral notes."*
+
+A `git grep` of the entire branch for `callback_query` / `answerCallbackQuery` / Slack `block_actions` intersected with `plan`/`approval` returns **zero hits**. **The in-host has no native interactive plan-approval button on any messaging channel.**
+
+### 1c. Button tap — **N/A** (no buttons exist)
+
+There is no button-tap handler. The user types a text command instead.
+
+### 1d. Resolve (`/plan accept` → `sessions.patch` → state machine)
+
+`src/auto-reply/reply/commands-plan.ts` — the universal `/plan` `CommandHandler` (PR-11), cross-channel (Telegram, Discord, Slack threads, Signal, iMessage, CLI):
+
+1. Parses `/plan accept [edits]` / `/plan revise <feedback>` / `/plan answer <text>` / `/plan on|off|status|view|restate|auto on|off`.
+2. Authorizes via `resolveApprovalCommandAuthorization` (mirrors `/approve` — operator + `operator.approvals` scope for internal channels).
+3. Pre-checks `planMode.approval === "pending"` and a non-null `approvalId` (PR-11 review M1 — avoids a confusing "stale approvalId" gateway error).
+4. Calls `callGateway` → `sessions.patch { planApproval: { action, approvalId, feedback? } }`.
+5. `src/gateway/sessions-patch.ts` (`"planApproval" in patch` branch, ~line 650) runs `resolvePlanApproval(next.planMode, action, feedback, expectedApprovalId)` — the state machine in `src/agents/plan-mode/approval.ts`:
+   - Stale-id guard (mismatched/absent `approvalId` → no-op).
+   - Terminal-state guard (`approved`/`edited`/`timed_out` are terminal).
+   - `approve`/`edit` → `mode: "normal"`, clears feedback, resets `rejectionCount`.
+   - `reject` → `mode` stays `"plan"`, increments `rejectionCount`.
+6. On `approve`/`edit`, `sessions-patch.ts` appends a `[PLAN_DECISION]: approved|edited` synthetic injection to the session's injection queue (`appendToInjectionQueue`) via `buildApprovedPlanInjection` / `buildAcceptEditsPlanInjection`. **Single source of truth**: any caller of `sessions.patch { planApproval }` gets the injection — no per-channel wiring.
+
+### 1e. Resume (continue the agent turn)
+
+Two **distinct** resume mechanisms — this is the crux of §4:
+
+- **Webchat:** `ui/src/ui/chat/plan-resume.ts::resumePendingPlanInteraction()` issues `chat.send { message: "continue", deliver: false, idempotencyKey }`. The injection is already persisted; this hidden send only *resumes the run*. **`deliver: false` ⇒ the "continue" text is not echoed into the chat transcript.**
+- **Non-web channels (Telegram/Slack/etc.):** `commands-plan.ts` returns **`{ shouldContinue: true }`** from the command handler. The auto-reply / agent-runner pipeline then continues the turn naturally — the `[PLAN_DECISION]` injection is consumed at next turn-start. **No `chat.send "continue"` is ever issued on text channels.** (Pre-PR-11-review-fix, the handler returned `shouldContinue: false` and the agent stalled until an unrelated later message — fixed per Codex P1 #68939.)
+
+---
+
+## 2. SDK seam availability on `2026.5.18`
+
+Verified against `/Users/lume/repos/Smarter-Claw/node_modules/openclaw/dist/plugin-sdk/`.
+
+### 2a. `ChannelApprovalCapability` — exists, but wrong subsystem + wrong attach point
+
+- **Type:** `plugin-sdk/src/channels/plugins/types.adapters.d.ts`:
+  ```ts
+  export type ChannelApprovalCapability = ChannelApprovalAdapter & {
+    authorizeActorAction?: (params: { …; approvalKind: "exec" | "plugin" }) => …;
+    getActionAvailabilityState?: (params: { …; approvalKind?: ChannelApprovalKind }) => …;
+    getExecInitiatingSurfaceState?: …;
+    resolveApproveCommandBehavior?: …;
+  };
+  ```
+- **Resolver:** `plugin-sdk/src/channels/plugins/approvals.d.ts` →
+  `resolveChannelApprovalCapability(plugin)` returns `plugin?.approvalCapability`.
+- **Attach point:** `ChannelPlugin.approvalCapability` — a field on a **channel plugin object**. Re-exported from `plugin-sdk/src/channels/plugins/index.d.ts`.
+
+**Two blockers:**
+
+1. **Subsystem mismatch.** `approvalKind` is typed `"exec" | "plugin"` — there is **no `"plan"` kind**. The native-approval machinery (`describeDeliveryCapabilities`, `resolveOriginTarget`, `ChannelApprovalNativeRequest = ExecApprovalRequest | PluginApprovalRequest`) targets the exec/tool-permission flow. Plan-mode approval resolves through `sessions.patch { planApproval }`, an entirely separate RPC. `ChannelApprovalCapability` is **not** the plan-approval seam.
+2. **Ownership mismatch.** A `ChannelApprovalCapability` is only consumed when it hangs off a `ChannelPlugin` *you registered*. Telegram and Slack are **built-in** channels. The plugin API exposes `registerChannel(...)` — which registers a *brand-new* channel — but **no API to decorate or extend a built-in channel's approval rendering.**
+
+### 2b. The full plugin `register*` surface — no interactive-handler seam
+
+`plugin-sdk/src/plugins/types.d.ts` — `OpenClawPluginApi` exposes exactly these registrars (lines 1972–2112):
+
+`registerSessionExtension`, `registerSessionSchedulerJob`, `registerSessionAction`, `registerControlUiDescriptor`, `registerAgentEventSubscription`, `registerRuntimeLifecycle`, `registerTool`, `registerHook`, `registerHttpRoute`, `registerHostedMediaResolver`, **`registerChannel`**, `registerGatewayMethod`, `registerCli`, `registerNodeCliFeature`, `registerReload`, `registerNodeHostCommand`, `registerNodeInvokePolicy`, `registerSecurityAuditCollector`, `registerService`, `registerGatewayDiscoveryService`, `registerCliBackend`, `registerTextTransforms`, `registerConfigMigration`, `registerMigrationProvider`, `registerAutoEnableProbe`, `registerModelCatalogProvider`, `registerCommand`.
+
+There is **NO** `registerInteractiveHandler`, `registerApprovalRenderer`, `registerChannelApprovalCapability`, `registerCallbackQueryHandler`, or equivalent. `registerHook(events, handler)` takes free-form event strings, but no documented inbound interactive-callback event (`channel.callback_query`, `slack.block_actions`, etc.) is exposed in the SDK type surface — the inbound-message hook literals found (`user_message`, `before_message_write`, …) are text-message hooks, not button-callback hooks.
+
+### 2c. Seam verdict
+
+> **The seam to render native interactive Approve/Reject buttons on a built-in channel (Telegram/Slack) and receive the button-tap callback is MISSING from the `2026.5.18` plugin SDK.**
+>
+> What *is* available to a plugin:
+> - `registerCommand` — cross-channel text commands (already used: `/plan` merged in #93).
+> - `registerHook` — text-message hooks (could intercept a typed reply).
+> - `registerChannel` — a whole new channel plugin (not applicable to built-in Telegram/Slack).
+> - `registerControlUiDescriptor` — webchat sidebar widget (already used).
+>
+> Native interactive buttons on Telegram/Slack require **either** an upstream OpenClaw PR adding a plugin-facing interactive-callback seam, **or** the plugin shipping its own Telegram/Slack channel plugin via `registerChannel` (a large, duplicative effort — out of scope).
+
+---
+
+## 3. Plugin implementation plan
+
+Because the true-button seam is missing, S16 splits into a **shippable now** track (recommended) and an **upstream-blocked** track.
+
+### Path A — RECOMMENDED: rich text-command approval UX (ship now)
+
+Deliver the *best approval experience the SDK allows today*: webchat keeps its native buttons (already works via `registerControlUiDescriptor`); Telegram/Slack get a polished, discoverable, attachment-backed text-command flow that reaches feature-parity with the in-host (which also never had buttons). This is **not a downgrade** — it matches the in-host's actual shipped behavior.
+
+#### Sub-PR ladder
+
+**S16-1 — Channel-aware approval prompt renderer** (~120–150 LOC)
+New file `src/channels/approval-prompt.ts`:
+- `renderPlanApprovalPrompt(plan, opts)` — builds a per-channel approval message body:
+  - **Webchat:** unchanged — the existing `registerControlUiDescriptor` sidebar + session-action buttons already render. The renderer returns a no-op marker so webchat keeps its native path.
+  - **Telegram:** a formatted HTML message — plan title, summary, step checklist, then an explicit, copy-pasteable command block (`/plan accept`, `/plan accept edits`, `/plan reject <feedback>`). Mirrors `buildPlanAttachmentCaption` from the in-host bridge.
+  - **Slack:** the same content as Slack `mrkdwn`.
+- Subscribe to plan-approval emission via `api.registerAgentEventSubscription` (the plugin already uses `registerSessionExtension` / hooks) OR hook the plugin's existing `exit_plan_mode` tool path in `src/tools/exit-plan-mode.ts` — after the tool persists the approval, dispatch the channel prompt. The plugin already owns `exit-plan-mode.ts`, so this is the cleaner anchor: no new event bus needed.
+- The prompt is delivered via the channel's normal outbound reply path (the plugin's tool result / hook can append a reply payload).
+
+**S16-2 — Attachment bridge (optional parity nicety)** (~60–90 LOC)
+New file `src/channels/plan-attachment-bridge.ts`:
+- Port `dispatchPlanArchetypeAttachment` — render the full archetype markdown, persist under `~/.openclaw/<plugin-data>/plans/`, and (Telegram only, where the SDK outbound supports document attachments) attach it with the S16-1 caption.
+- Slack: SDK outbound attachment support for Slack is unverified — gate behind a capability check; fall back to the inline S16-1 message if unsupported.
+- This sub-PR is **independent** of S16-1 and can be deferred — S16-1 alone closes the "cannot approve on Telegram/Slack" gap, because `/plan accept` already works (merged in #93).
+
+**S16-3 — Discoverability + reply-driven reject** (~80–100 LOC)
+- `src/channels/approval-prompt.ts` extension: after a `reject`, the in-host convention is "the user's next plain text message = revision feedback." Wire a one-shot `registerHook('user_message', …)` armed per-session when `approval === "rejected"`, so a Telegram/Slack user can just type their feedback instead of `/plan reject <feedback>`. Disarm on consumption / on any `/plan` command / on new approval cycle.
+- Ensure the S16-1 prompt's command block lists the exact `approvalId`-free commands the plugin's `slash-commands.ts` accepts (verify against `src/ui/slash-commands.ts`).
+
+> All three sub-PRs wire to the **existing** `src/ui/session-actions.ts` handlers — `plan.accept` (`continueAgent: true`), `plan.edit`, `plan.reject` — through the **existing** `/plan` `registerCommand` dispatcher in `src/ui/slash-commands.ts`. **No resolution logic is re-implemented.** S16 is purely a *rendering + discoverability* layer in front of the merged #93 command surface.
+
+### Path B — true native buttons (upstream-blocked)
+
+**S16-U (upstream OpenClaw PR)** — add a plugin-facing interactive seam to the channel SDK:
+- A `registerChannelInteractiveHandler({ channels, kind: "approval", render, onCallback })` API, where `render` returns channel-native interactive components (Telegram `inline_keyboard`, Slack `block_actions`) and `onCallback(payload)` receives the button tap.
+- Extend `ChannelApprovalKind` to include `"plan"`, or define a parallel `plan-approval` capability so the existing native-approval delivery machinery (`describeDeliveryCapabilities`, `resolveOriginTarget`) can be reused.
+- This is a **host-side** change; size unknown until scoped against OpenClaw `main`. File it as a tracked upstream issue referencing PR-13's original deferral.
+
+**S16-B (plugin consumer, gated on S16-U landing)** — once the seam ships, a plugin file `src/channels/native-buttons.ts` registers the interactive handler, maps the tap to `session-actions.ts` handlers. ~120–180 LOC, but **do not start until S16-U merges and the plugin bumps its OpenClaw floor.**
+
+---
+
+## 4. The plan-resume "continue" leak — VERIFIED
+
+**Planning-doc claim:** non-web channels may leak a visible "continue" message after approval.
+
+**Verdict: the leak does NOT exist. Claim is false.**
+
+Evidence (`/Volumes/LEXAR/repos/openclaw-pr70071-rebase` @ `ea04ea52c7`):
+
+- `ui/src/ui/chat/plan-resume.ts::resumePendingPlanInteraction()` is the **only** code path that sends a "continue" message. It is imported solely by `ui/src/ui/chat/slash-command-executor.ts` and `app-chat.ts` / `app.ts` — **all webchat UI files**. No server-side / channel code calls it.
+- Even on webchat, that call passes **`deliver: false`** — OpenClaw's documented semantics for a hidden run-resume that is *not* rendered into the chat transcript.
+- Non-web channels resume via `commands-plan.ts` returning **`{ shouldContinue: true }`** — a control-flow signal to the auto-reply pipeline, **not a message**. The `[PLAN_DECISION]` injection is consumed silently at next turn-start (`appendToInjectionQueue` in `sessions-patch.ts`).
+
+**Action for the plugin:** none required for a leak fix. The plugin's `plan.accept` handler already returns `continueAgent: true` (`src/ui/session-actions.ts:241`) — the plugin-equivalent of `shouldContinue: true`, the correct non-web pattern. **S16 must NOT introduce a `chat.send "continue"` call on any channel.** If S16-1/S16-3 ever need an explicit resume, use `continueAgent: true` from the action handler — never an outbound message.
+
+One real adjacent concern (not a leak, but worth a one-line guard in S16-1): when S16-1 dispatches the approval *prompt* on Telegram/Slack, ensure it is sent **once** per `approvalId`. The in-host de-dupes via `lastPlanPayloadHash`; the plugin already has `src/helpers/payload-hash.ts` and `src/runtime/grant-ledger.ts` — reuse the hash to suppress a duplicate prompt if `exit_plan_mode` fires twice for the same payload.
+
+---
+
+## 5. LOC estimate + risks
+
+### LOC (Path A — recommended, shippable now)
+
+| Sub-PR | New file(s) | Est. LOC |
+|---|---|---|
+| S16-1 channel-aware approval prompt renderer | `src/channels/approval-prompt.ts` | 120–150 |
+| S16-2 attachment bridge (optional/deferrable) | `src/channels/plan-attachment-bridge.ts` | 60–90 |
+| S16-3 discoverability + reply-driven reject | extends `approval-prompt.ts` + a hook | 80–100 |
+| **Total (Path A)** | | **~260–340 LOC** |
+
+Path B adds an **upstream host-side PR (S16-U)** of unscoped size + a plugin consumer (S16-B, ~120–180 LOC) — **not estimable** here and **not shippable** in this slice.
+
+### Risks
+
+| # | Risk | Severity | Mitigation |
+|---|---|---|---|
+| R1 | **Seam genuinely missing** — stakeholders may expect literal tappable buttons; Path A delivers a text-command UX instead. | High (expectation) | This spec documents that the *in-host itself never shipped buttons*. Path A reaches in-host parity. Set expectations explicitly; file Path B upstream. |
+| R2 | Slack outbound **attachment / `block_actions`** support via the plugin SDK outbound path is **unverified**. | Medium | S16-2 gates the attachment behind a runtime capability probe; falls back to the inline S16-1 message. Verify `ChannelDeliveryCapabilities` for Slack before S16-2. |
+| R3 | Anchoring S16-1 on the plugin's `exit-plan-mode.ts` tool vs. an event subscription — if a future host emits plan-approval without routing through the plugin tool, the prompt is skipped. | Low | The plugin **owns** `enter/exit_plan_mode` (registered via `registerTool`); the approval always originates from the plugin's own tool. Safe anchor. |
+| R4 | Duplicate approval prompt if `exit_plan_mode` fires twice. | Low | Reuse `src/helpers/payload-hash.ts` to de-dupe (§4). |
+| R5 | Reply-driven reject (S16-3) hook could swallow an unrelated user message. | Medium | One-shot, per-session armed only while `approval === "rejected"`; disarm on any `/plan` command, on consumption, or on new cycle. Mirror the in-host "next message = feedback" convention exactly. |
+| R6 | Authorization — text commands must enforce operator scope on internal channels (the in-host gates `/plan` on `operator.approvals`). | Medium | `/plan` resolution already merged in #93 — confirm its handler carries the auth gate; S16 adds rendering only, inherits #93's auth. |
+
+### Recommendation
+
+Ship **Path A, sub-PRs S16-1 → S16-3** (S16-2 optional, deferrable). This closes the stated gap — "on Telegram/Slack a user cannot approve a plan" — because `/plan accept` resolution already works (#93); S16 makes the approval **visible, discoverable, and well-formatted** on those channels, matching the in-host's actual shipped behavior. File **Path B (S16-U)** as a separate upstream OpenClaw issue/PR; do not block S16 on it.

--- a/docs/audits/parity-refresh/buildspec-S17-webchat-ui.md
+++ b/docs/audits/parity-refresh/buildspec-S17-webchat-ui.md
@@ -1,0 +1,265 @@
+# Build-Spec S17 — Webchat Inline Plan-Mode UI
+
+**Slice**: S17 (webchat inline UI) of the Smarter-Claw parity-refresh.
+**Status**: BUILD-SPEC (not an audit). Validates + refreshes the prior `architecture-v2-planning` effort.
+**Date**: 2026-05-19.
+
+## 0. Premise
+
+The Smarter-Claw plugin currently renders **zero inline webchat UI** — no mode-switcher
+chip, no in-stream plan cards, no approval card above the input bar. Only a sidebar
+descriptor (via `registerControlUiDescriptor`). Target: full webchat parity with the
+in-host plan-mode UI (PR #70071 lineage).
+
+This spec **reuses** the prior arch-v2 analysis rather than starting fresh. The
+authoritative inputs are, on branch `architecture-v2-planning`:
+- `architecture-v2/10-UI_GAP_ANALYSIS.md` — 25-element in-host UI catalog.
+- `architecture-v2/12-PATH_A_DEEP_DIVE.md` — 6-sub-PR build ladder (U1–U6).
+- `architecture-v2/07b-PR_LADDER_v2.md` — Track B (upstream UI) section.
+
+**Key reframing vs arch-v2**: arch-v2's "Path A" lands the UI **in OpenClaw upstream**
+as 6 sub-PRs. S17 is the *plugin-delivered* variant — the same 4 UI files, but rendered
+into Control-UI seam surfaces via a **bundle patcher**, not merged into core. The
+component inventory and LOC estimates carry over; the delivery mechanism does not.
+
+---
+
+## 1. Validation of `10-UI_GAP_ANALYSIS.md`
+
+**Verdict: the 25-element catalog is STILL VALID. Zero structural drift.**
+
+The catalog was built against `openclaw-pr70071-rebase` @ `ea04ea52c7`
+(branch `rebase/pr70071-onto-main-2026-04-25`). I re-verified the in-host UI tree at
+that same tip on `/Volumes/LEXAR/repos/openclaw-pr70071-rebase`:
+
+| Catalog claim | Re-verified | Result |
+|---|---|---|
+| `mode-switcher.ts` 424 LOC | `git show …:ui/src/ui/chat/mode-switcher.ts \| wc -l` → 424 | MATCH |
+| `plan-cards.ts` 122 LOC | → 122 | MATCH |
+| `plan-approval-inline.ts` 306 LOC | → 306 | MATCH |
+| `plan-resume.ts` 21 LOC | → 21 | MATCH |
+| `plan-cards.css` 134 LOC | → 134 | MATCH |
+| `views/chat.ts` 1652 LOC, ~250 plan-mode | 1652 total; 57 lines match plan-mode tokens | MATCH (token-grep proxy) |
+| `SessionEntry.planMode` at `types.ts:452-486` | lines 452 (`planMode?:`), 469 (`lastPlanSteps?:`), 487 (`pendingInteraction?:`) | MATCH |
+
+**Drift assessment — two axes:**
+
+1. **In-host tree drift (catalog tip → `2026.5.18`)**: NOT APPLICABLE in the way it
+   first appears. The catalog's render-surface *classification* (NEEDS_CHAT_STREAM /
+   FITS_SIDEBAR / EITHER_WAY) is an analysis of plan-mode UX semantics, not of a
+   moving source tree. The 4 in-host UI files are frozen at `ea04ea52c7` — that is the
+   port source-of-truth and does not chase upstream. So the catalog needs no refresh
+   for the in-host side.
+
+2. **Host-target drift (`2026.5.10-beta.5` → `2026.5.18`)**: THIS is the real drift,
+   and it lands entirely on the **patcher** (§3), not the catalog. The installed host
+   is now `2026.5.18` (verified: `/opt/homebrew/lib/node_modules/openclaw/package.json`).
+   The catalog's element list is unaffected; only the delivery overlay must be rebuilt.
+
+**One catalog item to re-confirm during build — element #17 (dead code).** The catalog
+flags `renderPlanCard()` as exported-but-never-imported in the in-host build (plan
+progress goes to the sidebar markdown only). For S17 this is an *opportunity*: the
+plugin's `chat-message` surface is exactly the home `renderPlanCard()` was written for.
+S17 should **wire it** (the in-host never did) — see component C2.
+
+**Net**: the 25-element catalog stands. Use it verbatim as the S17 element checklist.
+The NEEDS_CHAT_STREAM(10) / FITS_SIDEBAR(5) / EITHER_WAY(10) split is unchanged.
+
+---
+
+## 2. The 4 UI components
+
+The plugin already ships the FITS_SIDEBAR(5) elements via the sidebar descriptor.
+S17 adds the **NEEDS_CHAT_STREAM(10)** elements, which the in-host packs into 4 files.
+Each maps to one Control-UI seam surface introduced by the chat-stream-seam patcher.
+
+### C1 — Mode-switcher chip (`mode-switcher.ts`, ~424 LOC)
+
+- **Renders**: the Default / Ask / Accept / Plan / Plan⚡ / Bypass pill + dropdown menu
+  + `Ctrl+1..6` keyboard shortcut handler. Catalog elements **#1, #2, #3**.
+- **Surface**: `chat-input-toolbar-chip` — the pill sits in the input toolbar row
+  alongside file-attach + mic (per manifest `surfaceNames[2]`).
+- **Plugin-state read**: session plan-mode shape — `planMode` (`plan`/`normal`),
+  `autoApprove` (drives the ⚡ variant), plus `execSecurity`/`execAsk` for the
+  non-plan modes. Exports verified: `MODE_DEFINITIONS`, `resolveCurrentMode()`,
+  `renderModeSwitcher()`, `handleModeShortcut()`.
+- **Write path**: `sessions.patch { planMode }`. Backend no-ops if plan infra absent.
+- **Port note**: `handleModeShortcut` has a shadow-DOM focus guard (skips `Ctrl+digit`
+  when a composer/contenteditable surface is focused) — preserve it verbatim.
+
+### C2 — Plan-cards (`plan-cards.ts`, ~122 LOC)
+
+- **Renders**: `renderPlanCard()` (in-stream step-checklist card for `update_plan`
+  events) + `formatPlanAsMarkdown()`. Catalog elements **#13** (live checklist render),
+  **#17** (the currently-dead `renderPlanCard`).
+- **Surface**: `chat-message` — informational expandable card in the message stream,
+  same affordance class as tool-call cards (per manifest `surfaceNames[0]`).
+- **Plugin-state read**: `planMode.lastPlanSteps[]` (`{step,status,activeForm,
+  acceptanceCriteria,verifiedCriteria}`) + `lastPlanUpdatedAt`.
+- **Port note**: pure render functions, no state machine — lowest-risk component.
+  Wire `renderPlanCard()` into the `chat-message` surface (the in-host left it dead).
+
+### C3 — Plan-approval-inline card (`plan-approval-inline.ts`, ~306 LOC)
+
+- **Renders**: the Accept / Accept-with-edits / Revise card; the title strip
+  ("Agent proposed a plan — …"); the in-place revise textarea; the AskUserQuestion
+  variant (question + option buttons + "Other…" textarea); the error banner.
+  Catalog elements **#4, #5, #7, #8, #9, #10** — the bulk of NEEDS_CHAT_STREAM.
+- **Surface**: `chat-input-bar` — card renders **above** the chat input bar
+  (per manifest `surfaceNames[1]`).
+- **Plugin-state read**: `planApprovalRequest`, `planApprovalBusy`, `planApprovalError`,
+  `planApprovalReviseOpen`/`reviseDraft`, `planApprovalQuestionOtherOpen`/`otherDraft`,
+  `planApprovalDismissedApprovalIds` (#25, anti-blink set); plus
+  `SessionEntry.pendingInteraction` for the question variant. Exports verified:
+  `InlinePlanApprovalProps`, `renderInlinePlanApproval()`.
+- **Write path**: `sessions.patch { planApproval: … }`.
+- **HARD RISK — element #22 (input-bar suppression)**: in-host *replaces* the composer
+  with the card. A plugin overlaying `chat-input-bar` renders *above* the input but
+  **cannot suppress the host composer**. With a pending approval, the user can still
+  type + Enter → out-of-band chat message. arch-v2 `10-UI_GAP_ANALYSIS.md` calls this
+  a **correctness gap, not cosmetic**. S17 mitigation: render a disabled-state overlay
+  + an explicit "approval pending — submit anyway?" confirm on composer-submit. This
+  does not reach in-host fidelity; flag for Eva. (arch-v2 Path C — a real
+  `registerChatStreamRenderer` SDK seam with `suppressInputWhileVisible` — is the only
+  true fix, and #80982 is that seam in flight.)
+
+### C4 — Plan-resume (`plan-resume.ts`, ~21 LOC)
+
+- **Renders**: nothing — network-only. Catalog element **#21**.
+- **Surface**: none. Ships inside the C3 bundle as a helper.
+- **Behavior**: `resumePendingPlanInteraction()` fires a hidden
+  `client.request("chat.send", { deliver: false, … })` to nudge the agent to resume
+  after approval. Verified at `plan-resume.ts:11-18`.
+- **Port note**: trivial; the only watch-item is `chat.send` idempotency (don't
+  double-fire on re-render).
+
+**Not in S17**: the FITS_SIDEBAR(5) elements (#12 plan-view widget, #14 title,
+#15 archetype sections, #23 auto-open) — already shipped via the sidebar descriptor.
+S17 keeps them; it only *adds* the chat-stream surfaces.
+
+---
+
+## 3. Patcher plan
+
+The plugin delivers webchat UI by **overlaying OpenClaw's compiled control-UI bundle**.
+The existing patcher (`scripts/install-chat-stream-seam.mjs` +
+`patches/openclaw-2026.5.10-beta.5/manifest.json`) cherry-picks upstream PR
+**openclaw/openclaw#80982** to add 3 Control-UI surfaces (`chat-message`,
+`chat-input-bar`, `chat-input-toolbar-chip`) onto `2026.5.10-beta.5`.
+
+**S17 must regenerate the patcher for `2026.5.18`. Three concrete deltas:**
+
+1. **Content-hashed bundle filenames changed.** Verified on the installed host:
+   - manifest expects `dist/loader-DdN5GTsW.js` + `dist/protocol-BBwaRnfZ.js`.
+   - `2026.5.18` ships `dist/loader-CxUWY2_6.js` / `loader-jaFoEHc6.js` and
+     `dist/protocol-B17omF7t.js` / `protocol-CdYy0xVK.js` (multiple — the seam-bearing
+     pair must be identified during regen).
+   The patcher keys on `relativePath` + SHA, so a new
+   `patches/openclaw-2026.5.18/manifest.json` directory is mandatory. The patcher
+   *script* itself needs one change: `MANIFEST_RELDIR` is hard-coded to
+   `patches/openclaw-2026.5.10-beta.5` (line 65) — parameterize it or bump it.
+
+2. **Re-cherry-pick #80982 onto the `2026.5.18` tag**, rebuild the loader + protocol
+   bundles, recompute `baselineSha256` (stock `2026.5.18`) + `patchedSha256`
+   (post-overlay), and write the new manifest. The 4 seam commits are listed in the
+   current manifest's `seamSource.commits`.
+
+3. **`2026.5.18` does NOT already ship the seam.** Verified: no `chat-input-toolbar-chip`
+   / `chat-input-bar` surface strings in `/opt/homebrew/lib/node_modules/openclaw/dist/`.
+   So the patcher is still required — it cannot be dropped yet.
+
+### The #80982 cherry-pick risk — ELEVATED
+
+- **#80982 is still OPEN** (verified `gh pr view 80982 -R openclaw/openclaw`:
+  `state: OPEN`, `mergedAt: null`, `mergeCommit: null`). Last updated 2026-05-12,
+  13 files / +684, **no review decision** recorded.
+- The PR **title has drifted**: the manifest cites it as *"add chat-stream Control UI
+  surfaces"* (a descriptor-surface approach), but the live PR is now
+  *"feat(plugin-sdk): registerChatStreamRenderer for plugin-owned inline UI"* — a
+  **different, larger API shape** (a renderer-registration seam, matching arch-v2's
+  Path C). This means the upstream design moved away from the 3-surface approach the
+  current patcher cherry-picks.
+- **Implication**: the 4 seam commits in the manifest are a *now-stale snapshot* of
+  #80982. When #80982 eventually merges it will likely land the `registerChatStreamRenderer`
+  shape, NOT the 3 named surfaces. S17's patcher will then be overlaying an API that
+  upstream never shipped — a permanent fork the plugin must carry until it re-ports
+  the 4 UI files onto whatever #80982 actually merges.
+- **Recommendation**: treat the cherry-pick snapshot as load-bearing and *pin it*
+  (the manifest already records the 4 commit SHAs — good). Add a tracking note that
+  when #80982 merges, S17's UI files need a re-port onto the merged seam shape, and
+  the patcher gets dropped (per the script's own header comment, lines 19-21).
+
+---
+
+## 4. Implementation sub-PR ladder
+
+S17 is the **plugin-delivered** variant of arch-v2's Track B. arch-v2's U1–U6 land in
+OpenClaw upstream; S17's S17.1–S17.6 land in the **Smarter-Claw repo** and ship the
+*same* 4 UI files into the patched seam surfaces. LOC per component carries over from
+`12-PATH_A_DEEP_DIVE.md` §2.
+
+| Sub-PR | Title | Components | Prod LOC | Test LOC | Depends on |
+|---|---|---|---|---|---|
+| **S17.1** | Patcher regen for `2026.5.18` + manifest | patcher script + new `patches/openclaw-2026.5.18/` | ~120 (manifest + script param) | ~80 (verify-seam) | — |
+| **S17.2** | Mode-switcher chip → `chat-input-toolbar-chip` | C1 | ~424 | ~388 | S17.1 |
+| **S17.3** | Plan-approval-inline card → `chat-input-bar` | C3 | ~306 | ~295 | S17.1, S17.2 |
+| **S17.4** | Plan-cards → `chat-message` + plan-resume | C2, C4 | ~143 (122+21) | ~185 (159+26) | S17.3 |
+| **S17.5** | CSS + input-bar-suppression mitigation | `plan-cards.css` + composer-guard | ~134 + ~80 | ~60 | S17.3 |
+| **S17.6** | Plugin-state wiring + parity smoke | mirror to seam props + harness | ~180 | ~200 | S17.2–S17.5 |
+
+**Totals**: ~1,387 prod LOC + ~1,208 test LOC = **~2,595 LOC across 6 sub-PRs**.
+Aligned with arch-v2's "~2,560 LOC" Track B figure (`07b-PR_LADDER_v2.md` line 24).
+Every sub-PR < 600 LOC — satisfies the AGENTS.md per-PR ceiling and avoids the
+`openclaw-barnacle` / Greptile-100-file bot-closure failure mode that killed PR #71676.
+
+**Ordering rationale**: S17.1 first (the seam must exist before anything renders into
+it). S17.2 (chip) is self-contained. S17.3 (approval card) is the biggest behavioral
+piece + carries the #22 risk. S17.4 is pure-render on top of S17.3's shell. S17.5
+(CSS + mitigation) and S17.6 (wiring + smoke) close it out. S17.4 + S17.5 can land in
+parallel (both depend only on S17.3).
+
+**i18n note**: arch-v2's U6 was a standalone full-locale-sync PR because the in-host
+`ui/CLAUDE.md` forbids hand-editing non-English bundles. For the **plugin-delivered**
+path the plugin owns its own strings — S17 folds i18n into each component sub-PR
+rather than a separate locale-regen PR (no host-locale-pipeline coupling). This is the
+one structural divergence from the arch-v2 ladder.
+
+---
+
+## 5. Risks
+
+| # | Risk | Severity | Mitigation |
+|---|---|---|---|
+| **R1** | **#80982 still OPEN + API shape drifted** to `registerChatStreamRenderer`. The 3-surface cherry-pick is now a stale snapshot of a moving PR. | **HIGH** | Pin the 4 commit SHAs (manifest already does). Accept the patcher as a carried fork. Plan a re-port of the 4 UI files when #80982 merges; drop the patcher then. |
+| **R2** | **Content-hashed bundle names rotate every host release.** `2026.5.10-beta.5` → `2026.5.18` already changed `loader-*` / `protocol-*` hashes. Every host bump re-breaks the patcher. | **HIGH** | New `patches/openclaw-<version>/` manifest per host release. The SHA pre-flight in `install-chat-stream-seam.mjs` (lines 186-218) *correctly refuses to apply on drift* — so this fails safe, but needs a manifest-regen each bump. |
+| **R3** | **Rebuild requirement.** Patcher overlays compiled bundles; the host must be re-patched after any `npm i -g openclaw` upgrade or the seam silently reverts. | **MEDIUM** | Document in install flow; `verify-chat-stream-seam.mjs` checks the sentinel. Consider a postinstall hook. |
+| **R4** | **Input-bar suppression (element #22) is unreachable via patched surfaces** — overlaying `chat-input-bar` cannot disable the host composer. arch-v2 calls this a correctness gap. | **MEDIUM** | S17.5 ships a disabled overlay + submit-confirm. Not full fidelity. True fix = #80982's `suppressInputWhileVisible` (Path C) — gated on R1. |
+| **R5** | **Patcher script hard-codes `MANIFEST_RELDIR`** (line 65) to the beta.5 path — regen alone is insufficient without a script edit. | **LOW** | S17.1 parameterizes the manifest dir (auto-detect installed version → matching manifest). |
+
+### The single biggest risk
+
+**R1 — upstream PR #80982 is OPEN and its API has drifted.** The plugin's entire
+webchat-UI delivery rests on a cherry-pick of #80982's *3-named-surface* design, but
+the live PR is now a `registerChatStreamRenderer` renderer-seam — a different shape.
+S17 can ship today against the pinned snapshot, but the moment #80982 merges (or is
+closed in favor of yet another design) the patcher overlays an API upstream never
+released, forcing a re-port of all 4 UI components. Everything else (hash rotation,
+rebuilds) is mechanical toil; R1 is a moving-target architectural dependency on code
+the Smarter-Claw team does not own.
+
+---
+
+## 6. Files referenced
+
+- `/Users/lume/repos/Smarter-Claw/scripts/install-chat-stream-seam.mjs` — patcher (`MANIFEST_RELDIR` line 65; SHA pre-flight 186-218)
+- `/Users/lume/repos/Smarter-Claw/patches/openclaw-2026.5.10-beta.5/manifest.json` — stale-target manifest (#80982 cherry-pick: `seamSource.commits`)
+- `architecture-v2-planning:architecture-v2/10-UI_GAP_ANALYSIS.md` — 25-element catalog (validated §1)
+- `architecture-v2-planning:architecture-v2/12-PATH_A_DEEP_DIVE.md` — U1–U6 ladder + LOC source
+- `architecture-v2-planning:architecture-v2/07b-PR_LADDER_v2.md` — Track B section
+- `rebase/pr70071-onto-main-2026-04-25:ui/src/ui/chat/mode-switcher.ts` — C1 (424 LOC)
+- `rebase/pr70071-onto-main-2026-04-25:ui/src/ui/chat/plan-cards.ts` — C2 (122 LOC)
+- `rebase/pr70071-onto-main-2026-04-25:ui/src/ui/views/plan-approval-inline.ts` — C3 (306 LOC)
+- `rebase/pr70071-onto-main-2026-04-25:ui/src/ui/chat/plan-resume.ts` — C4 (21 LOC)
+- `rebase/pr70071-onto-main-2026-04-25:ui/src/ui/types.ts:452-486` — `SessionEntry.planMode` shape
+- (in-host source: `/Volumes/LEXAR/repos/openclaw-pr70071-rebase`, branch `rebase/pr70071-onto-main-2026-04-25`, tip `ea04ea52c7`)
+- `/opt/homebrew/lib/node_modules/openclaw` — installed host `2026.5.18` (patch target)

--- a/docs/audits/parity-refresh/buildspec-S18-S9-commands-ui.md
+++ b/docs/audits/parity-refresh/buildspec-S18-S9-commands-ui.md
@@ -1,0 +1,226 @@
+# Build-spec S18 + Parity audit S9 — per-channel `/plan` routing & UI surfaces
+
+**Date:** 2026-05-19
+**Plugin:** Smarter-Claw (OpenClaw plan-mode plugin)
+**Host SDK:** `openclaw` `2026.5.18` (npm, `node_modules/openclaw/dist`)
+**In-host reference:** `/Users/lume/repos/openclaw-pr70071-rebase` @ `ea04ea52c7` (worktree on `test-env/beta4-base`; plan-mode files present at that commit)
+
+Scope:
+
+- **Part 1 — S18 build-spec:** does `/plan` / `/plan-mode` actually work on every channel (webchat / Telegram / Slack)?
+- **Part 2 — S9 audit:** parity of `src/ui/sidebar-descriptor.ts`, `src/ui/session-actions.ts`, `src/ui/sweep-command.ts`.
+
+---
+
+# Part 1 — S18 build-spec: per-channel `/plan` command routing
+
+## 1.1 Verdict (TL;DR)
+
+**`/plan` works on webchat: YES. On Telegram: YES, with one real silent-failure risk (the 100-command limit). On Slack: UNKNOWN — almost certainly works via the universal text path, but cannot be confirmed because `@openclaw/slack` is not installed in this plugin's `node_modules`.**
+
+The plugin's `slash-commands.ts` header claim — *"Registered without a `channels` filter → available on every channel surface (webchat, Telegram, Slack, etc.)"* — is **substantially correct but for the wrong reason**, and it papers over the Telegram limit. The reason `/plan` is universal is **not** the absence of a `channels` filter; it is that `api.registerCommand` commands are dispatched by the host's **auto-reply text-command pipeline** (`handlePluginCommand`, the first handler in `loadCommandHandlers()`), which runs on every channel that routes inbound text through auto-reply. The `channels` filter only *narrows* that universal default.
+
+## 1.2 How OpenClaw 2026.5.18 routes `registerCommand` commands
+
+There are **TWO independent dispatch paths** for a plugin-registered command. This is the single most important fact for S18.
+
+### Path A — universal auto-reply text pipeline (the one that makes `/plan` work everywhere)
+
+`dist/commands-handlers.runtime-DiUdB82z.js`:
+
+- `loadCommandHandlers()` (line 6132) returns a handler array whose **first entry is `handlePluginCommand`**.
+- `handlePluginCommand` (line 4502) calls `matchPluginCommand(command.commandBodyNormalized, { channel: command.channel })` then `executePluginCommand({ ..., sessionKey: params.sessionKey, ... })`.
+- This handler chain runs inside `get-reply` (`dist/get-reply-CXtCkTsR.js`) — the auto-reply core used by **every** channel, webchat included. `sessionKey` is in scope there and is threaded through (`get-reply` lines 221, 4517).
+
+Gating: `shouldHandleTextCommands` (`dist/commands-text-routing-CDXX9zWn.js`):
+
+```js
+function shouldHandleTextCommands(params) {
+  if (params.commandSource === "native") return true;
+  if (params.cfg.commands?.text !== false) return true;     // <-- default ON
+  return !isNativeCommandSurface(params.surface);
+}
+```
+
+`cfg.commands.text` defaults to `undefined` → `!== false` → **`true`**. So body-text command dispatch is **enabled on every channel by default**. A user typing `/plan accept` as a normal message gets matched here, on webchat, Telegram, Slack, Discord, CLI — identically.
+
+This is exactly how the in-host shipped it. The in-host `handlePlanCommand` was a dedicated built-in handler in the *same* `loadCommandHandlers()` chain (`src/auto-reply/reply/commands-handlers.runtime.ts`), with the comment: *"PR-11: universal /plan slash commands work on every channel (Telegram, Discord, Signal, iMessage, Slack, CLI)."* The plugin's `/plan` rides the generic `handlePluginCommand` slot instead of a bespoke handler — **functionally equivalent universality**.
+
+### Path B — native slash-command surface (the menu / `bot.command()` registration)
+
+This is the Telegram "/" autocomplete menu and Telegram's per-command runtime handler. `dist/command-specs-B-5P366Q.js`:
+
+```js
+function getPluginCommandSpecs(provider, options) {
+  ...
+  if (providerName && (getLoadedChannelPlugin(providerName)?.commands ?? commandDefaults)
+        ?.nativeCommandsAutoEnabled !== true) return [];      // <-- gate
+  return listProviderPluginCommandSpecs(provider);
+}
+```
+
+A plugin command appears on a channel's **native** surface only if that channel plugin sets `nativeCommandsAutoEnabled: true`.
+
+- Telegram: `dist/channel.setup-DOFx9Q1W.js:972` → `nativeCommandsAutoEnabled: true`. **Telegram opts in.**
+- Discord: `dist/shared-CnbIV8Bu.js:133` → `nativeCommandsAutoEnabled: true`.
+- Slack: external plugin `@openclaw/slack` — **not installed here**, value unknown.
+
+`listProviderPluginCommandSpecs` filters via `pluginCommandSupportsChannel(cmd, provider)` which (`dist/types-BaOU_7l0.js:330`) returns `true` whenever `command.channels` is empty/absent. So `/plan` (no `channels`) **is** eligible for every native surface.
+
+### Effect of the type's other fields
+
+`OpenClawPluginCommandDefinition` (`dist/plugin-sdk/src/plugins/types.d.ts:1601`):
+
+| Field | Plugin `/plan` sets it? | Effect if omitted |
+|---|---|---|
+| `channels?: readonly string[]` | **No** | Command available on every channel (correct intent). |
+| `nativeNames?: { default?, <provider>? }` | **No** | Native menu uses the bare `name` (`/plan`). No native alias needed — `/plan` is already a valid Telegram command name (`a-z0-9_`, ≤32 chars). **Not a defect.** |
+| `acceptsArgs?: boolean` | **Yes — `true`** | **Load-bearing.** `matchPluginCommand` (`dist/commands-BdI3fczN.js:37`): `if (args && !command.acceptsArgs) return null`. Without `acceptsArgs: true`, `/plan accept` (anything with args) would silently fail to match on **both** paths. The plugin sets it correctly. |
+| `requireAuth?: boolean` | **No** (defaults `true`) | `executePluginCommand` (`commands-BdI3fczN.js:83`) blocks unauthorized senders. Plan-mode controls *should* be operator-gated, so the `true` default is correct. Worth an explicit note (see §1.5). |
+| `requiredScopes?: OperatorScope[]` | **No** | No gateway-scope gate. Fine — chat-surface command owners would satisfy it anyway. |
+
+**Conclusion on routing:** the plugin's "no `channels` filter" is the right choice. `/plan` reaches every channel via Path A unconditionally, and additionally shows in the Telegram native menu via Path B — *unless the menu is full*.
+
+## 1.3 THE Telegram 100-command-limit risk (the reported "doesn't work on Telegram")
+
+`dist/bot-deps-CiCNa5m4.js`:
+
+```js
+const TELEGRAM_MAX_COMMANDS = 100;
+...
+fitTelegramCommandsWithinTextBudget(allCommands.slice(0, maxCommands), maxTotalChars)
+```
+
+`dist/bot-BRuINTsq.js:731` builds the menu list as:
+
+```js
+allCommands: [
+  ...nativeCommands.map(...),     // host built-ins FIRST
+  ...nativeEnabled ? pluginCatalog.commands : [],   // plugin commands SECOND
+  ...customCommands               // operator custom commands THIRD
+]
+```
+
+then `buildCappedTelegramMenuCommands` does `allCommands.slice(0, 100)` — **keeps the first 100, drops the rest**, and logs:
+
+> `Telegram limits bots to 100 commands. 122 configured; registering first 100…`
+
+The gateway log the user already observed (*"telegram limits bots to 100 commands; 122 configured; registering first 100"*) is this exact path firing.
+
+**Risk analysis — split into the two paths:**
+
+| Path | Affected by the 100-cap? | Consequence |
+|---|---|---|
+| **B — native menu (`setMyCommands`)** | **YES.** Plugin commands are appended *after* all host `nativeCommands`. With 122 configured, the last 22 are dropped. `/plan` + `/plan-mode` are 2 plugin commands sitting in that tail region. | If `/plan` falls past slot 100, it **disappears from Telegram's "/" autocomplete menu**. The user types `/pl…` and sees nothing — looks broken. |
+| **B — native runtime handler (`bot.command()`)** | **NO.** `dist/bot-BRuINTsq.js:1064` registers `bot.command()` for **`pluginCatalog.commands`** (the *uncapped* plugin list from `buildPluginTelegramMenuCommands`), not the capped `commandsToRegister`. | The handler is still wired even past slot 100. A user who *types `/plan accept` anyway* still hits a working handler. |
+| **A — universal text pipeline** | **NO.** Independent of the menu entirely. | `/plan accept` as a plain message always works on Telegram. |
+
+**Net:** even in the worst case, `/plan` is not *broken* on Telegram — it is **invisible** (no autocomplete entry, no menu hint). Users who don't memorize the command, or who rely on the "/" menu to discover it, will report "it doesn't work on Telegram." That is the most plausible match for the user's report. The functionality (Path A) survives; the **discoverability** does not.
+
+A secondary, harder failure: Telegram can reject the whole `setMyCommands` payload with `BOT_COMMANDS_TOO_MUCH` (`isBotCommandsTooMuchError`, `bot-deps` line 110) if even the capped+budgeted set is too large; the retry path (`formatTelegramCommandRetrySuccessLog`) drops more commands. Under that path `/plan` is even more likely to be cut.
+
+## 1.4 `PluginCommandContext.sessionKey` per channel
+
+`/plan` needs `sessionKey` — `dispatchAction` and `handleEnter` in `slash-commands.ts` both bail with a user-facing error if `ctx.sessionKey` is falsy.
+
+`PluginCommandContext` (`types.d.ts:1539`) declares `sessionKey?: string` — **optional**. Whether it is populated depends on the caller:
+
+- **Webchat (Path A):** `get-reply` resolves `sessionKey` for the active conversation and threads it into `handlePluginCommand` → `executePluginCommand({ sessionKey: params.sessionKey })`. **Present.**
+- **Telegram native (Path B):** `bot-BRuINTsq.js:1147` calls `executePluginCommand({ ..., sessionKey: route.sessionKey, ... })` where `route` comes from `resolveCommandRuntimeContext` (a Telegram conversation→agent route resolution, line 1103). **Present** for any chat bound to an agent route.
+- **Telegram text (Path A):** same `get-reply` pipeline as webchat; the Telegram inbound message resolves a route → `sessionKey`. **Present.**
+- **Slack:** **UNKNOWN** — `@openclaw/slack` not installed. Slack channel plugins that resolve an agent route per conversation will supply `sessionKey` identically; the SDK type permits it. No reason to expect otherwise, but it is unverified.
+
+Edge case worth a regression test: a `/plan` issued from a Telegram chat that is **not** bound to any agent route (e.g. a brand-new group before activation) — `route.sessionKey` could be empty, and `/plan` would correctly return its "requires a session context" reply. That is graceful, not a crash. **Not a defect**, but document it.
+
+## 1.5 S18 findings
+
+| # | Finding | Class | Sev |
+|---|---|---|---|
+| S18-1 | **Telegram native-menu drop.** With >100 total Telegram commands, `/plan` + `/plan-mode` (plugin commands, appended after host built-ins) can be sliced off the `setMyCommands` menu. Functionality survives via the universal text pipeline + the uncapped `bot.command()` handler, but the command vanishes from "/" autocomplete → users perceive it as broken on Telegram. This is the most likely cause of the reported "doesn't work on Telegram." | parity-gap | **P1** |
+| S18-2 | **Misleading header rationale.** `slash-commands.ts` lines 38-41 attribute universality to the *absence of a `channels` filter*. The real mechanism is the auto-reply `handlePluginCommand` text pipeline. The comment also makes no mention of the Telegram menu cap. Misleads future maintainers into thinking native-menu presence is guaranteed. | parity-gap | P2 |
+| S18-3 | **Slack unverified.** `@openclaw/slack` is not in `node_modules`; native-menu behavior + `sessionKey` population on Slack cannot be confirmed from this tree. Universal text path (A) almost certainly works, but S9/S18 "works on Slack" is **unverified**, not "yes." | test-gap | P2 |
+| S18-4 | **No native discoverability fallback.** Because `/plan` is two registrations (`plan`, `plan-mode`), it consumes *two* of the scarce native-menu slots, doubling the chance one is dropped, and offers no `agentPromptGuidance` so the agent can't tell the user "type /plan accept" when the menu entry is missing. | missing-feature | P2 |
+| S18-5 | **`acceptsArgs: true` is correct and load-bearing** — verified against `matchPluginCommand` (`commands-BdI3fczN.js:37`). No action; recorded so a future refactor does not drop it. | (ok) | — |
+
+## 1.6 S18 fix / build plan
+
+**Goal:** keep `/plan` reliably reachable and discoverable on Telegram, and make the Slack story verified rather than assumed.
+
+### Build step 1 — guarantee Telegram menu presence (addresses S18-1, P1)
+
+The cap keeps the *first* 100; host built-ins are always first; plugin commands are appended. The plugin cannot reorder the host's array. Three viable mitigations, in preference order:
+
+1. **(Recommended) Collapse two commands into one.** Drop the separate `/plan-mode` *native* registration; keep `/plan-mode` only as a text-pipeline alias (Path A) or document it as removed. This halves native-slot consumption (2 → 1) and the surviving `/plan` is the canonical surface. Implementation: still call `api.registerCommand` for both, **but give `plan-mode` a `channels` filter that excludes `telegram`** so it never enters `getPluginCommandSpecs("telegram")` — Path A still serves it on Telegram via text. Net: one Telegram menu slot, both commands still typeable everywhere.
+2. **Add `agentPromptGuidance`** to the `/plan` definition (e.g. `["When plan mode is available, the user can type /plan accept | reject | edit <body> | cancel directly in chat."]`). The host injects this into the agent's system prompt (`listRegisteredPluginAgentPromptGuidance`), so even with no menu entry the agent can tell the user how to invoke it. Cheap, channel-agnostic, addresses S18-4.
+3. **Document the operator escape hatch.** If a deployment genuinely runs >100 Telegram commands, the operator can set `channels.telegram.commands.native: false` (mentioned verbatim in the host's overflow log) — that disables the native menu entirely and forces *all* commands onto the text pipeline, where `/plan` always works. Add this to the plan-mode operator runbook.
+
+### Build step 2 — correct the header (addresses S18-2, P2)
+
+Rewrite `slash-commands.ts` lines 37-44 to state the real mechanism:
+
+> `/plan` is dispatched by the host's auto-reply text-command pipeline (`handlePluginCommand`), which runs on every channel that routes inbound text — webchat, Telegram, Slack, Discord, CLI. The absence of a `channels` filter keeps it eligible for every channel's *native* command menu as well. NOTE: on Telegram the native menu is capped at 100 commands; if a deployment exceeds that, `/plan` may drop off the "/" autocomplete menu — it still works when typed, and `agentPromptGuidance` tells the agent how to prompt the user.
+
+### Build step 3 — Slack verification (addresses S18-3, P2)
+
+Add a CI/parity-harness step that installs `@openclaw/slack`, registers the plugin, and asserts (a) `getPluginCommandSpecs("slack")` includes `plan` (or that Slack lacks `nativeCommandsAutoEnabled` — either way, record the truth), and (b) a synthetic Slack inbound `/plan status` reaches `handlePluginCommand` with a non-empty `sessionKey`. Until then, S18/S9 status for Slack is "unverified," not "yes."
+
+### Build step 4 — regression tests
+
+- `matchPluginCommand("/plan accept", { channel: "telegram" })` → matches (guards `acceptsArgs`).
+- `buildCappedTelegramMenuCommands` with 121 host commands + `plan` appended → assert `plan` is dropped, proving S18-1 is real and that step-1 mitigation (≤1 plugin slot) keeps it in.
+- `handlePluginCommand` with `sessionKey: undefined` → `/plan accept` returns the graceful "requires a session context" reply, **not** a thrown error.
+
+---
+
+# Part 2 — S9 parity audit: UI surfaces
+
+**In-host reality check (important framing):** at `ea04ea52c7` the in-host has **no** `registerControlUiDescriptor` call and **no** `session sweep --plan-mode-clear` CLI flag (`git grep` for `plan-mode-clear`, `registerControlUiDescriptor`, `sweep` under `src/cli/**` and `src/agents/plan-mode/**` all return nothing). The in-host plan-mode UI lived in webchat chip + approval-card surfaces driven by `sessions.patch`. Therefore:
+
+- `sidebar-descriptor.ts` is a **plugin-specific construct** — there is no in-host sidebar to be at parity *with*. The audit target is *internal consistency* (does the declared schema match the plugin's own `PlanModeSessionState`?), not host parity.
+- `sweep-command.ts`'s `host_ref` (`openclaw session sweep --plan-mode-clear`) **does not exist in-host**. The file's own comment hedges this ("referenced in P-12's spec"). The command is a net-new plugin operator tool, not a port.
+- `session-actions.ts` *does* have a real in-host parity target: `resolvePlanApproval` (`src/agents/plan-mode/approval.ts:44-130`).
+
+## 2.1 Findings table
+
+| # | File | Finding | Class | Sev |
+|---|---|---|---|---|
+| S9-1 | `sidebar-descriptor.ts` | **Schema omits 5 real state fields.** The descriptor `schema.properties` declares `mode, approval, rejectionCount, approvalId, title, feedback, lastPlanSteps, autoApprove, __schemaVersion`. The actual payload (`types.ts` `PlanModeSessionState`, produced by `state/store.ts`) also carries **`enteredAt`, `confirmedAt`, `updatedAt`, `approvalRunId`, `lastPlanPayloadHash`**. `store.ts` demonstrably writes `enteredAt`/`updatedAt` (lines 349-350, 419, 657-674). A UI client doing strict schema validation against this descriptor would reject or silently drop those fields. The descriptor undersells the contract. | parity-gap | **P1** |
+| S9-2 | `session-actions.ts` | **Terminal-state semantics diverge from the in-host on the `rejected` state.** In-host `resolvePlanApproval` (approval.ts:83) allows `approve`/`edit`/`reject` when `approval === "pending"` **OR `"rejected"`** — `rejected` is explicitly *non-terminal*, kept open for re-approval/re-rejection. The plugin's `checkApprovalId` (session-actions.ts:174-182) rejects with `NO_PENDING_APPROVAL` whenever `approval !== "pending"`. So `plan.accept`/`plan.reject` on a *rejected* plan that was never re-proposed fails in the plugin but succeeds in-host. In practice the agent normally re-fires `exit_plan_mode` (→ `pending`) after a rejection, masking this — but an operator clicking Approve on a still-`rejected` card hits the divergence. | parity-gap | **P1** |
+| S9-3 | `sweep-command.ts` | **`host_ref` cites a non-existent in-host command.** `openclaw session sweep --plan-mode-clear` does not exist at `ea04ea52c7`. The command is fine as a plugin-only tool, but the `host_ref:` line (and the "In-host parity" section) imply a port that cannot be verified. Reclassify the comment as "plugin-specific operator tool; no in-host equivalent." | parity-gap | P2 |
+| S9-4 | `sidebar-descriptor.ts` | **`lastPlanSteps.items` is loosely typed vs. the producer.** Schema sets `status: { type: "string" }` with no `enum`; the plugin's `PlanStep.status` is a free `string` so this is *technically* consistent, but the in-host normalizes status to a known enum set. `activeForm` is correctly optional. Minor — tighten only if a client needs the enum. | test-gap | P2 |
+| S9-5 | `session-actions.ts` | **`plan.answer` is registered but unreachable from any user surface.** The 6th action exists and is correct, but `slash-commands.ts` deliberately does not wire `/plan answer` (no plugin-side question-state), and the sidebar descriptor exposes no question fields (`questionId`/`questionPrompt` absent from schema). So `plan.answer` can only be invoked by a UI client that already knows a `questionId` out-of-band — which nothing in this plugin provides. The action is effectively dead until question-state tracking lands. Known/tracked, but call it out as a coverage hole. | missing-feature | P2 |
+| S9-6 | `sweep-command.ts` | **No `--all-sessions` and no list seam** — acknowledged in the file header as an SDK-gap deferral. Single-session sweep is the shipped scope. Correct for now; recorded so it is not mistaken for complete. | missing-feature | P2 |
+| S9-7 | `session-actions.ts` | **`continueAgent` semantics are correct and match intent** — `plan.accept`/`edit`/`reject` set `continueAgent: true` (agent resumes/revises), `plan.cancel` sets `false` (user-driven next turn). Consistent with the in-host injection model. No action. | (ok) | — |
+| S9-8 | `sidebar-descriptor.ts` | **`requiredScopes: []` (empty) on a state-*read* surface is acceptable** — the comment correctly notes mutation gating happens in the action handlers. No defect; the empty array is intentional and documented. | (ok) | — |
+
+## 2.2 Severity roll-up
+
+- **P0: 0**
+- **P1: 2** — S9-1 (sidebar schema omits 5 fields), S9-2 (rejected-state terminal-guard divergence).
+- **P2: 4** — S9-3, S9-4, S9-5, S9-6.
+- Plus 2 OK confirmations (S9-7, S9-8).
+
+**Worst finding: S9-2** — the `session-actions.ts` terminal-state divergence is the highest-impact because it is a *behavioral* parity break in the approval state machine (the most load-bearing surface in the plugin), not just a descriptor/metadata mismatch. S9-1 is tied on severity but is a contract-completeness issue (UI clients), not a wrong-behavior issue.
+
+## 2.3 S9 fix plan
+
+1. **S9-1:** add `enteredAt`, `confirmedAt`, `updatedAt`, `approvalRunId`, `lastPlanPayloadHash` to `sidebar-descriptor.ts` `schema.properties` (all `{ type: "integer" }` for the timestamps, `{ type: "string" }` for the two ids/hashes). Keep them optional (not in `required`). The schema should mirror `PlanModeSessionState` field-for-field; consider generating it from the type to prevent future drift.
+2. **S9-2:** decide intentionally. Either (a) restore in-host parity — extend `checkApprovalId` to accept `approval === "pending" || approval === "rejected"`, matching `resolvePlanApproval`'s non-terminal `rejected` — or (b) document the plugin's stricter rule (rejected plans must be re-proposed before any action) as a deliberate divergence with a `host_ref` note explaining why. Option (a) is the lower-surprise choice and matches the cited parity contract in the file header.
+3. **S9-3:** rewrite the `sweep-command.ts` `host_ref:` line and "In-host parity" section to state plainly that there is no in-host equivalent; it is a plugin-native operator tool.
+4. **S9-5:** either wire a minimal `/plan answer` once question-state exists, or add `questionId`/`questionPrompt` to the sidebar schema so a UI client *can* drive `plan.answer` — currently neither surface can.
+5. **S9-4 / S9-6:** no code change required; keep as recorded known-limitations.
+
+---
+
+# Appendix — key host evidence paths
+
+- `dist/commands-handlers.runtime-DiUdB82z.js:6132` — `loadCommandHandlers()`, `handlePluginCommand` first.
+- `dist/commands-handlers.runtime-DiUdB82z.js:4502` — `handlePluginCommand` (universal text dispatch, passes `sessionKey`).
+- `dist/commands-text-routing-CDXX9zWn.js:21` — `shouldHandleTextCommands` (text commands default ON).
+- `dist/commands-BdI3fczN.js:25,77` — `matchPluginCommand` (line 37 `acceptsArgs` guard) / `executePluginCommand`.
+- `dist/command-specs-B-5P366Q.js:15` — `getPluginCommandSpecs` (`nativeCommandsAutoEnabled` gate).
+- `dist/types-BaOU_7l0.js:330` — `pluginCommandSupportsChannel` (empty `channels` → true).
+- `dist/bot-deps-CiCNa5m4.js:43` — `TELEGRAM_MAX_COMMANDS = 100`; `buildCappedTelegramMenuCommands` `slice(0,100)`.
+- `dist/bot-BRuINTsq.js:731` — Telegram menu list ordering (host built-ins, then plugin, then custom); `:748` overflow log; `:1064` uncapped `bot.command()` handler registration; `:1147` `sessionKey: route.sessionKey`.
+- `dist/channel.setup-DOFx9Q1W.js:972` — Telegram `nativeCommandsAutoEnabled: true`.
+- In-host `openclaw-pr70071-rebase@ea04ea52c7`: `src/auto-reply/reply/commands-plan.ts` (universal `/plan`), `src/auto-reply/reply/commands-handlers.runtime.ts:38-70` (handler chain), `src/agents/plan-mode/approval.ts:44-130` (`resolvePlanApproval` terminal-state guard), `src/config/sessions/types.ts:274-385` (`planMode` session-entry shape).

--- a/docs/audits/parity-refresh/slice-audit-A-tools.md
+++ b/docs/audits/parity-refresh/slice-audit-A-tools.md
@@ -1,0 +1,105 @@
+# Parity Refresh — Slice Audit A: tools cluster
+
+**Auditor**: parity-refresh adversarial diff (tools cluster)
+**Date**: 2026-05-19
+**Scope**: slices S1 (enter/exit tools) + part of S5 (ask_user_question, auto-enable)
+**In-host source-of-truth**: branch `rebase/pr70071-onto-main-2026-04-25` @ `ea04ea52c7`
+in `/Volumes/LEXAR/repos/openclaw-pr70071-rebase`.
+**Post-surgical context**: PR #87 re-ported S1 (enter/exit), PR #88 touched S5 (auto-enable).
+
+---
+
+## Per-file verdict
+
+| Plugin file | In-host counterpart | Verdict |
+|---|---|---|
+| `src/tools/enter-plan-mode.ts` | `src/agents/tools/enter-plan-mode-tool.ts` | **clean** (sound thick-tool adaptation) |
+| `src/tools/exit-plan-mode.ts` | `src/agents/tools/exit-plan-mode-tool.ts` | **drift** — see A1, A2, A6 |
+| `src/tools/ask-user-question.ts` | `src/agents/tools/ask-user-question-tool.ts` | **regressed** — description not re-ported (A3) |
+| `src/tools/common.ts` | `src/agents/tools/common.ts` | **drift** — no snake_case aliasing (A4) |
+| `src/plan-mode/tool-descriptions.ts` | `src/agents/tool-description-presets.ts` | **clean** (byte-identical, but untested — A7) |
+| `src/plan-mode/auto-enable.ts` | `src/agents/plan-mode/auto-enable.ts` | **regressed** — byte-identical helper but never wired (A5) |
+
+**Severity counts**: P0 = 0, P1 = 3 (A1, A3, A5), P2 = 4 (A2, A4, A6, A7).
+
+---
+
+## Detailed analysis
+
+### enter-plan-mode.ts — CLEAN
+
+Description via `describeEnterPlanModeTool()` is byte-identical to in-host (verified
+char-for-char incl. TOOL LIFECYCLE block + reference-card pointer). `TOOL_OUTPUT_TEXT`
+is byte-identical to the in-host inline `text` array. Schema (`reason?` +
+`additionalProperties:false`) matches. The thick-tool adaptation (tool body calls
+`store.enterPlanMode()` vs in-host runner-intercept) is documented in the header and
+sound. `no-session` / `failed` soft-error paths are a plugin-only addition with no
+in-host equivalent — justified (plugin has no runner to catch a thrown error). The
+`displaySummary` omission is documented (SDK tool shape surfaces only `label` +
+`description`); constant still exported for parity. No findings.
+
+### exit-plan-mode.ts — DRIFT
+
+Schema (title, plan, summary, 5 archetype fields) byte-identical to in-host incl. every
+field `description`. `readPlanSteps` + `readPlanArchetypeFields` are line-faithful ports.
+Title-required guard + 80-char clamp present and correctly ordered (title check BEFORE
+plan validation — matches in-host). Findings A1/A2/A6 below.
+
+### ask-user-question.ts — REGRESSED
+
+Schema is byte-identical to in-host (incl. `additionalProperties:false`). Validation
+logic (2-6 options, dedupe, trim/filter, deterministic `questionId`) is a faithful port.
+**But the tool description was NOT re-ported** — see A3. This is the exact drift class
+S1 fixed for enter/exit; S5's surgical PR #88 missed `ask_user_question`'s description.
+
+### common.ts — DRIFT
+
+`ToolInputError` + `readStringParam` are functionally close. The plugin version is a
+hand-rewrite, not a copy: it lacks the `status: 400` field, the function overloads, the
+`trim`/`allowEmpty` options, and (most importantly) snake_case param aliasing — see A4.
+
+### tool-descriptions.ts — CLEAN (untested)
+
+Byte-identical port of `describeEnterPlanModeTool` / `describeExitPlanModeTool` +
+3 display-summary constants. Diff against in-host `tool-description-presets.ts` is empty.
+Note: in-host also has `describeAskUserQuestionTool` — the plugin chose NOT to port it
+into this file (root cause of A3). Test gap A7.
+
+### auto-enable.ts — REGRESSED (dead code)
+
+`evaluateAutoEnableForMatch` + `compilePattern` + cache are byte-identical to in-host.
+**But the function is never called anywhere in `src/`** (grep: only self-references in
+the file's own doc comments). In-host wires it into `src/cron/isolated-agent/run.ts:580-605`.
+The plugin port restored the helper but not the wiring — see A5.
+
+---
+
+## Findings
+
+| id | severity | type | plugin loc | in-host loc | description | suggested fix |
+|---|---|---|---|---|---|---|
+| **A1** | P1 | parity-gap | `src/tools/exit-plan-mode.ts:321-364` | `src/agents/tools/exit-plan-mode-tool.ts:~205-280` | **Subagent-completion gate not ported.** In-host `exit_plan_mode` hard-blocks plan submission while spawned subagents are still in flight (throws `ToolInputError` listing pending child run ids) AND enforces a `SUBAGENT_SETTLE_GRACE_MS` settle window after the last subagent returns. The plugin tool body has neither check. The plugin header documents skipping the subagent-gate "depends on host-internal `getAgentRunContext`; the gateway-side gate at sessions-patch.ts remains authoritative" — but the plugin has no gateway-side `sessions-patch.ts` either, so for the plugin there is **no** subagent gate at all. The exit_plan_mode tool *description* still tells the model "the runtime rejects submission with an error listing pending child run ids" (tool-descriptions.ts:76) — a promise the plugin runtime does not keep. Either a real gate must exist or the description over-promises. | Decide: (a) if the plugin genuinely cannot track subagents, soften the `WAIT FOR SPAWNED SUBAGENTS` description clause to drop "the runtime rejects submission…" (it is now a false statement); OR (b) port a plugin-side equivalent gate keyed on whatever subagent-tracking the plugin SDK exposes. Document the decision in the file header — the current header asserts a gateway gate that does not exist in the plugin. |
+| **A2** | P2 | parity-gap | `src/tools/exit-plan-mode.ts:438-451` | `src/agents/tools/exit-plan-mode-tool.ts` (`logPlanModeDebug` calls) | **Plan-mode debug-log events not emitted.** In-host `exit_plan_mode` emits two structured debug events (`gate_decision` and `tool_call` with `{title, stepCount, payloadHash}`) via `logPlanModeDebug` + an always-on `agents/exit-plan-gate` subsystem logger. The plugin emits none. Watcher-style log tailers that correlate "plan submitted" with "approval landed" (an Eva live-test workflow) lose this signal in the plugin. | If the plugin has a debug-log sink (check `src/agents/plan-mode/plan-mode-debug-log.ts` analog), emit at least the `tool_call` event on persist. If no sink exists, note the gap explicitly in the file header as a deliberate adaptation rather than leaving it silent. |
+| **A3** | P1 | parity-gap | `src/tools/ask-user-question.ts:70-77` | `src/agents/tool-description-presets.ts` `describeAskUserQuestionTool()` | **`ask_user_question` description is a paraphrase, not the in-host string.** The plugin uses a hardcoded ~70-word `TOOL_DESCRIPTION`. The in-host `describeAskUserQuestionTool()` is a 7-clause structured description that additionally carries: (1) the runtime-pauses-your-run behavior, (2) Control-UI-vs-`/plan answer` channel detail, (3) an explicit **USE FOR** list (product/scope/design/priority tradeoffs), (4) an explicit **DO NOT USE FOR** list (things you could grep/read/web_search, AGENTS.md defaults, confirmation requests), (5) the `allowFreetext` pointer. This is the same drift class Wave-1 S1 found for enter/exit — PR #88 re-ported S5's `auto-enable` but missed this description. The plugin's `host_ref:` cites `ask-user-question-tool.ts` but the description does not match it. | Add `describeAskUserQuestionTool()` to `src/plan-mode/tool-descriptions.ts` as a byte-identical port of the in-host preset, export `ASK_USER_QUESTION_TOOL_DISPLAY_SUMMARY` alongside the other two summaries, and have `ask-user-question.ts` import + use it (deleting the local `TOOL_DESCRIPTION`). Mirrors exactly how enter/exit already work. |
+| **A4** | P2 | bug | `src/tools/common.ts:27-53` | `src/agents/tools/common.ts:88-120` + `src/param-key.ts` | **`readStringParam` drops snake_case param aliasing.** In-host `readStringParam` reads via `readSnakeCaseParamRaw`, so a tool arg declared `activeForm` is also accepted as `active_form` (and `allowFreetext`↔`allow_freetext`). The plugin's `readStringParam` reads `params[key]` verbatim — no aliasing. A model (or replayed transcript) that emits snake_case keys silently loses those values in the plugin where in-host would accept them. Lower severity because the typebox schema declares camelCase and the SDK normally round-trips the declared casing, but it is a genuine silent behavioral divergence vs the cited `host_ref`. | Either port `param-key.ts`'s `readSnakeCaseParamRaw` and route `readStringParam` through it (full parity), OR update the `common.ts` `host_ref:` comment to explicitly state snake_case aliasing is intentionally dropped and why. Do not leave the citation implying parity it does not have. |
+| **A5** | P1 | parity-gap | `src/plan-mode/auto-enable.ts` (whole file) | `src/cron/isolated-agent/run.ts:580-605` | **`evaluateAutoEnableForMatch` is exported but never called — dead code.** The helper is a byte-identical port, but no plugin code invokes it. In-host wires it into the cron isolated-agent path: when `planMode.enabled` is true, `sessionEntry.planMode` is `undefined` (never toggled), and `autoEnableFor` is non-empty, a matching model auto-flips the session into `mode:"plan"` before the turn. The plugin's file header itself claims "this helper restores that capability" and that the `before_prompt_build` hook is the seam — but the hook does not call it. Net effect: a configured `agents.defaults.planMode.autoEnableFor` does nothing in the plugin. | Wire `evaluateAutoEnableForMatch` into the plugin's session-start / `before_prompt_build` seam: read `planMode.autoEnableFor` from config, resolve the session's model id, and if it matches AND the session has no existing plan-mode state, call `store.enterPlanMode()`. Match the in-host guard precisely — do NOT auto-enable when plan-mode state exists with `mode:"normal"` (user explicitly turned it off). Add an integration test. |
+| **A6** | P2 | test-gap | `src/tools/exit-plan-mode.ts:429-430` | `src/agents/tools/exit-plan-mode-tool.ts` (`headlineLabel` fallback) | **`summary`-as-headline fallback is untested.** In-host result text falls back `title ?? summary ?? bare-count`. The plugin's persist-branch text uses `title ? ... : ...`; since title is now always required, the summary branch is structurally dead but still present. Tests in `exit-plan-mode.test.ts` only exercise the title-present branch. Minor — the dead branch is harmless, but the divergence-from-in-host (in-host can still hit `summary` if title were ever absent) is unverified. | Either delete the now-unreachable `title ? ...` ternary in the `persisted`/`reused` text (title is guaranteed non-empty past the guard at line 350) and simplify, OR add a test pinning the behavior. Prefer deletion — clamped `title` is always truthy here, so the ternary is misleading. |
+| **A7** | P2 | test-gap | `src/plan-mode/tool-descriptions.ts` (whole file) | n/a | **`tool-descriptions.ts` has no direct test.** The byte-identical-port parity contract for `describeEnterPlanModeTool` / `describeExitPlanModeTool` is only checked indirectly by `enter-plan-mode.test.ts` / `exit-plan-mode.test.ts` via loose `toMatch(/substring/)` assertions. A future edit that drops a clause but keeps the matched substring would pass CI. The file's own header says "Do NOT prune for length" — that intent is unenforced. | Add `tests/plan-mode/tool-descriptions.test.ts` that asserts the full strings byte-for-byte against an inline expected constant (or a checked-in fixture copied from in-host). This converts the "byte-identical port" claim from a comment into a guarded invariant — and would have caught A3 had `describeAskUserQuestionTool` been in scope. |
+
+---
+
+## Cross-cluster observations
+
+- **S1 surgical port (PR #87) is correct.** enter/exit descriptions, schema, title-required,
+  80-char clamp, archetype fields, and validation ordering all verified at parity. The
+  thick-tool adaptation is documented and sound. The remaining S1 gaps (A1, A2) are
+  *features the surgical port did not cover*, not regressions of what it did cover.
+- **S5 surgical port (PR #88) is incomplete.** It re-ported `auto-enable.ts` byte-for-byte
+  but (a) left it unwired (A5) and (b) did not touch `ask_user_question`'s description
+  (A3). Both are parity-gaps the S5 PR should have closed.
+- **`host_ref:` citation accuracy**: all six files carry a `host_ref:` line. Three are
+  precise. Three are misleading and should be corrected as part of the fixes above:
+  `ask-user-question.ts` (cites the in-host tool but the description does not match it —
+  A3), `common.ts` (cites in-host `readStringParam` but the port silently drops
+  snake_case aliasing — A4), and `exit-plan-mode.ts` (header asserts a "gateway-side gate
+  at sessions-patch.ts remains authoritative" that does not exist in the plugin — A1).

--- a/docs/audits/parity-refresh/slice-audit-B-gates.md
+++ b/docs/audits/parity-refresh/slice-audit-B-gates.md
@@ -1,0 +1,124 @@
+# Parity Refresh — Slice Audit B: gates cluster
+
+**Auditor**: parity-refresh adversarial diff (gates cluster)
+**Date**: 2026-05-19
+**Scope**: slices S2 (mutation gate — fail-CLOSED), S10 (exec allowlist / dangerous-flag blocking), S12 (shell-escape layered defense + accept-edits trigger predicate). The security-critical gates.
+**In-host source-of-truth**: branch `rebase/pr70071-onto-main-2026-04-25` @ `ea04ea52c7` in `/Volumes/LEXAR/repos/openclaw-pr70071-rebase`.
+**Post-surgical context**: PR #90 re-ported S12/S10 (accept-edits gate — trigger predicate fixed, shell-escape coverage backfilled). This refresh re-verifies the surgical port and revisits the three SHARED-bug claims from the Wave-1 S12 report.
+**Method**: read-only adversarial diff. Executable-line diff of both gate files vs in-host; trigger-predicate trace through `index.ts` ↔ in-host `pi-tools.before-tool-call.ts` ↔ `sessions-patch.ts` ↔ `resolvePlanApproval`. No code executed; no commits made.
+
+---
+
+## Per-file verdict
+
+| Plugin file | In-host counterpart | Verdict |
+|---|---|---|
+| `src/gates/mutation-gate.ts` | `src/agents/plan-mode/mutation-gate.ts` | **clean** — executable lines byte-identical; only sound adaptations (import path, `DANGEROUS_FLAGS` module-hoist, `_testing` export). `host_ref:` citations present + correct. |
+| `src/gates/accept-edits-gate.ts` | `src/agents/plan-mode/accept-edits-gate.ts` | **clean** — executable lines **byte-identical** (diff EXIT=0). All 8 pattern lists + 6 C4 escape regexes + normalizer + extractor identical. `host_ref:` correct. |
+| `tests/gates/mutation-gate.test.ts` | `src/agents/plan-mode/mutation-gate.test.ts` | **clean** — restructured table-driven; semantic SUPERSET of in-host. |
+| `tests/gates/accept-edits-gate.test.ts` | `src/agents/plan-mode/accept-edits-gate.test.ts` | **clean** — first 629 lines 1-for-1 with in-host; PR #90 backfill (P0 #4–#10) complete. |
+| `src/index.ts:371-479` (gate wiring) | `src/agents/pi-tools.before-tool-call.ts:296-378` | **drift** — see B1 (apply_patch extraction not tool-gated), B2 (filePath priority order), B3 (`params.cmd`/`params.target` over-extraction). All fail-safe for these gate postures. |
+
+**Severity counts**: P0 = 0, P1 = 1 (B4 — trigger-predicate has zero integration test), P2 = 5 (B1, B2, B3, B5, B6).
+
+**Headline**: No security boundary is weakened vs in-host. Both gate algorithms are byte-identical. PR #90's trigger-predicate fix is **correct parity** — and it retroactively resolves the Wave-1 S12 report's "P0 #2" finding, which was a **misdiagnosis** (see §"Wave-1 re-verification" below). The remaining findings are wiring-layer drift (all fail-safe) and one genuine integration-test gap.
+
+---
+
+## Detailed analysis
+
+### mutation-gate.ts — CLEAN
+
+Executable-line diff vs in-host shows exactly three differences, all sound adaptations:
+
+1. **Import path** `../types.js` vs in-host `./types.js` — required seam adaptation (plugin keeps `PlanMode` in `src/types.ts`, not a `plan-mode/` subdir). Benign.
+2. **`DANGEROUS_FLAGS` hoisted to module scope** (plugin `mutation-gate.ts:150-161`) vs in-host function-body local (`mutation-gate.ts:213-225`). **Same 10 entries, same order, same case**: `-delete`, `-exec`, `-execdir`, `--delete`, `-rf`, `--output`, `-fprint`, `-fprint0`, `-fprintf`, `-fls`. The hoist enables the `_testing`-driven per-flag test loop — a net coverage improvement, no behavioral change.
+3. **`_testing` export added** (`mutation-gate.ts:274-281`) — exposes the 6 lists as `Array.from()` copies for test introspection. In-host has no equivalent. Test-only; copies, not live refs.
+
+All six data lists verified against in-host: `PLAN_MODE_ALLOWED_TOOLS` (17), `MUTATION_TOOL_BLOCKLIST` (11), `MUTATION_SUFFIX_PATTERNS` (3), `READONLY_SUFFIX_PATTERNS` (5), `READ_ONLY_EXEC_PREFIXES` (22), `DANGEROUS_FLAGS` (10) — **all byte-identical**. Shell-operator regex `/[;|&` backtick `\n\r]|\$\(|>>?|<\(|>\(/` identical. Control flow (8-step decision tree) identical. `host_ref:` citations present on every block and point to correct in-host line ranges. Fail-CLOSED default-deny intact.
+
+### accept-edits-gate.ts — CLEAN
+
+Executable-line diff vs in-host: **EXIT=0 — byte-identical**. The only file-level differences are the parity-contract preamble (lines 4–16) and the `>=95%` ASCII swap (in-host `≥95%`) — both pure documentation. Verified identical:
+
+- `DESTRUCTIVE_EXEC_PREFIXES` (8: `rm`, `rmdir`, `unlink`, `shred`, `trash`, `truncate`, `diskutil erasedisk`, `diskutil eraseall`)
+- `DESTRUCTIVE_SQL_PATTERNS` (7: `DROP TABLE/DATABASE/SCHEMA`, `DELETE FROM`, `TRUNCATE`, `FLUSHALL`, `FLUSHDB`)
+- `DESTRUCTIVE_FIND_FLAGS` (3: `-delete`, `-exec <verb>`, `-execdir <verb>`)
+- `DESTRUCTIVE_ESCAPE_PATTERNS` (6 C4 regexes: env-var indirection, backtick subshell, `$()` subshell, quote-concat, hex `\xNN`, octal `\NNN`)
+- `SELF_RESTART_PATTERNS` (10), `CONFIG_CHANGE_PATTERNS` (4), `PROTECTED_CONFIG_PATH_PREFIXES` (5), `PATH_WRITER_TOOLS` (5)
+- `normalizeCandidatePath`, `checkProtectedPath`, `extractApplyPatchTargetPaths`, `checkAcceptEditsConstraint` — identical.
+
+Fail-OPEN posture intact. `host_ref:` correct.
+
+### Trigger-predicate parity — VERIFIED CORRECT (PR #90)
+
+The in-host fires the accept-edits gate at `pi-tools.before-tool-call.ts:333`:
+`latestPlanMode === "normal" && getLatestAcceptEdits?.()`, where `getLatestAcceptEdits` reads `SessionEntry.postApprovalPermissions.acceptEdits === true` live from disk (`fresh-session-entry.ts:115`).
+
+PR #90 changed the plugin predicate (`index.ts:451`) from `autoApprove === true || approval === "edited"` to **`approval === "edited"`**. Trace confirms this is correct parity:
+
+- **In-host `sessions-patch.ts:982-993`** sets `postApprovalPermissions.acceptEdits = true` **only on `action === "edit"`**; `action === "approve"` *explicitly clears* it (verbatim execution — comment: *"`approve` explicitly does NOT grant acceptEdits"*).
+- **Plugin `store.ts:511`** sets `approval: "edited"` exactly when `action === "edit"`. The plugin's `resolvePlanApproval` `edit` branch (`approval.ts:121-126`) sets `mode: "normal"` AND `approval: "edited"` together, so the gate-fire state `(mode==="normal", approval==="edited")` is reachable and survives the plan→normal transition.
+- **`autoApprove`** in the plugin auto-resolves `exit_plan_mode` "straight to **approved**" (`store.ts:612-616`) → `approval: "approved"`, never `"edited"`. The old `autoApprove === true` disjunct therefore over-fired the gate for operators who pre-toggled auto-mode (a UX regression). In-host autoApprove likewise auto-resolves to `approve` (verbatim, no acceptEdits grant). PR #90's removal of the disjunct is **correct**.
+
+The mode-mutual-exclusion also matches: in-host runs the mutation gate when `mode==="plan"` and the accept-edits gate `else if mode==="normal" && ...`; the plugin does `if (mode==="plan") {...; return}` then the accept-edits block — same mutual exclusion.
+
+### Wave-1 re-verification — "P0 #2" was a MISDIAGNOSIS
+
+The Wave-1 S12 report (`docs/audits/wave-1/S12-shell-escape-accept-edits.md` §4 P0 #2, §6.3) claimed plain "Accept" should fire the gate and the plugin's failure to do so was a P0 silent-bypass. **This is incorrect.** The in-host `sessions-patch.ts:982-993` source proves plain "Accept" (`action==="approve"`) does NOT set `postApprovalPermissions.acceptEdits` — it *clears* it. In-host plain-Accept does **not** fire the gate either. PR #90's `approval === "edited"` predicate is faithful in-host parity. The Wave-1 "P0 #2" / §6.3 "trigger predicate BROKEN" findings are **resolved / withdrawn**.
+
+### Wave-1 SHARED bugs — confirmed STILL SHARED (not plugin regressions)
+
+The Wave-1 S12 report documented three SHARED bugs. Because `accept-edits-gate.ts` is now verified byte-identical to in-host, all three are confirmed **still shared with in-host — not plugin-only regressions**, so out of scope for a parity finding:
+
+- **Trailing-slash normalization bypass** (`~/.openclaw/` → `~/.openclaw`, slash stripped, `startsWith("~/.openclaw/")` false). `normalizeCandidatePath` is byte-identical → shared.
+- **`bash -c "rm -rf"` quoted-body bypass** — `matchExecPrefix` is byte-identical → shared.
+- **Command-chain bypass** (`ls && rm`) — prefix-anchored matching is byte-identical → shared.
+
+These remain real attack surfaces but are correctly out of scope for the plugin parity audit (a fix belongs upstream in in-host first, then re-ports).
+
+---
+
+## Findings table
+
+| ID | Severity | Type | Plugin loc | In-host loc | Description | Suggested fix |
+|---|---|---|---|---|---|---|
+| **B1** | P2 | parity-gap | `src/index.ts:464` | `pi-tools.before-tool-call.ts:354-357` | `extractApplyPatchTargetPaths(params.input)` is called **unconditionally** for any path-writer tool. In-host gates it on `toolName === "apply_patch"`. If a non-`apply_patch` tool's `params.input` happens to contain literal `*** Update File:` text, the plugin extracts phantom paths and could over-block. Fail-OPEN gate → worst case is a spurious block, not a bypass. | Gate the extractor call on `event.toolName === "apply_patch"` to match in-host exactly. |
+| **B2** | P2 | parity-gap | `src/index.ts:455-462` | `pi-tools.before-tool-call.ts:341` | `filePath` priority order diverges: plugin `file_path ?? path ?? target`; in-host `path ?? filePath ?? file_path`. If a tool ever sends BOTH `path` and `file_path` with different values, the two pick different candidates. No known tool does this today, so currently cosmetic — but it is silent behavioral drift. | Reorder to `params.path ?? params.filePath ?? params.file_path` to match in-host; drop `target` or document the seam reason. |
+| **B3** | P2 | parity-gap | `src/index.ts:402-407` | `pi-tools.before-tool-call.ts:312,335` | Command extraction uses `params.command \|\| params.cmd`; in-host uses `params.command` only. The `cmd` fallback is a plugin-only over-extraction. For both a fail-CLOSED (mutation) and fail-OPEN (accept-edits) gate, feeding *more* command text can only cause *more* blocking, never a bypass — fail-safe — but it is undocumented drift. | Either drop the `params.cmd` fallback for byte-parity, or add a `host_ref` note explaining the plugin-specific tool convention it covers. |
+| **B4** | P1 | test-gap | `src/index.ts:451` (`isAcceptEditsPhase`); `tests/gates/` | — | The trigger predicate `approval === "edited"` has **zero unit/integration test**. `accept-edits-gate.test.ts:854-865` explicitly defers this to `smoke-4-accept-edits-adversarial`, an Eva live-smoke (not in CI). No CI-runnable test pins: (a) gate FIRES when `approval==="edited"` + `mode==="normal"`; (b) gate does NOT fire when `approval==="approved"` (the autoApprove path — the exact over-fire PR #90 fixed); (c) gate does NOT fire when `mode==="plan"`. A future refactor of the `index.ts` wiring (e.g. reinstating an `autoApprove` disjunct, or an `||`-vs-`&&` slip) passes the green suite silently. The 72-case gate-function suite validates the gate ALGORITHM, never the INVOCATION CONDITION. | Add a CI-runnable wiring test that invokes the `before_tool_call` handler with stubbed `getSessionExtension` / `store` snapshots across the 3 states above. This is the same gap flagged in Wave-1 §7 ("hook-wiring integration is the weak link") and is the single most valuable missing test for this cluster. |
+| **B5** | P2 | parity-gap | `src/state/store.ts` (no plan-complete clear) | `plan-snapshot-persister.ts:714-716` | In-host clears `postApprovalPermissions` on plan-complete / close-on-complete. The plugin has no equivalent: `approval: "edited"` persists until the next `enterPlanMode` (`store.ts:347` → `"none"`) or `exitPlanMode` (`store.ts:417` → `"none"`). So the accept-edits gate stays armed for the whole post-approval phase + beyond, where in-host disarms it at plan-complete. This is a *narrowing-not-applied* — the plugin gate stays ON **longer**, i.e. strictly more blocking. Fail-safe for a security gate; not a weakening. Worth noting because it is observable parity drift (a destructive command long after the plan finished is blocked in the plugin, allowed in in-host). | Optional: wire a plan-complete hook (or reuse the existing completion-injection path) to reset `approval` to `"none"` for exact in-host parity. Low priority — current behavior is the safe direction. |
+| **B6** | P2 | test-gap | `tests/gates/mutation-gate.test.ts` | `pi-tools.before-tool-call.ts:309-322` | The mutation-gate wiring (`index.ts:412-421` — mode resolution via `getSessionExtension` then `store.readSnapshot`, `command` extraction) has no integration test. `mutation-gate.test.ts` covers the gate function only. Same class as B4 but for the fail-CLOSED gate. Lower severity than B4 because the mutation gate's default-deny means a wiring bug that drops the command tends to fail-closed (block), whereas an accept-edits wiring bug fails-open (allow). | Fold a mutation-gate case into the B4 wiring test (inject `before_tool_call` with `mode: "plan"`, assert block-on-blocklisted-tool). |
+
+---
+
+## Confidence
+
+P(a security regression vs in-host slips through this cluster) = **~0.05** (low).
+
+- Both gate algorithms are byte-identical to in-host — verified by executable-line diff, not eyeball. There is no pattern drift, no dropped/weakened regex, no allowlist/blocklist divergence.
+- PR #90's trigger-predicate fix is correct parity and is backed by the in-host `sessions-patch.ts` source — and it resolves the Wave-1 "P0 #2" misdiagnosis.
+- PR #90's coverage backfill (P0 #4–#10) is complete: every coded accept-edits pattern now has a positive test.
+- All wiring-layer divergences (B1–B3) are fail-SAFE for their respective gate postures (more text/more paths → more blocking, never a bypass).
+- B5 (no plan-complete clear) is a narrowing-not-applied — the safe direction.
+
+The residual risk is **B4** — a wiring refactor that re-breaks the trigger predicate (the precise thing PR #90 fixed) would pass the green CI suite, because the predicate has no CI-runnable test. That is a regression-detection gap, not a current bypass. Closing B4 takes this cluster's confidence to ~0.02.
+
+---
+
+## Appendix — files referenced (absolute paths)
+
+- `/Users/lume/repos/Smarter-Claw/src/gates/mutation-gate.ts`
+- `/Users/lume/repos/Smarter-Claw/src/gates/accept-edits-gate.ts`
+- `/Users/lume/repos/Smarter-Claw/tests/gates/mutation-gate.test.ts`
+- `/Users/lume/repos/Smarter-Claw/tests/gates/accept-edits-gate.test.ts`
+- `/Users/lume/repos/Smarter-Claw/src/index.ts` (gate wiring: 371-479)
+- `/Users/lume/repos/Smarter-Claw/src/state/store.ts` (`recordApproval`, `applyApprovalAction`, `enterPlanMode`, `exitPlanMode`, `setAutoApprove`)
+- `/Users/lume/repos/Smarter-Claw/src/plan-mode/approval.ts` (`resolvePlanApproval`)
+- `/Volumes/LEXAR/repos/openclaw-pr70071-rebase` @ `ea04ea52c7`:
+  - `src/agents/plan-mode/mutation-gate.ts` + `.test.ts`
+  - `src/agents/plan-mode/accept-edits-gate.ts` + `.test.ts`
+  - `src/agents/pi-tools.before-tool-call.ts` (trigger predicate, 296-378)
+  - `src/gateway/sessions-patch.ts:940-1010` (`postApprovalPermissions` set/clear)
+  - `src/auto-reply/reply/fresh-session-entry.ts:88-120` (`resolveLatestAcceptEditsFromDisk`)
+  - `src/gateway/plan-snapshot-persister.ts:705-720` (plan-complete `postApprovalPermissions` clear)

--- a/docs/audits/parity-refresh/slice-audit-C-state.md
+++ b/docs/audits/parity-refresh/slice-audit-C-state.md
@@ -1,0 +1,127 @@
+# Parity Audit C — State Cluster (S3 + S15)
+
+**Auditor**: parity-refresh slice C (adversarial, read-only diff)
+**Date**: 2026-05-19
+**Cluster**: `src/state/{store.ts, session-store-gateway.ts, in-memory-gateway.ts, schema-version.ts}`
+**Parity slices**: S3 (`persistApprovalRequest` 10-invariant race-fix mutator), S15 (real persistence gateway)
+**In-host source-of-truth**: branch `rebase/pr70071-onto-main-2026-04-25` @ `ea04ea52c7` in `/Volumes/LEXAR/repos/openclaw-pr70071-rebase`
+**In-host anchors**:
+- `src/agents/pi-embedded-subscribe.handlers.tools.ts:130-237` — `persistPlanApprovalRequest` (race-fix anchor `1081067476`)
+- `src/config/sessions/store.ts:610-668` — `withSessionStoreLock` + `updateSessionStoreEntry`
+- `src/agents/plan-mode/approval.ts:45-150` — `resolvePlanApproval`
+- `src/gateway/sessions-patch.ts:940` — `resolvePlanApproval` callsite (passes `expectedApprovalId`)
+
+---
+
+## 1. Per-file verdict
+
+| File | Verdict | Notes |
+|------|---------|-------|
+| `src/state/store.ts` | **PASS with 2 parity-gaps** | All 10 invariants of `persistApprovalRequest` present + correct. `applyApprovalAction` drops the `expectedApprovalId` stale-event guard (C-1, P1). `persistApprovalRequest` writes `updatedAt` but in-host's lock writes nothing extra — minor (C-5). |
+| `src/state/session-store-gateway.ts` | **PASS** | Faithfully wraps `updateSessionStoreEntry`; inherits invariants 5+6 (atomic lock + fresh `skipCache` read) from the SAME in-host SDK function. `null`-return-skips-write contract matched. SDK import-path guesses are fragile but fallback-guarded (C-6, P2). |
+| `src/state/in-memory-gateway.ts` | **PASS** | Promise-chain per-key lock + `structuredClone` fresh-read correctly models invariants 5+6 for the test tier. Test-only; not a parity risk. |
+| `src/state/schema-version.ts` | **PASS** | Stamp/read are correct and defensive. Invariant beyond in-host scope (in-host has no `__schemaVersion`); additive, not a drift. |
+
+**Overall**: the load-bearing S3 slice is **structurally faithful**. No dropped invariant, no re-introduced race. The findings are one real P1 (stale-event guard not wired through the approval mutators) and several P2 polish items.
+
+---
+
+## 2. The 10 invariants — per-invariant parity table
+
+In-host enumeration per `architecture-v2/09-AMENDMENT_1_VERIFICATION.md` and the in-host function body `pi-embedded-subscribe.handlers.tools.ts:130-237`.
+
+| # | Invariant | In-host `file:line` | Plugin `file:line` | Present? | Correct? | Tested? |
+|---|-----------|---------------------|--------------------|----------|----------|---------|
+| 1 | **Sync bundle write** — `approvalId`+`title`+`payloadHash`+`lastPlanSteps`+`approval`+`updatedAt` in ONE write | tools.ts:206-223 | store.ts:250-272 | YES | YES — single `next` object literal returned to `withLock`; `stampSchemaVersion` wraps it; one write only | YES — store.test.ts:86-192 (7 cases incl. "ALL FOUR race-fix fields land atomically", asserts `writeCount===1`) |
+| 2 | **Mode precondition guard** — `!current \|\| mode!=="plan"` → no write | tools.ts:180-182 | store.ts:214-221 | YES | YES — identical 2-clause guard; returns `{next:null}`; sets `kind:"skipped" reason:"not-plan-mode"` | YES — store.test.ts:42-84 (no-payload + normal-mode + plan-mode positive) |
+| 3 | **Payload-hash idempotency** — hash-match cycle reuses `approvalId` | tools.ts:193-205 | store.ts:229-243 | YES | YES — sets `kind:"reused"`, returns existing `approvalId`, `{next:null}` (no write) | YES — store.test.ts:194-288 (REUSE happy case + writeCount===0) |
+| 4 | **Audit-event emission** — `logPlanModeApprovalTransition` on persist path | tools.ts:224-229 | store.ts:275-284 | YES | YES — `audit()` fires only when `transition` is set (persist path only); see C-3 note re: emit-after-write ordering | YES — store.test.ts:290-351 ("emits audit event on the persist path") |
+| 5 | **Atomic lock around read+update** | tools.ts:175 → store.ts:650 (`withSessionStoreLock`) | store.ts:209-273 via `gateway.withLock`; gateway impl: session-store-gateway.ts:225-262 → in-host `updateSessionStoreEntry` | YES | YES — production gateway delegates to the *same* in-host `updateSessionStoreEntry`, inheriting `withSessionStoreLock`. InMemoryGateway models it with a promise-chain lock | PARTIAL — in-memory chain only; real-gateway lock untested (store.test.ts:11-17 explicitly defers; C-4) |
+| 6 | **Fresh-read inside the lock** (`skipCache:true`) | tools.ts:176 (`entry.planMode` from the locked, `skipCache` store at store.ts:651) | session-store-gateway.ts:230-232 reads `entry.pluginExtensions[...]` from the entry handed by `updateSessionStoreEntry` (which did `loadSessionStore(...,{skipCache:true})`) | YES | YES — fresh-read is inherited from in-host `updateSessionStoreEntry`; InMemoryGateway clones a fresh `Map` read | PARTIAL — same as #5 |
+| 7 | **4-conjoined-condition idempotency decomposition** — ALL FOUR of: `payloadHash` truthy / hash-match / `approval==="pending"` / `approvalId` non-empty string | tools.ts:194-199 | store.ts:229-235 | YES | YES — exact 4-clause conjunction (`hashMatch && stillPending && hasApprovalId`, where `hashMatch` itself folds in the `payloadHash!==undefined` clause) | YES — store.test.ts:225-287 — one ROTATE test per failing condition (6 tests covering all 4 fail-axes incl. empty-string + rejected-state) |
+| 8 | **IO-error fail-soft** — try/catch swallows, returns candidate `approvalId`, never throws | tools.ts:153-235 (catch at 233-235) | store.ts:208 / 296-305 | YES | YES — outer try/catch; `kind:"failed"` carries `error` + candidate `approvalId`; `logger.warn`; never re-throws | YES — store.test.ts:353-400 ("returns failed + candidate approvalId", "NEVER throws") |
+| 9 | **Deliberate audit-skip on reuse** | tools.ts:202-204 (comment + early `return null` before `logPlanModeApprovalTransition`) | store.ts:236-243 (returns `{next:null}` with NO `transition` → audit branch at 277 not taken) | YES | YES — reuse path returns no `transition`; `if (transition && this.audit)` therefore skips | YES — store.test.ts:314-329 ("SKIPS audit on the reuse path — invariant 9") |
+| 10 | **Lazy-imports discipline** | tools.ts:154-164 (`Promise.all` of dynamic imports) | session-store-gateway.ts:156-205 (`loadSdk()` dynamic `import()` behind a memoized promise) | YES | YES — store.ts is self-contained (N/A, per its docstring); the *gateway* preserves lazy-import discipline for the SDK surface — closer parity than the docstring claims | YES (shape) — session-store-gateway.test.ts:25-88 covers routing fallback; full lazy-resolution deferred to Eva-live |
+
+**10-invariant pass/fail line: 10 / 10 PRESENT, 10 / 10 CORRECT, 8 / 10 fully unit-tested (#5 + #6 are integration-deferred — `test-gap`, not a bug).**
+
+---
+
+## 3. Lock semantics — `withLock` vs in-host `withSessionStoreLock`
+
+- **Production path (`SessionStoreGateway`)**: `withLock` resolves the store path, then calls in-host `updateSessionStoreEntry` (`session-store-gateway.ts:225`). That function IS the in-host one — `withSessionStoreLock(storePath, …)` + `loadSessionStore(storePath, {skipCache:true})` (in-host `store.ts:650-651`). So invariants 5 (atomic lock) and 6 (fresh `skipCache` read) are not *re-implemented* — they are *inherited from the identical SDK function*. This is the strongest possible parity for S15. ✔
+- **`null`-skips-write contract**: in-host `updateSessionStoreEntry` treats a `null` return from the `update` callback as "no patch" (`store.ts:658-660`). The plugin gateway returns `null` from its inner callback whenever `update()` yields `{next:null}` (`session-store-gateway.ts:235-241`). Matched exactly. ✔
+- **In-memory path**: promise-chain lock keyed per `sessionKey` + `structuredClone` on both read and write. Correctly serializes and prevents mutate-by-reference. Adequate for the test tier. ✔
+- **Gap (C-2, P2)**: the in-host lock keys on **`storePath`** (one mutex per store file — *all* sessions in a store serialize). The plugin's `InMemoryGateway` keys on **`sessionKey`** (finer-grained). For the in-memory test gateway this is harmless (tests are single-session). The *production* gateway inherits the in-host `storePath`-keyed lock, so production parity is intact — but the InMemoryGateway's finer lock could mask a cross-session ordering bug that only the real gateway exposes. Documentation-level risk, not a runtime bug.
+
+---
+
+## 4. The race-fix (commit `1081067476`)
+
+The race fix made `persistPlanApprovalRequest` write `lastPlanSteps` + `title` **synchronously, in the same write as `approvalId`**, so `sessions-patch.ts` reads populated steps on a fast Approve click.
+
+- **In-host**: `tools.ts:206-223` — single `nextPlanMode` literal; caller `tools.ts:1863-1876` passes `title`, `payloadHash`, and a mapped `lastPlanSteps` array into the SAME call.
+- **Plugin**: `store.ts:250-272` — single `next` literal carrying `approval`, `approvalId`, `updatedAt`, and conditionally `title` / `lastPlanPayloadHash` / `lastPlanSteps`; returned once to `gateway.withLock`. **One write.** ✔
+- **Verified synchronous**: `store.test.ts:146-162` ("ALL FOUR race-fix fields land atomically in one write") asserts every field is present AND `gw.writeCount === 1`. The race cannot re-appear through this mutator. ✔
+
+**Race-fix verdict: faithfully ported.** No P0.
+
+---
+
+## 5. `host_ref:` citations
+
+- `store.ts` carries `host_ref:` tags at lines 89, 111, 135, 315, 388, 456, 492, 525 — and a module-level anchor at lines 5-7. **Present and accurate** against `ea04ea52c7`. ✔
+- One citation drift (C-7, P2): `store.ts:6` cites the anchor commit as "`1081067476`, the empty-plan-body race-fix anchor" — correct — but the file lines `130-237` are quoted against `ea04ea52c7` (current tip). Both are stated; harmless but the doc-comment conflates the two SHAs without saying `1081067476` is an *ancestor* of `ea04ea52c7`. Cosmetic.
+- `store.ts:135` cites the caller-contract at `pi-embedded-subscribe.handlers.tools.ts:1881-1886` — verified, the in-host caller reads `persistResult.reused` at `tools.ts:1882`. ✔
+- `session-store-gateway.ts:14` cites `pi-embedded-subscribe.handlers.tools.ts:156` for `updateSessionStoreEntry` — verified (in-host line 156 is inside the `Promise.all` import block). ✔
+
+---
+
+## 6. Schema-version stamping
+
+- `stampSchemaVersion` is applied on **every** successful-write return path in `store.ts`: persist (272), enterPlanMode (357), exitPlanMode (425), applyApprovalAction (581), setAutoApprove lazy-init (662) + toggle (677). ✔
+- Reuse / skip / noop / failed paths return `{next:null}` → no stamp, correctly (C-3 test confirms). ✔
+- `readSnapshot` rejects payloads with a newer `__schemaVersion` (`store.ts:727-732`). ✔
+- This is a **plugin-only invariant** — the in-host has no `__schemaVersion` field. It is additive (does not change any in-host-visible field), so it is **not a parity drift**; it is a forward-compat hardening the plugin adds because its `PlanModeSessionState` is now a cross-plugin wire contract. Acceptable.
+
+---
+
+## 7. Test coverage assessment
+
+`tests/state/store.test.ts` — claimed "67 cases". Actual: **57 `it()` blocks** across 16 `describe` blocks (C-8, `test-gap`/doc-drift, P2). Coverage of the 10 invariants + 4 result kinds:
+
+- **All 10 invariants**: covered (see §2 table). #5/#6 only via the in-memory gateway — the real-gateway lock + `skipCache` round-trip is **explicitly deferred** to Eva-live (`store.test.ts:11-17`). That deferral is a genuine `test-gap` (C-4): a regression in `session-store-gateway.ts`'s slot-merge logic (e.g. clobbering a sibling plugin's `pluginExtensions` entry) would not be caught by any automated test — `session-store-gateway.test.ts` is shape-only (no disk round-trip, lines 13-19 say so).
+- **4 result kinds** of `persistApprovalRequest`: `persisted` ✔ (75-83), `reused` ✔ (213-223), `skipped` ✔ (53-73), `failed` ✔ (353-399). All four also asserted to carry an `approvalId` (402-445). ✔
+- **Missing negative test (C-9, `test-gap`, P2)**: no test asserts that on the **reuse** path the candidate `lastPlanSteps` / `title` are NOT written (the reuse path returns `{next:null}` so by construction nothing is written, but there is no regression test pinning "a reuse call with a *different* `lastPlanSteps` leaves the persisted steps untouched"). A future refactor that moved the bundle-build above the idempotency guard would silently overwrite. Worth one test.
+
+---
+
+## 8. Findings table
+
+| ID | Title | Class | Severity | In-host `file:line` | Plugin `file:line` |
+|----|-------|-------|----------|---------------------|--------------------|
+| C-1 | **`applyApprovalAction` never passes `expectedApprovalId` to `resolvePlanApproval`** — the stale-event guard (`approval.ts:80-83`) is dead code in the plugin's mutator path. In-host `sessions-patch.ts:940` passes `expectedApprovalId` so a stale Approve click (token mismatch) is no-op'd. The plugin's `recordApproval`/`recordRejection`/`recordTimeout` call `resolvePlanApproval(current, action, feedback)` with NO 4th arg — any pending cycle is resolvable by *any* caller regardless of which `approvalId` the UI event carried. Re-opens the orphan-card / cross-surface-stale-click class the guard exists to close. | parity-gap | **P1** | `sessions-patch.ts:940`; `approval.ts:80-83` | `store.ts:571` (call site, 4th arg omitted); `applyApprovalAction` input type `store.ts:549-557` has no `expectedApprovalId` field |
+| C-2 | InMemoryGateway locks per **`sessionKey`**; in-host `withSessionStoreLock` locks per **`storePath`** (coarser). Production gateway inherits the in-host lock so prod parity holds — but the test gateway's finer lock can mask a cross-session ordering bug. | parity-gap | P2 | `store.ts:610` (`storePath`-keyed) | `in-memory-gateway.ts:38,70-78` (`sessionKey`-keyed) |
+| C-3 | Audit emitted **after** `withLock` resolves (i.e. after the write lands). In-host emits `logPlanModeApprovalTransition` *inside* the callback, *before* the disk persist. Plugin: if a sibling subscriber observed the audit event it would be post-write — actually *safer* than in-host (in-host can log a transition that then fails to persist). Noting as a deliberate, benign divergence, not a bug. | parity-gap | P2 | `tools.ts:224` (inside callback, pre-persist) | `store.ts:277-284` (after `withLock`) |
+| C-4 | No automated test exercises the **real** `SessionStoreGateway` against a `session.json` round-trip. `session-store-gateway.test.ts` is shape-only; invariants 5/6 are in-memory-only. A slot-merge regression (clobbering sibling `pluginExtensions`) ships uncaught. | test-gap | P2 | n/a | `tests/state/session-store-gateway.test.ts:13-19` (deferral stated) |
+| C-5 | `persistApprovalRequest` writes `updatedAt: Date.now()` on the persist path; in-host also writes `updatedAt: now`. **Matched** — listed only to record it was checked. No action. | (verified) | — | `tools.ts:210` | `store.ts:254` |
+| C-6 | `SessionStoreGateway.loadSdk` guesses SDK import paths (`openclaw/plugin-sdk/config-runtime`, `openclaw/plugin-sdk/runtime`) with `as string` casts + try/catch fallback. If the installed SDK renames these, config/routing silently degrade to the fallback parser (still functional, but `resolveStorePath` could resolve the wrong store if `loadConfig` is missing). Fragile; the in-host imports are statically resolved (`tools.ts:154-164` import real module paths). | parity-gap | P2 | `tools.ts:50-56` (typed module imports) | `session-store-gateway.ts:164-177` |
+| C-7 | `store.ts:6` doc-comment conflates anchor SHA `1081067476` with tip `ea04ea52c7` without noting the ancestor relationship. Cosmetic. | parity-gap | P2 | n/a | `store.ts:5-7` |
+| C-8 | `store.test.ts:1` header + brief claim "67 cases"; file actually has **57** `it()` blocks. Doc-drift in the test header / brief. | test-gap | P2 | n/a | `tests/state/store.test.ts` (count) |
+| C-9 | No negative regression test pinning that the **reuse** path does not overwrite persisted `lastPlanSteps`/`title` with a differing candidate. Currently safe by construction (`{next:null}`); unprotected against a future bundle-reorder refactor. | test-gap | P2 | n/a | `tests/state/store.test.ts` (absent case) |
+
+---
+
+## 9. Severity counts
+
+- **P0**: 0
+- **P1**: 1 — C-1 (`expectedApprovalId` stale-event guard not wired through `applyApprovalAction`)
+- **P2**: 7 — C-2, C-3, C-4, C-6, C-7, C-8, C-9 (C-5 is a verified-OK, not a finding)
+
+---
+
+## 10. Conclusion
+
+The S3 race-fix mutator is **structurally faithful** — all 10 invariants present, all 10 correct, the empty-plan-body race cannot re-appear through `persistApprovalRequest`. The S15 production gateway is the strongest possible port because it *reuses the identical in-host `updateSessionStoreEntry`* rather than re-implementing the lock.
+
+The one real defect is **C-1**: the plugin re-ported `resolvePlanApproval` byte-identically (correct) including its `expectedApprovalId` parameter — but the `PlanModeStore` mutators that *call* it never thread the approval token through. In-host, `sessions-patch.ts:940` does. The result: the stale-event / cross-surface-click guard that `resolvePlanApproval` carries is dead code in the plugin. This should be P1-fixed by adding `expectedApprovalId?: string` to the `recordApproval`/`recordRejection`/`recordTimeout` inputs and forwarding it as the 4th arg at `store.ts:571`.

--- a/docs/audits/parity-refresh/slice-audit-D-prompt.md
+++ b/docs/audits/parity-refresh/slice-audit-D-prompt.md
@@ -1,0 +1,425 @@
+# Parity Refresh — Slice Audit D: prompt + injection cluster
+
+**Auditor**: parity-refresh adversarial diff (prompt + injection cluster)
+**Date**: 2026-05-19
+**Scope**: slices S4 (planMode runtime context propagation), S5 (archetype prompt),
+S8 (rejection UX / `[PLAN_DECISION]` injection).
+**In-host source-of-truth**: branch `rebase/pr70071-onto-main-2026-04-25` @ `ea04ea52c7`
+in `/Volumes/LEXAR/repos/openclaw-pr70071-rebase`.
+**Post-surgical context**: PR #88 re-ported S4/S5 (system-prompt block + wired
+`buildApprovedPlanInjection`/`buildAcceptEditsPlanInjection`); PR #86 re-ported
+`approval.ts`; hotfix #93 wired the PLAN MODE AVAILABLE branch into `before_prompt_build`.
+
+**Method**: byte-level diff. The three prompt artifacts were extracted and compared
+char-for-char; the assembled `buildPlanModeActiveSystemContext()` / `…Available…()`
+outputs were produced by *executing* the plugin TypeScript via `tsx` and diffed against
+an in-host reconstruction (in-host `attempt.ts` array elements decoded with JS-string
+semantics + the evaluated `PLAN_ARCHETYPE_PROMPT` / `PLAN_MODE_REFERENCE_CARD`).
+
+---
+
+## Per-file verdict
+
+| Plugin file | In-host counterpart | Verdict |
+|---|---|---|
+| `src/prompt/plan-mode-injection.ts` | `attempt.ts:691-749` (inline block) | **clean** — assembled ACTIVE + AVAILABLE bytes byte-identical |
+| `src/prompt/archetype-prompt.ts` | `plan-mode/plan-archetype-prompt.ts` | **clean** — byte-identical (5980-byte source, 5979-byte evaluated) |
+| `src/prompt/reference-card.ts` | `plan-mode/reference-card.ts` | **clean** — byte-identical (100-element array literal) |
+| `src/prompt/pending-injections.ts` | `plan-mode/injections.ts:347-360` | **clean** — `composePromptWithPendingInjections` byte-identical; stale `host_ref:` line numbers (D4) |
+| `src/prompt/plan-decision-injection.ts` | `plan-mode/types.ts:185-209` | **drift** — function byte-identical but wired as a live emitter the in-host runtime never uses (D1); stale `host_ref:` (D4) |
+| `src/runtime/injection-writer.ts` | `plan-mode/injections.ts` (write side) | **drift** — see D1, D3, D5 |
+| `src/plan-mode/approval.ts` | `plan-mode/approval.ts` | **clean** — byte-identical (only the documented `./types.js`→`../types.js` import adaptation) |
+
+**Severity counts**: P0 = 0, P1 = 3 (D1, D2, D3), P2 = 2 (D4, D5).
+
+**Byte-level prompt drift**: NONE. All three system-prompt artifacts
+(`plan-mode-injection.ts` ACTIVE + AVAILABLE, `archetype-prompt.ts`,
+`reference-card.ts`) are confirmed byte-identical to the in-host. The prompt-cache key
+is intact. The findings below are about injection *builders* and *wiring*, not the
+cached system-prompt prefix.
+
+---
+
+## Findings table
+
+| ID | Class | Sev | One-line |
+|----|-------|-----|----------|
+| D1 | parity-gap | P1 | `[PLAN_DECISION]: rejected` injection wired through `buildPlanDecisionInjection`; in-host runtime emits a different inline 2-line form |
+| D2 | parity-gap | P1 | Approved-plan step lines append `status` enum; in-host appends `activeForm` gerund |
+| D3 | test-gap | P1 | No byte-fixture test pins prompt artifacts against in-host bytes — only `.toContain()` + a 2000-byte-wide length window |
+| D4 | parity-gap | P2 | `host_ref:` line numbers stale in `plan-decision-injection.ts` + `pending-injections.ts` |
+| D5 | parity-gap | P2 | Plan-decision idempotency key includes `:${decision}`; in-host upserts by `approvalId` alone |
+
+---
+
+## Detailed analysis
+
+### plan-mode-injection.ts — CLEAN (byte-identical assembled output)
+
+`buildPlanModeActiveSystemContext()` assembles from sub-constants
+(`PLAN_MODE_HEADER`, `PLAN_MODE_PREAMBLE`, `PLAN_MODE_ACTION_CONTRACT`,
+`PLAN_MODE_INVESTIGATION_PHASE`, `PLAN_MODE_HARD_RULES`, `PLAN_MODE_SEPARATOR`,
+`PLAN_ARCHETYPE_PROMPT`, `PLAN_MODE_REFERENCE_CARD`) joined with blank-line
+separators. The in-host emits the equivalent as one inline array in
+`attempt.ts:692-732`.
+
+**Verification (executed, not eyeballed)**: the plugin's `buildPlanModeActiveSystemContext()`
+was run via `tsx`; the in-host ACTIVE string was reconstructed by decoding the
+`attempt.ts` array elements with JS-string-literal semantics and substituting the
+*evaluated* archetype + reference-card constants. Result:
+
+```
+host_active  (evaluated) = 14332 bytes
+plug_active             = 14332 bytes
+BYTE-IDENTICAL: True
+```
+
+`buildPlanModeAvailableSystemContext()` likewise: in-host 979 bytes, plugin 979 bytes,
+`diff` empty. The 29-char bottom rule on the AVAILABLE block (vs the ACTIVE block's
+25-char separator) is correctly preserved — the inline comment at
+`plan-mode-injection.ts:104` flags it explicitly.
+
+The plugin's sub-constant split (kept "exposed for byte-level test pinning") does NOT
+change output bytes: the embedded `""` inside `PLAN_MODE_ACTION_CONTRACT` (between
+step 3 and the defect clause) reproduces the in-host array's `""` element at
+`attempt.ts:701`; all other blank lines come from the assembler's interleaved `""`
+entries, which match the in-host array structure 1:1.
+
+**`before_prompt_build` wiring (`src/index.ts:563-590`)** — correct vs the in-host
+branch logic with one documented divergence:
+
+- In-host `attempt.ts`: `planMode === "plan"` → ACTIVE block; else if
+  `planModeFeatureEnabled` (`config.agents.defaults.planMode.enabled === true`) →
+  AVAILABLE block; else → `""` (nothing injected).
+- Plugin: reads `snap?.mode`; `=== "plan"` → `buildPlanModeActiveSystemContext()`;
+  otherwise **always** → `buildPlanModeAvailableSystemContext()`.
+
+The plugin has no per-session feature flag — `register()` is gated on `config.enabled`
+(`src/index.ts:170-177`), so "plugin installed + enabled" *is* the feature flag. The
+plugin's "always inject AVAILABLE when not in plan mode" therefore corresponds exactly
+to the in-host's "feature enabled" branch. The third in-host case (feature OFF →
+`""`) is unreachable in the plugin because a disabled plugin registers no hook at all.
+Hotfix #93's rationale comment at `index.ts:577-586` documents this. **Not a finding** —
+the wiring is faithful to the in-host's two reachable branches.
+
+The output goes through `appendSystemContext` (prompt-cached prefix) — the right
+channel for cache-key stability, matching the intent of the in-host's
+`planModeAppendPrompt` (prepended to `appendPrompt`, cached).
+
+### archetype-prompt.ts — CLEAN (byte-identical)
+
+`PLAN_ARCHETYPE_PROMPT` template literal extracted from both sources and `diff`'d:
+identical, 5980-byte source on each side (5979 bytes evaluated — the source has 50
+escaped backticks `` \` `` that evaluate to 50 literal backticks). Em-dash (U+2014) in
+the header preserved; `≤` (U+2264), `≥` (U+2265), `↻`, `✓` all intact. The
+plugin-only `buildPlanFilenameSlug` / `buildPlanFilename` helpers present in the
+in-host file are NOT ported here — out of this cluster's scope (filename slug is a
+persistence concern), no finding.
+
+### reference-card.ts — CLEAN (byte-identical)
+
+`PLAN_MODE_REFERENCE_CARD` is a 100-element string array `.join("\n")` on both sides.
+Array-literal bodies extracted and `diff`'d: identical (6562-byte literal source on
+each side). The box-drawing diagram (`┌ ┐ └ ┘ │ ─ ┬ ┴ ↻ ▼`), the 37-char bottom rule,
+and the escaped grep patterns (`'\\[plan-mode/'`) all match byte-for-byte. Confirmed
+transitively: the evaluated reference card is embedded in the byte-identical
+`buildPlanModeActiveSystemContext()` output.
+
+### pending-injections.ts — CLEAN (compose contract byte-identical)
+
+`composePromptWithPendingInjections` is byte-identical to the in-host
+`injections.ts:347-360`: empty-queue → `userPrompt` unchanged; whitespace-only user
+prompt → `preamble` alone; otherwise `${preamble}\n\n${trimmedUser}` with entries
+joined `\n\n`. The brief notes this is a "parity-reference function" (host owns the
+real drain) — correct: the plugin re-exports the type contract
+(`PendingAgentInjectionEntry`, `PendingAgentInjectionKind`,
+`DEFAULT_INJECTION_PRIORITY`, `MAX_QUEUE_SIZE`) and the read-side composer; the host's
+`enqueueNextTurnInjection` SDK seam owns steps 1-4 of the drain. `DEFAULT_INJECTION_PRIORITY`
+values (`plan_decision:10` … `plan_nudge:1`) and `MAX_QUEUE_SIZE = 10` match the
+in-host `injections.ts:52-66`. See D4 for stale `host_ref:` line numbers.
+
+### plan-decision-injection.ts — DRIFT (see D1, D4)
+
+`buildPlanDecisionInjection(decision, feedback, rejectionCount)` is **byte-identical**
+to the in-host `types.ts:185-209` function: same one-line opener, same
+`feedback: ${JSON.stringify(sanitizeFeedbackForInjection(feedback))}` line, same
+"Revise your plan based on the feedback and call update_plan again." line, same
+`rejectionCount >= 3` deescalation hint, same `expired`/`timed_out` resume text. The
+`sanitizeFeedbackForInjection` helper (`src/helpers/sanitize.ts`) byte-matches the
+in-host inline function at `types.ts:158-160` (`/\[\/PLAN_DECISION\]/gi` → ZWSP form).
+The plugin-only `buildPlanApprovedDecisionLine` / `buildPlanEditedDecisionLine`
+one-liners are documented fallbacks. Function-level parity is intact — the drift is in
+*how it is wired* (D1).
+
+### injection-writer.ts — DRIFT (see D1, D3, D5)
+
+The WRITE-side adapters over the SDK seam `api.session.workflow.enqueueNextTurnInjection`.
+`enqueuePlanApprovedInjection` (the approve/edit emitter) and
+`enqueuePlanDecisionInjection` (the reject/timeout emitter) are sound SDK adaptations
+of the in-host's direct `appendToInjectionQueue` writes — except the reject path emits
+a different injection (D1) and the idempotency key diverges (D5).
+
+### approval.ts — CLEAN (byte-identical)
+
+`resolvePlanApproval`, `buildApprovedPlanInjection`, `buildAcceptEditsPlanInjection`,
+`DEFAULT_APPROVAL_CONFIG`, `SUBAGENT_SETTLE_GRACE_MS`,
+`MAX_CONCURRENT_SUBAGENTS_IN_PLAN_MODE` are byte-identical to the in-host
+`plan-mode/approval.ts`. The only delta is the documented `./types.js` → `../types.js`
+import-path adaptation. The state-machine guards (stale-`approvalId` fail-closed,
+terminal-state guard, no-token "none" defense), the approve/edit `rejectionCount: 0` +
+`feedback: undefined` reset, and the reject `rejectionCount + 1` are all faithful.
+`buildApprovedPlanInjection` / `buildAcceptEditsPlanInjection` strings match the
+in-host char-for-char (verified incl. the `≥95%` figure and the 3 hard-constraints
+block). No findings in this file itself — but see D2: the *callers* in
+`session-actions.ts` feed these builders mis-formatted step lines.
+
+---
+
+## Finding details
+
+### D1 — `[PLAN_DECISION]: rejected` injection diverges from the in-host runtime — parity-gap, P1
+
+**In-host**: `src/gateway/sessions-patch.ts:1043-1056`
+**Plugin**: `src/ui/session-actions.ts:412-418` → `src/runtime/injection-writer.ts:61-97`
+→ `src/prompt/plan-decision-injection.ts:47-73`
+
+The in-host runtime — the code that actually fires when a user rejects a plan via
+`sessions.patch { planApproval: "reject" }` — builds the reject injection **inline**:
+
+```js
+// sessions-patch.ts:1045-1050
+const safeFeedback = (feedback ?? "")
+  .replace(/@(channel|here|everyone)\b/gi, "@\u{FE6B}$1")
+  .replace(/<@/g, "<\u{200B}@");
+const rejectText = safeFeedback
+  ? `[PLAN_DECISION]: rejected\nfeedback: ${safeFeedback}`
+  : `[PLAN_DECISION]: rejected`;
+```
+
+The in-host runtime reject injection is **at most 2 lines**:
+`[PLAN_DECISION]: rejected` + (optionally) `feedback: <raw text>`. The feedback is
+sanitized with **mention-stripping** (`@channel`/`@here`/`@everyone` → `@﹫…`,
+`<@` → `<​@`) and is **not** JSON-quoted.
+
+`buildPlanDecisionInjection` (in-host `types.ts:185`) **exists** but has **zero
+non-test callers** in the in-host tree — `git grep` over `src/` (excluding `*.test.*`)
+finds only the definition (`types.ts:185`) and the barrel re-export
+(`plan-mode/index.ts:2`). It is a test-only / latent function. The in-host
+runtime does not use it.
+
+The plugin ports `buildPlanDecisionInjection` byte-faithfully (correct, it is a named
+parity target) **and then wires it as the live reject emitter**. The plugin's runtime
+`[PLAN_DECISION]: rejected` injection therefore differs from the in-host's in three
+observable ways:
+
+1. **Extra instruction lines** — the plugin appends
+   `Revise your plan based on the feedback and call update_plan again.` and (at
+   `rejectionCount >= 3`) the `Multiple revisions have been rejected…` deescalation
+   hint. The in-host runtime emits neither.
+2. **Feedback encoding** — plugin: `feedback: "looks wrong"` (JSON-quoted, with
+   surrounding double-quotes, `[/PLAN_DECISION]`→ZWSP sanitized). In-host runtime:
+   `feedback: looks wrong` (raw, unquoted, mention-stripped).
+3. **Sanitization domain** — plugin neutralizes the envelope-closing tag; in-host
+   runtime neutralizes chat-platform mentions. Neither applies the other's sanitizer,
+   so an adversarial feedback string is differently (and incompletely) defended on
+   each side.
+
+**Why this is P1 not P2**: the `[PLAN_DECISION]:` injection is a synthetic message the
+agent reads verbatim at the top of its next turn; its bytes steer behavior. A plugin
+that emits a different reject injection than the in-host is, by the audit's mandate, a
+parity break — and the `feedback:` line difference is directly user-visible in the
+agent's context. It is not P0 because both forms are individually well-formed and the
+plugin's variant is arguably *better* (the revise steer + deescalation hint are
+useful). The brief's note that `buildPlanDecisionInjection` is a parity target is
+satisfied at the *function* level; the gap is that the in-host runtime emitter is
+`sessions-patch.ts`, not that function.
+
+**Recommended resolution** — pick ONE and document it:
+- (a) **True parity**: change `enqueuePlanDecisionInjection`'s reject branch to emit
+  the in-host runtime's 2-line inline form (incl. the `@channel`/`<@` mention-strip),
+  and keep `buildPlanDecisionInjection` as a parity-pinned-but-unused mirror of
+  `types.ts` (matching its in-host latent status). OR
+- (b) **Documented intentional upgrade**: keep `buildPlanDecisionInjection` as the live
+  emitter but add a `host_ref:` + a `PARITY NOTE` stating the plugin deliberately uses
+  the richer (test-covered) `types.ts` form rather than the in-host runtime's thinner
+  inline form, and ALSO add the mention-stripping so the chat-safety property is not
+  lost on Telegram/Slack channels. (b) is the better product outcome; (a) is stricter
+  parity. Either is acceptable — silent divergence is not.
+
+### D2 — Approved-plan step lines append `status`, not `activeForm` — parity-gap, P1
+
+**In-host**: `src/gateway/sessions-patch.ts:1002-1004`
+**Plugin**: `src/ui/session-actions.ts:69-79` (`planStepsToInjectionLines`)
+
+When a plan is approved, the in-host builds the per-step lines that feed
+`buildApprovedPlanInjection` / `buildAcceptEditsPlanInjection` like this:
+
+```js
+// sessions-patch.ts:1002-1004
+const approvedSteps = (next.planMode?.lastPlanSteps ?? []).map((step) =>
+  step.activeForm ? `${step.step} (${step.activeForm})` : step.step,
+);
+```
+
+The parenthetical carries **`activeForm`** — the gerund/progress phrasing
+(e.g. `Run migration (Running migration)`), present iff `activeForm` is set.
+
+The plugin's `planStepsToInjectionLines` does:
+
+```js
+// session-actions.ts:69-79
+return steps.map((s) => {
+  if (s.status === "pending") return s.step;
+  return `${s.step} (${s.status})`;
+});
+```
+
+The parenthetical carries **`status`** — the status enum
+(e.g. `Run migration (in_progress)`), present iff `status !== "pending"`.
+
+The plugin's own inline comment (`session-actions.ts:71-73`) claims *"Match in-host's
+per-step format"* — but it does not. The in-host appends the gerund description; the
+plugin appends the status string. Different field, different gating condition.
+
+The plugin's `PlanStep` type (`src/types.ts:85-89`) has **both** `status: string` and
+`activeForm?: string`, and the in-host `lastPlanSteps[]` shape
+(`config/sessions/types.ts:334-340`) has the same `step` / `status` / `activeForm?`
+trio — so the data is available on both sides. The plugin simply reads the wrong field.
+
+**Impact**: the step list inside the `[PLAN_DECISION]: approved` (and `: edited`)
+injection — the concrete plan the agent executes from — has different bytes than the
+in-host emits. For a fresh plan (all steps `pending`, no `activeForm`) the outputs
+coincide (both emit bare `step`), which is why existing tests pass. They diverge for
+any partially-started plan (a resumed cycle, a re-approval after revision).
+
+**Recommended resolution**: change `planStepsToInjectionLines` to
+`s.activeForm ? \`${s.step} (${s.activeForm})\` : s.step` and correct the misleading
+comment. Add a test with a step carrying `activeForm` so the regression is pinned.
+
+### D3 — No byte-fixture test pins prompt artifacts against in-host bytes — test-gap, P1
+
+**Plugin**: `tests/prompt/plan-mode-injection.test.ts`,
+`tests/prompt/reference-card.test.ts`, `tests/parity/parity-harness.test.ts`
+
+The cluster's docstrings advertise byte-identity enforcement that does not exist:
+
+- `archetype-prompt.ts:18-20`: *"Tests assert byte-identical match against the in-host
+  source (parity-harness Layer 1 extension at
+  `tests/parity/archetype-prompt-parity.test.ts`)."* — **that file does not exist.**
+- `plan-mode-injection.ts:36-40`: refers to a "parity-harness Layer-1 diff" catching
+  drift in the system-prompt block.
+
+The actual parity harness (`tests/parity/parity-harness.test.ts` →
+`parity-harness/diff.ts`) runs `inputs/persistApprovalRequest.json` — it tests the
+`PlanModeStore` state machine, **not** any prompt string.
+
+Every prompt-string test is a substring `.toContain()` assertion or a wide length
+window:
+
+- `plan-mode-injection.test.ts` — all `.toContain()` / ordering `indexOf` checks. The
+  closest thing to a byte pin, *"byte count is stable (regression sentinel)"*
+  (line 239-246), only asserts `length > 4000 && length < 6000` — a **2000-byte**
+  tolerance window. A paraphrase, an added sentence, or whitespace drift of up to
+  ~1000 bytes passes.
+- `reference-card.test.ts` — `.toContain()` for sections/tags/commands; `length > 1000`;
+  `.toBe(PLAN_MODE_REFERENCE_CARD)` against *itself* (tautology, line 69).
+- `plan-decision-injection.test.ts` — phrase `.toMatch()` only.
+
+None of these would catch the byte drift this cluster is explicitly chartered to
+prevent (cache-bust). Today the artifacts *are* byte-identical (verified in this
+audit), so the gap is latent — but the test suite gives a false sense of protection: a
+future paraphrase in `archetype-prompt.ts` would ship green.
+
+**Recommended resolution**: add a real fixture test. Either (a) commit the three
+in-host strings as fixtures under `tests/prompt/__fixtures__/` (snapshotted from
+branch `rebase/pr70071-onto-main-2026-04-25` @ `ea04ea52c7`) and `expect(actual).toBe(fixture)`,
+or (b) extend the parity harness with a Layer-1 prompt diff that reads the in-host
+files directly (the harness already knows the in-host path). Tighten the
+`byte count is stable` sentinel to an exact `===` once a fixture exists. Create the
+`archetype-prompt-parity.test.ts` the docstring promises, or delete the docstring
+claim.
+
+### D4 — Stale `host_ref:` line numbers — parity-gap, P2
+
+**Plugin**: `src/prompt/plan-decision-injection.ts:6`,
+`src/prompt/pending-injections.ts` (multiple)
+
+The `host_ref:` citations have drifted from the in-host at `ea04ea52c7`:
+
+- `plan-decision-injection.ts:6` cites `types.ts:172-209` for `buildPlanDecisionInjection`.
+  Actual: the function declaration is at `types.ts:185`; the docstring begins ~`:166`.
+  The `:172-209` range is approximately right but the headline number (`172`) is off.
+- `plan-decision-injection.ts:5` (and the test header) also cite `types.ts:172-209`.
+- `pending-injections.ts:5-7` cites `injections.ts:43-103` for a port of
+  `appendPendingAgentInjection`. **There is no function named
+  `appendPendingAgentInjection`** in the in-host `injections.ts` — the writers are
+  `enqueuePendingAgentInjection` (`:209`), `appendToInjectionQueue` (`:183`),
+  `upsertIntoQueue` (`:159`). The `:43-103` range covers the priority table +
+  migration helper, not those writers.
+- `pending-injections.ts:111` cites `injections.ts:347-360` for
+  `composePromptWithPendingInjections` — **correct** (`:347` is the declaration).
+- `sanitize.ts` cites `types.ts:158-160` for `sanitizeFeedbackForInjection` —
+  **correct** (`:158`).
+
+These are documentation-accuracy defects, not behavioral — hence P2. But they actively
+mislead the next porter (e.g. someone looking for `appendPendingAgentInjection` will
+not find it). Recommended: re-derive every `host_ref:` against `ea04ea52c7` and pin the
+function name, not just a line range.
+
+### D5 — Plan-decision idempotency key includes `:${decision}` — parity-gap, P2
+
+**In-host**: `src/gateway/sessions-patch.ts:1011-1016, 1051-1056`
+**Plugin**: `src/runtime/injection-writer.ts:78, 153`
+
+The in-host queue-entry id for a plan decision is `plan-decision-${approvalId}` — the
+decision string is **not** part of the key. Because `appendToInjectionQueue` upserts by
+`id`, an approve-then-reject (or reject-then-approve) on the **same** `approvalId`
+**replaces** the earlier entry — last write wins, one entry drains.
+
+The plugin's idempotency key is `smarter-claw:plan_decision:${approvalId}:${decision}`
+— the decision string **is** part of the key. So approve and reject on the same
+`approvalId` become **two distinct entries**; both survive to drain time and the agent
+sees both, relying on drain-order recency to pick the winner.
+
+The plugin documents this explicitly (`injection-writer.ts:31-40, 55-57`) as an
+intentional choice ("Approve-then-reject races become two distinct enqueues … the
+later one wins by drain-time recency"). It is a defensible SDK-seam adaptation — the
+host's `idempotencyKey` is per-plugin-per-session and the plugin cannot reach the
+host's raw `id`-upsert. But it is still a behavioral divergence from the in-host's
+upsert-by-`approvalId` semantics, and on a genuine approve/reject race the agent gets
+two `[PLAN_DECISION]:` lines instead of one. P2 because the race window is narrow and
+the docstring owns the decision; flagged so it is a *known* divergence, not a silent
+one. Recommended: keep, but cross-reference D1's resolution — if the reject path is
+re-aligned, revisit whether the `:${decision}` suffix should stay.
+
+---
+
+## Cross-cutting note — `buildPlanDecisionInjection` is a latent in-host function
+
+D1 and D3 share a root cause worth stating once. `buildPlanDecisionInjection`
+(in-host `types.ts:185`) is **defined and tested but never called by in-host runtime
+code**. The in-host runtime reject path (`sessions-patch.ts`) re-implements the
+2-line form inline. The plugin port treated `buildPlanDecisionInjection` as the
+source-of-truth for the reject injection — a reasonable assumption from the function's
+name and its presence in `approval.test.ts`, but the *runtime* source-of-truth is
+`sessions-patch.ts`. When re-porting an injection, verify the **runtime caller**, not
+just the most plausibly-named builder. (This mirrors MEMORY's
+`feedback_wire_as_you_go` / `code-as-ground-truth` lessons: the live emitter is the
+contract.)
+
+---
+
+## Verdict summary
+
+The **system-prompt prefix is byte-clean** — `plan-mode-injection.ts` (ACTIVE +
+AVAILABLE), `archetype-prompt.ts`, and `reference-card.ts` are all confirmed
+byte-identical to the in-host at `ea04ea52c7`. The prompt-cache key is not at risk.
+`approval.ts` and `composePromptWithPendingInjections` are likewise byte-identical.
+
+The real exposure is in the **injection builders + their wiring**: the live reject
+injection (D1) and the approved-plan step formatting (D2) diverge from the in-host
+*runtime* emitter, and the test suite does not actually pin prompt bytes against the
+in-host (D3) despite docstrings claiming it does. None are P0 — no crash, no data loss,
+both prompt variants well-formed — but D1/D2 produce observably different agent-facing
+bytes for the reject and resumed-plan paths, and D3 leaves the cluster's core
+parity guarantee unenforced.

--- a/docs/audits/parity-refresh/slice-audit-E-runtime.md
+++ b/docs/audits/parity-refresh/slice-audit-E-runtime.md
@@ -1,0 +1,316 @@
+# Parity Refresh — Slice Audit E: Runtime + Foundation Cluster
+
+**Auditor:** parity-refresh slice-E agent (adversarial, read-only against in-host)
+**Date:** 2026-05-19
+**Cluster:** S6 (plan-tier model), S7 (escalating retry), S11 (grant-ledger + debug-log), S13 (plugin foundation), S14 (public types + helpers)
+**In-host source-of-truth:** branch `rebase/pr70071-onto-main-2026-04-25` commit `ea04ea52c7` in `/Volumes/LEXAR/repos/openclaw-pr70071-rebase`
+**Installed SDK:** OpenClaw `2026.5.18` (per `docs/audits/AUDIT-E-sdk-seam-parity.md` re-execution)
+
+---
+
+## Method
+
+- Mechanical byte-comparison of all 24 S7 constants (extracted both sides via regex, diffed programmatically).
+- Line-by-line diff of S14 helpers (`approval-id`, `payload-hash`, `sanitize`) and `types.ts` against in-host `plan-mode/types.ts` + `tools/exit-plan-mode-tool.ts`.
+- Diff of plugin `debug-log.ts` event union vs in-host `plan-mode-debug-log.ts`.
+- SDK seam re-check: `node_modules/openclaw/dist/plugin-sdk` for `registerSessionSchedulerJob`, `registerCommand`, `before_agent_finalize` event shape.
+- Test-coverage review: `tests/runtime/*`, `tests/types.test.ts`, `tests/helpers/*`, `tests/p1-skeleton.test.ts`.
+
+---
+
+## Per-file verdict
+
+| File | Slice | Verdict | Notes |
+|---|---|---|---|
+| `src/runtime/escalating-retry-constants.ts` | S7 | **PASS** | All 24 constants byte-identical to in-host. PR #89 re-port verified. |
+| `src/runtime/escalating-retry.ts` | S7 | **PASS-with-gaps** | Coarse detection honestly documented. One stale doc + one new-seam opportunity (E-3, E-4). |
+| `src/runtime/plan-tier-model.ts` | S6 | **PASS-with-gaps** | Plugin-invented feature, honestly flagged as having no in-host counterpart. Turn-limit watchdog deferral is now **stale** (E-1). |
+| `src/runtime/debug-log.ts` | S11 | **PARITY-GAP** | Event union diverges from in-host in 4 event kinds. Not byte-parity despite "verbatim" claim (E-2). |
+| `src/runtime/grant-ledger.ts` | S11 | **PASS** | Plugin-only correlation cache; process-local is intentional + documented. |
+| `src/index.ts` | S13 | **PASS-with-gaps** | All 5 hooks + tool/command/CLI/UI registrations wired. Hotfix #93 `registerCommand` confirmed valid (E-5). Provider/model not threaded (E-4). |
+| `src/types.ts` | S14 | **PASS** | Matches in-host union + interface; additive-only extra fields documented. |
+| `src/helpers/approval-id.ts` | S14 | **PASS-with-gaps** | Logic byte-identical; one error-message string diverged (E-7). |
+| `src/helpers/payload-hash.ts` | S14 | **PASS** | Byte-identical to in-host `exit-plan-mode-tool.ts:353-362`. |
+| `src/helpers/sanitize.ts` | S14 | **PASS** | Byte-identical ZWSP replacement; U+200B verified. |
+
+---
+
+## Findings table
+
+| ID | Severity | Class | Title | In-host ref | Plugin ref |
+|---|---|---|---|---|---|
+| E-1 | **P1** | parity-gap | S6 turn-limit watchdog deferral is now stale — the blocking seam exists | `incomplete-turn.ts` (loop-bound rationale) | `plan-tier-model.ts` (no watchdog); `docs/audits/wave-1/S6-S13-S14-foundation.md:159-196` |
+| E-2 | **P1** | parity-gap | `debug-log.ts` event union diverges from in-host despite "verbatim port" claim | `plan-mode-debug-log.ts:63-141` | `src/runtime/debug-log.ts:60-131` |
+| E-3 | **P2** | bug | `escalating-retry.ts` doc comment cites wrong `maxAttempts` & stale line numbers | `incomplete-turn.ts:151-265` | `escalating-retry.ts:27-39`; `tests/runtime/escalating-retry.test.ts:18-22` |
+| E-4 | **P2** | missing-feature | `before_agent_finalize` now exposes `provider`+`model`; plugin discards them | `incomplete-turn.ts:556-573` (provider-gated detection) | `src/index.ts:530-547`; `escalating-retry.ts:79-101` |
+| E-5 | **P2** | test-gap | `registerCommand` (hotfix #93) has no unit/skeleton-test coverage | n/a | `src/index.ts:322-333` |
+| E-6 | **P1** | bug | `madeToolCall` proxy via `stopHookActive` is semantically unverified and likely wrong | `incomplete-turn.ts` (real `toolMetas`) | `src/index.ts:539`; `escalating-retry.ts:86-91` |
+| E-7 | **P2** | parity-gap | `newPlanApprovalId` throw-message says `"newPlanApprovalId:"`; in-host says `"buildApprovalId:"` | `plan-mode/types.ts:142` | `helpers/approval-id.ts:66` |
+| E-8 | **P2** | test-gap | `newPlanApprovalId` hard-refuse (throw-on-missing-RNG) path still untested | `approval.test.ts:247-261` (entropy only) | `tests/helpers/approval-id.test.ts:12-16` (explicitly deferred) |
+| E-9 | **P2** | test-gap | No test pins `index.ts` hook *registration* — degraded-state + 5-hook wiring | n/a | `tests/p1-skeleton.test.ts` (module-shape only) |
+| E-10 | **P2** | test-gap | `escalating-retry` attemptIndex is never wired from a real counter; cross-cycle staleness untested | `incomplete-turn.ts` (host counts via idempotencyKey) | `src/index.ts:542-547` (omits `attemptIndex`) |
+| E-11 | **P2** | parity-gap | S11 grant-ledger correlation is never consumed — `record`/`prune` wired, but no read path | `plan-mode-debug-log.ts` correlation enrichment | `src/index.ts:255-277` (writes only); `grant-ledger.ts:98-106` (`get` unused in `src/`) |
+
+---
+
+## Detail
+
+### E-1 — S6 turn-limit watchdog deferral is stale (P1, parity-gap)
+
+The Wave-1 foundation audit (`docs/audits/wave-1/S6-S13-S14-foundation.md:25,159-196`) deferred the
+turn-limit watchdog with the explicit rationale: *"would need `registerSessionSchedulerJob` wiring"* — i.e.
+the deferral was **conditioned on the SDK seam not existing**.
+
+That condition no longer holds. On the installed SDK (`2026.5.18`):
+
+- `node_modules/openclaw/dist/plugin-sdk/src/plugins/types.d.ts:1982` —
+  `registerSessionSchedulerJob: (job: PluginSessionSchedulerJobRegistration) => PluginSessionSchedulerJobHandle | undefined`
+  exposed on `api.session.workflow`.
+- `host-hooks.d.ts:151` defines `PluginSessionSchedulerJobRegistration`; `:162` defines the handle.
+- `api-builder.d.ts:17` confirms it is part of the public `OpenClawPluginApi` surface.
+
+So the seam the deferral waited for **is shipping**. The watchdog is the single biggest functional gap
+in S6 (the Wave-1 audit's own conclusion at line 305), and its primary use case — auto-mode + repeated
+rejections — is *exactly* the scenario Smarter-Claw markets. The plugin already carries
+`rejectionCount` on `PlanModeSessionState` (`types.ts:139`) and `autoApprove` (`types.ts:212`), so the
+state needed to trip a watchdog is present.
+
+**Verdict:** This is now a *silent divergence*, not an honest limitation. The "deferred" status is
+documented against a precondition that has expired. Either (a) implement the watchdog via
+`registerSessionSchedulerJob`, or (b) re-document the deferral with a *current* rationale (e.g. "v1.0
+scope cut") and a tracking issue — not "the seam doesn't exist."
+
+`plan-tier-model.ts` itself is sound: its `host_ref` honestly states the in-host has no centralized
+model-override file and that `modelOverride` is a generic per-session field (confirmed — in-host
+`agent-command.ts:184,668,705` treats `modelOverride` as a session-entry field, never plan-mode-scoped).
+The plan-tier-model hook is a *plugin-invented* feature, acceptably flagged. No finding on the override
+logic itself.
+
+### E-2 — `debug-log.ts` event union diverges from in-host despite "verbatim" claim (P1, parity-gap)
+
+`src/runtime/debug-log.ts:57-59` claims: *"Port verbatim from in-host plan-mode-debug-log.ts:63-141."*
+It is **not** verbatim. Diffing the two `PlanModeDebugEvent` unions:
+
+| Event kind | In-host shape | Plugin shape | Divergence |
+|---|---|---|---|
+| `tool_call` | `tool: "enter_plan_mode" \| "exit_plan_mode" \| "update_plan" \| "ask_user_question"`; `runId: string`; `details?` | `tool: string`; `mode: string`; `meta?`; `approvalRunId?`; `approvalId?` | **Different fields entirely** — in-host has `runId`, plugin has `mode`+`meta`. In-host `tool` is a 4-value union; plugin is open `string`. |
+| `synthetic_injection` | `tag: string`; `preview: string` | `injectionKind: string`; `idempotencyKey?` | **Different field names** — `tag`/`preview` vs `injectionKind`/`idempotencyKey`. |
+| nudge event | kind = `nudge_event`; `nudgeId`; `phase: "scheduled"\|"fired"\|"cleaned"` | kind = `nudge_phase`; `phase: string`; `details?` | **Different kind name** (`nudge_event` vs `nudge_phase`) and field set. |
+| approval event | kind = `approval_event`; `action`; `openSubagentCount`; `result` | (absent) | **Plugin drops the `approval_event` kind entirely.** |
+| toast event | kind = `toast_event`; `toast`; `phase: "fired"\|"dismissed"` | kind = `ui_toast`; `message`; `severity?` | **Different kind name + fields.** |
+| `subagent_event` | `parentRunId`; `childRunId`; `event: "spawn"\|"return"` | `event: string`; `details?` | In-host has explicit parent/child runIds; plugin has open `string`. |
+
+Only `state_transition`, `gate_decision`, and `approval_transition` are genuinely shape-compatible.
+
+This matters because the debug log is the operator's correlation surface — a `grep '\[plan-mode/'`
+runbook written against the in-host taxonomy (`nudge_event`, `toast_event`, `approval_event`) will
+silently miss events on the plugin. The header's "verbatim" claim is false and should be downgraded to
+"semantic port; event taxonomy adapted to the SDK surface" with a divergence table, OR the union should
+be re-aligned. Given S11's purpose is operator debuggability, the honest fix is to align the kind names
+at minimum (`nudge_phase`→`nudge_event`, `ui_toast`→`toast_event`) and restore `approval_event`.
+
+Sub-note: plugin's `tool_call` event has no `runId` field, so a plugin debug stream cannot correlate a
+tool call to an agent run the way the in-host stream can — a real loss of the C7 correlation design the
+header claims to preserve.
+
+### E-3 — `escalating-retry.ts` doc comment cites wrong `maxAttempts` + stale line numbers (P2, bug)
+
+`escalating-retry.ts:27` header says *"Escalation levels (max 3 retries per cycle)"*. That is correct
+only for `PLANNING_RETRY`. `PLAN_YIELD` and `PLAN_ACK_ONLY` both cap at **2**
+(`DEFAULT_PLAN_APPROVED_YIELD_RETRY_LIMIT = 2`, `DEFAULT_PLAN_MODE_ACK_ONLY_RETRY_LIMIT = 2`) — and the
+code itself sets `maxAttempts: 2` for those (lines 144, 161). The blanket "max 3" header is misleading.
+
+Separately, `escalating-retry.test.ts:19` claims the regex constants are *"byte-identical
+(incomplete-turn.ts:66-74)"* — the actual in-host regex block is lines **66-89** (six regexes, the
+`PLANNING_ONLY_ACTION_VERB_RE` ends at line 89). And line 21 references
+`incomplete-turn.ts:151-265` for instruction strings — those are actually at the lines noted in the
+constants file's own headers (151-156, 157-160, 161-166, 226-243, 254-265), so "151-265" as a single
+range silently includes unrelated code. Cosmetic, but a parity-harness Layer-1 diff keyed on those line
+numbers would mis-anchor. Tighten the citations.
+
+The constants themselves are **byte-perfect** (24/24 verified) — this is a documentation-accuracy bug,
+not a constants regression.
+
+### E-4 — Plugin discards the now-available `provider`+`model` finalize fields (P2, missing-feature)
+
+Wave-0's AUDIT-E re-execution (`docs/audits/AUDIT-E-sdk-seam-parity.md:372-376`) found that on
+`2026.5.18` the `before_agent_finalize` event gained `provider`, `model`, and `messages` fields —
+confirmed at `node_modules/openclaw/dist/plugin-sdk/src/plugins/hook-types.d.ts:143-150`:
+
+```ts
+export type PluginHookBeforeAgentFinalizeEvent = {
+    runId?: string; sessionId: string; sessionKey?: string; turnId?: string;
+    provider?: string;   // <-- new on 2026.5.18
+    model?: string;      // <-- new on 2026.5.18
+    cwd?: string; transcriptPath?: string;
+    stopHookActive: boolean; lastAssistantMessage?: string; messages?: unknown[];
+};
+```
+
+The in-host detection is provider-gated: `incomplete-turn.ts:556-573` only applies incomplete-turn
+recovery for `isStrictAgenticSupportedProviderModel` or the Gemini provider set
+(`GEMINI_INCOMPLETE_TURN_PROVIDER_IDS`). The plugin's `TurnSignal` (`escalating-retry.ts:79-101`) has
+**no** `provider`/`model` field, and `src/index.ts:542-547` builds the signal without reading
+`event.provider` / `event.model`. Result: the plugin retries uniformly regardless of provider, which
+diverges from in-host behavior (in-host would NOT retry for an unsupported provider).
+
+This is a *missing-feature* (the seam is available, the parity behavior is not built), severity P2
+because the plugin's coarse detector is already a documented approximation. But it should be noted in
+the coarse-detection limitation comment, and `provider`/`model` should be threaded through `TurnSignal`
+so a future PR can gate. Right now the divergence is silent — the coarse-detection doc block
+(`escalating-retry.ts:40-59`) lists what's deferred but does NOT mention provider gating.
+
+### E-5 — `registerCommand` (hotfix #93) has no test coverage (P2, test-gap)
+
+`src/index.ts:322-333` registers `/plan` and `/plan-mode` slash commands via `api.registerCommand`.
+`registerCommand` is confirmed a real SDK seam (`registry.d.ts:67`, `types.d.ts:2142`,
+`api-builder.d.ts:17`) — the wiring is valid. But `tests/p1-skeleton.test.ts` only asserts module
+shape (id/name/description/register fn). No test exercises the command registration, the
+`sessionActionHandlers` snapshot map (`index.ts:303-315`), or the `/plan accept|reject|cancel|edit|answer`
+→ session-action routing. The slash-command wiring is a hotfix with zero regression net.
+
+### E-6 — `madeToolCall` proxy via `stopHookActive` is semantically unverified (P1, bug)
+
+`src/index.ts:539`: `const madeToolCall = event.stopHookActive === true;`
+
+The plugin's own comment (`escalating-retry.ts:86-91`) and the Wave-1 S7 report
+(`docs/audits/wave-1/S7-escalating-retry.md`, "`event.stopHookActive` semantics — 40%, assumed not
+verified") both flag this as a *guess*. The SDK type (`hook-types.d.ts:148`) gives `stopHookActive` no
+doc comment at all. Conventionally `stopHookActive` indicates *"this finalize is a re-invocation of a
+stop hook"* — i.e. it is about hook re-entrancy, NOT about whether the turn called a tool. If that
+conventional meaning holds, then `madeToolCall` is **wrong**:
+
+- A genuine chat-only first turn has `stopHookActive = false` → plugin infers `madeToolCall = false` →
+  detector fires. (Happens to be correct by accident.)
+- A tool-call turn that is NOT a stop-hook re-invocation also has `stopHookActive = false` → plugin
+  infers `madeToolCall = false` → detector **wrongly fires a retry on a turn that already acted.**
+
+This is the single highest-risk correctness issue in the cluster: the entire 3-detector mechanism keys
+off `madeToolCall`, and `madeToolCall` is derived from a field whose semantics are unverified and
+plausibly unrelated. The in-host uses real `toolMetas` (a list of actual tool calls) — there is no
+honest proxy for that in the SDK event today. This should be escalated: either (a) find a real seam
+(`messages?: unknown[]` is now on the event — the plugin could inspect the last message for tool-call
+content), or (b) the coarse-detection doc must explicitly state "tool-call detection is a heuristic
+proxy via `stopHookActive` and may false-positive" — currently it claims `stopHookActive` "IS true
+during turns that resolved via stop_hook (which fires for tool-call-using turns)" (`index.ts:537-538`),
+an assertion with no SDK-doc backing.
+
+`messages?: unknown[]` arriving on the event (E-4 / AUDIT-E line 374) is the unblock here — the plugin
+can now inspect the final message array for tool-call entries instead of guessing from `stopHookActive`.
+
+### E-7 — `newPlanApprovalId` throw-message diverges (P2, parity-gap)
+
+`helpers/approval-id.ts:66-68` throws with a message beginning `"newPlanApprovalId: no
+cryptographically secure RNG available..."`. The in-host (`plan-mode/types.ts:142`) throws the *same*
+message but beginning `"buildApprovalId: ..."`. The file header claims *"This is a byte-identical
+port"* (`approval-id.ts:45`). It is not — the function-name prefix in the error string differs. Either
+the in-host has a stale name (`buildApprovalId` was likely the pre-rename identifier) and the plugin
+"fixed" it silently, or the plugin should match. Low impact (error text only), but it contradicts the
+explicit byte-identical claim and a parity-harness string diff will flag it. Recommend: match in-host
+exactly, or downgrade the header claim to "logic-identical port; error string corrected to current
+function name."
+
+The rest of `approval-id.ts` (resolution order, `globalThis.crypto` → `node:crypto` → throw, the
+`plan-` prefix, the v4-UUID `isPlanApprovalId` regex) **is** byte/behavior-identical. The plugin also
+*adds* `isPlanApprovalId`, which the in-host `types.ts` does not export — an additive helper, fine.
+
+### E-8 — `newPlanApprovalId` hard-refuse path untested (P2, test-gap)
+
+`tests/helpers/approval-id.test.ts:12-16` explicitly defers the throw-on-missing-RNG test:
+*"NOT covered here (deferred): Throw-on-missing-RNG fallback path."* The Wave-1 audit
+(`S6-S13-S14-foundation.md:216,284,304`) already flagged this as the highest-leverage S14 gap. The
+throw is a *security* contract (refuse to mint a weak token rather than silently degrade
+plan-approval staleness protection). It remains untested. The hard-refuse path is reachable in a test
+by stubbing both `globalThis.crypto` and the `node:crypto` import — awkward but not impossible with
+`vi.mock`. This carried over un-actioned from Wave-1.
+
+### E-9 — No test pins `index.ts` hook registration / degraded-state wiring (P2, test-gap)
+
+`tests/p1-skeleton.test.ts` covers `resolveConfig` and `buildAdvisorySessionMessage` in isolation but
+never calls `register(api)` with a fake `api`. So nothing asserts:
+
+- All 5 hooks (`before_tool_call`, `before_model_resolve`, `before_agent_finalize`,
+  `before_prompt_build`, `session_start`) are actually registered.
+- `before_model_resolve` is registered **only when `config.planTierModel` is set** (`index.ts:504`) —
+  a conditional registration with no test.
+- `enabled: false` skips all wiring (`index.ts:170-177`).
+- The session-extension namespace is registered.
+
+A fake-`api` test that records `api.on` / `api.registerTool` / `api.registerCommand` calls would close
+this. The Wave-1 S13 section flagged "manifest accepts, implementation no-ops" as the dominant prior
+failure mode — registration is exactly where that bug class lives, and it has no net.
+
+### E-10 — `attemptIndex` never wired; cross-cycle counter staleness untested (P2, test-gap)
+
+`escalating-retry.ts`'s `TurnSignal.attemptIndex` drives the FIRM/FINAL escalation. But
+`src/index.ts:542-547` constructs the signal **without** `attemptIndex`, so it always defaults to 0 —
+the plugin always emits the *standard* instruction and never escalates to FIRM/FINAL in production.
+The escalation resolvers are unit-tested in isolation (`escalating-retry.test.ts:406-458`) but the
+*integration* — "does the plugin ever actually escalate?" — is not, and the answer with current wiring
+is **no**. The SDK enforces `maxAttempts` via `idempotencyKey`, but the *instruction text* never
+escalates because the plugin never feeds back the attempt count. Either the host exposes a retry-count
+the plugin should read, or the escalation tiers are effectively dead code. This is a real
+parity/behavior gap dressed as a test gap — flagging P2 because the standard instruction still
+functions; the escalation is just inert.
+
+### E-11 — Grant-ledger correlation is write-only (P2, parity-gap)
+
+`src/index.ts:255-277` calls `grantLedger.record(...)` on pending-approval transitions and
+`grantLedger.prune(...)` on terminal states. But **nothing in `src/` ever calls `grantLedger.get(...)`**
+— the lookup the whole class exists for. `grant-ledger.ts:22-23` states the ledger's purpose is *"a
+CHEAP lookup by approvalId-only ... useful in hot paths like debug-log emit where the caller has an
+approvalId ... and wants to enrich the event with approvalRunId."* That enrichment never happens:
+`logPlanModeApprovalTransition` (`index.ts:244-251`) is called with `event.prev`/`event.next` directly
+and never consults the ledger. So S11's grant-ledger is currently a correctly-implemented, fully-tested
+data structure that is **wired in but never read** — pure overhead. Either wire the `get`-based
+enrichment into the debug-log emit path (the documented intent), or document the ledger as
+"infrastructure for a future correlation feature, not yet consumed." The process-local nature
+(resets on restart) is fine and matches the documented intent — the canonical data lives on the session
+row; the ledger is only a cache. No finding on persistence.
+
+---
+
+## `host_ref:` citation audit
+
+All cluster files carry `host_ref:` comments. Findings:
+
+- `escalating-retry-constants.ts` — citations present and **accurate** (verified line ranges).
+- `escalating-retry.ts` — present; line range `151-265` is over-broad (see E-3).
+- `plan-tier-model.ts` — present and **honest** ("in-host has no centralized model-override file").
+- `debug-log.ts` — present but the **"verbatim" claim is false** (see E-2). `host_ref:` line numbers
+  (`63-141`, `210-227`, `234-247`, `260-287`) are roughly right but the *content* diverges.
+- `grant-ledger.ts` — `host_ref: plan-mode-debug-log.ts:46-62` points at the C7 design-notes comment;
+  reasonable since the ledger is a plugin-only construct with no direct in-host counterpart.
+- `types.ts` — every type has a `host_ref:`; all verified accurate against in-host `plan-mode/types.ts`.
+- `approval-id.ts` — present; "byte-identical" claim is **false by one error string** (see E-7).
+- `payload-hash.ts` — `host_ref: exit-plan-mode-tool.ts:353-362` — verified **exact**.
+- `sanitize.ts` — `host_ref: plan-mode/types.ts:158-160` — verified **exact**.
+
+No `host_ref: TBD` anywhere (Guardrail #1 satisfied).
+
+---
+
+## Severity roll-up
+
+| Severity | Count | IDs |
+|---|---|---|
+| **P0** | 0 | — |
+| **P1** | 3 | E-1, E-2, E-6 |
+| **P2** | 8 | E-3, E-4, E-5, E-7, E-8, E-9, E-10, E-11 |
+
+**Total: 11 findings.**
+
+No P0: the constants are byte-perfect, the helpers are sound, and the gates this cluster touches are
+not in scope (S5/S12 are other slices). The P1s are: a stale deferral that has become a silent
+divergence (E-1), a false "verbatim" parity claim with a real operator-facing taxonomy mismatch (E-2),
+and an unverified-semantics proxy that the entire S7 detector mechanism depends on (E-6).
+
+## Honest-limitation vs silent-divergence ledger (per task spec)
+
+- **Honest limitation (acceptable):** S7 coarse detection collapsing ~7 in-host detectors into 3 — the
+  doc block (`escalating-retry.ts:40-59`) and test header own this explicitly. `plan-tier-model.ts`
+  being a plugin-invented feature — `host_ref` says so. Grant-ledger process-local — documented.
+- **Silent divergence (a finding):** E-1 (deferral rationale expired), E-2 ("verbatim" is false),
+  E-4 (provider gating dropped, not in the limitation list), E-6 (`stopHookActive` asserted to mean
+  tool-call with no SDK backing), E-7 ("byte-identical" false). E-10 (escalation tiers inert in
+  production despite being unit-tested as live).

--- a/docs/audits/parity-refresh/wave-1-catalog.md
+++ b/docs/audits/parity-refresh/wave-1-catalog.md
@@ -1,0 +1,173 @@
+# Wave 1 — Consolidated Findings Catalog
+
+**Date**: 2026-05-13
+**Plan**: parity-refresh + release-readiness, Wave 1.
+**Inputs**: 5 slice-audit reports (A–E), 3 build-specs (S16/S17/S18+S9), 1 benchmark.
+**Audit base**: plugin `main` post-#93 post-Wave-0; in-host source-of-truth `ea04ea52c7`; host `2026.5.18`.
+
+This catalog is the actionable input to **Wave 3 (Fix)**. Findings are
+grouped by **file-cluster** so Wave 3 can sequence PRs without merge
+collisions.
+
+---
+
+## Headline
+
+| Severity | Count | Meaning |
+|---|---|---|
+| **P0** | 2 | user-visible breakage class — both UX, neither a correctness/security regression |
+| **P1** | 17 | real, bounded — mostly "ported but never wired" + cross-platform gaps |
+| **P2** | ~30 | polish, test-gaps, stale citations |
+
+**Zero P0 correctness or security regressions.** The gates are
+byte-identical to in-host; the 10 `persistApprovalRequest` invariants
+are all present + correct; the system-prompt block is byte-identical
+(verified by execution-diff). The security + state core is sound.
+
+**The dominant defect class: "ported but never wired."** Five separate
+findings (A5, C-1, D1, E-10, E-11) are in-host functions copied
+byte-faithfully into the plugin and then *never called* — or wired to
+the wrong consumer. This is the precise "port not done correctly"
+pattern: file-level copying without integration.
+
+**Two withdrawn findings** (prior audits were wrong):
+- Wave-1 "S12 P0 #2" (plain-Accept bypasses the accept-edits gate) —
+  **misdiagnosis**. In-host `sessions-patch.ts:982-993` confirms plain
+  Accept does NOT grant `acceptEdits` either. PR #90's trigger fix is
+  correct in-host parity. Withdrawn.
+- The `plan-resume` "visible continue-message leak on text channels" —
+  **verified false**. `resumePendingPlanInteraction` is webchat-only
+  and uses `deliver: false`. Withdrawn.
+
+---
+
+## P0 findings
+
+| ID | Type | Cluster | Description | Fix |
+|---|---|---|---|---|
+| **W1-P0-1** (BENCH-F1) | missing-feature | ui/session-actions | A pending plan sits `pending` with NO notification — the reference card even suppresses `[PLAN_NUDGE]` while pending. Codex shows action-required terminal titles + mobile push; Claude Code rings a bell. On Telegram/Slack the user gets no signal a plan is waiting. | Wire an action-required signal in the session-action layer (no SDK seam needed). |
+| **W1-P0-2** (BENCH-F2) | bug | prompt | The archetype prompt + reference card tell the model its `title` becomes a persisted `plan-YYYY-MM-DD-<slug>.md` file. **No code writes that file.** The prompt lies to the model. | Either write the markdown file on approval, OR remove the persistence claim from the prompt. Prefer writing it (matches in-host intent). |
+
+---
+
+## P1 findings — grouped by file-cluster
+
+### Cluster: tools (`src/tools/*`, `src/plan-mode/tool-descriptions.ts`, `auto-enable.ts`)
+
+| ID | Type | Description | In-host ref |
+|---|---|---|---|
+| **W1-A5** | parity-gap | `evaluateAutoEnableForMatch` (`src/plan-mode/auto-enable.ts`) is a byte-identical port but is **never called** anywhere in `src/`. A configured `agents.defaults.planMode.autoEnableFor` does nothing. The file header falsely claims it "restores that capability." | in-host wires it into the cron isolated-agent path |
+| **W1-A3** | parity-gap | `ask_user_question` tool description is a ~70-word paraphrase. In-host `describeAskUserQuestionTool()` is a 7-clause structured description (USE FOR / DO NOT USE FOR lists, `allowFreetext` pointer). Same drift class PR #87 fixed for enter/exit. | `tool-description-presets.ts` |
+| **W1-A1** | parity-gap | `exit_plan_mode`'s tool description PROMISES "the runtime rejects submission … listing pending child run ids" if subagents are in flight. The plugin has NEITHER the tool-side subagent gate NOR a gateway-side one. The description lies. | `exit-plan-mode-tool.ts` subagent gate |
+
+### Cluster: state (`src/state/store.ts`)
+
+| ID | Type | Description | In-host ref |
+|---|---|---|---|
+| **W1-C1** | parity-gap | `applyApprovalAction` (`store.ts:571`) calls `resolvePlanApproval(current, action, feedback)` with the 4th arg `expectedApprovalId` **omitted**. The plugin re-ported `resolvePlanApproval` byte-identically *including* its stale-event guard — but the mutators never thread the approval token, so the guard is dead code. A stale/cross-surface Approve resolves regardless of which `approvalId` the UI event carried. | `sessions-patch.ts:940` passes it |
+
+### Cluster: prompt + injection (`src/prompt/*`, `src/runtime/injection-writer.ts`, `src/ui/session-actions.ts`)
+
+| ID | Type | Description | In-host ref |
+|---|---|---|---|
+| **W1-D1** | parity-gap | The plugin emits `[PLAN_DECISION]: rejected` via `buildPlanDecisionInjection` — a byte-faithful port of an in-host function that has **zero non-test callers**. The in-host runtime reject path (`sessions-patch.ts:1045-1050`) builds a thinner 2-line form with raw (not JSON-quoted) feedback + `@channel`/`<@` mention-stripping. The plugin's runtime emitter is not in-host-parity. | `sessions-patch.ts:1045-1050` |
+| **W1-D2** | bug | `planStepsToInjectionLines` (`session-actions.ts:69-79`) appends each step's `status` enum; the in-host (`sessions-patch.ts:1002-1004`) appends `activeForm` (the gerund). The plugin reads the wrong field. Outputs coincide only for fresh all-`pending` plans — they diverge for any resumed/re-approved plan. | `sessions-patch.ts:1002-1004` |
+| **W1-D3** | test-gap | No byte-fixture test pins the prompt artifacts against in-host bytes. Docstrings reference a `tests/parity/archetype-prompt-parity.test.ts` that **does not exist**. Every prompt test is `.toContain()` or a wide length window — a paraphrase ships green. | — |
+
+### Cluster: runtime + foundation (`src/runtime/*`, `src/index.ts`)
+
+| ID | Type | Description | In-host ref |
+|---|---|---|---|
+| **W1-E6** | bug | The 3-detector escalating-retry mechanism keys off `madeToolCall`, which `index.ts:539` derives as `event.stopHookActive === true`. `stopHookActive` signals hook re-entrancy, **not** whether a tool ran. A real tool-call turn gets `madeToolCall=false` → spurious retry on a turn that already acted. The new `messages[]` field on `before_agent_finalize` (2026.5.18) is the correct signal. | `incomplete-turn.ts` |
+| **W1-E1** | parity-gap | The S6 turn-limit watchdog is documented as "deferred — needs `registerSessionSchedulerJob`". That seam **now ships** (`2026.5.18` `types.d.ts:1982`, `api.session.workflow`). The deferral is stale; the unbounded auto-mode-rejection loop it prevents is a marketed use case. | — |
+| **W1-E2** | bug | `debug-log.ts` claims a "verbatim port" of the in-host event union but 4 of 8 kinds diverge: `nudge_event`→`nudge_phase`, `toast_event`→`ui_toast`, `tool_call` drops `runId` (breaks C7 correlation), `approval_event` dropped entirely. | `plan-mode-debug-log.ts` |
+
+### Cluster: ui-surfaces (`src/ui/*`)
+
+| ID | Type | Description | In-host ref |
+|---|---|---|---|
+| **W1-S9-2** | bug | `session-actions.ts` `checkApprovalId` rejects any action when `approval !== "pending"`. But the re-ported `resolvePlanApproval` (`approval.ts:83`) treats `rejected` as **non-terminal** — re-approvable. The plugin's own session-action guard contradicts the state machine it dispatches to. | `approval.ts:83` |
+| **W1-S9-1** | parity-gap | The sidebar `PluginControlUiDescriptor` schema omits 5 fields the store actually writes: `enteredAt`, `confirmedAt`, `updatedAt`, `approvalRunId`, `lastPlanPayloadHash`. | — |
+| **W1-S18-1** | bug | Telegram caps its native slash menu at 100 commands; the gateway has 122 configured; plugin commands are in the dropped tail. `/plan` + `/plan-mode` may be **invisible** on Telegram's "/" autocomplete (functionality survives via the text pipeline). This is the most plausible match for the reported "doesn't work on Telegram." | — |
+| **W1-B4** | test-gap | The accept-edits trigger predicate (`approval === "edited"`) has **zero CI-runnable test** — coverage is an Eva live-smoke not in CI. A refactor re-breaking the predicate (the exact thing PR #90 fixed) ships green. | — |
+
+### Cluster: benchmark gaps (cross-cutting)
+
+| ID | Type | Description |
+|---|---|---|
+| **W1-F3** | missing-feature | No multi-surface approval — Approve/Edit/Reject buttons are sidebar-only. Telegram/Slack users get no interactive card. (Inline cards are upstream-SDK-blocked; a channel ping is not.) |
+| **W1-F4** | bug | `/plan auto on` flips an `autoApprove` flag that **does nothing** — the runtime that fires auto-approve "lands at P-final". A non-functional safety-relevant control. Wire it or hide it. |
+| **W1-F5** | parity-gap | `/plan answer` cannot resolve a pending `ask_user_question` on Telegram/Slack — needs plugin-side question-state tracking (also flagged as a known gap in #93). |
+
+---
+
+## P2 findings
+
+~30 P2s across the 5 slice audits + S9 — stale `host_ref:` citations
+(A: 3 misleading; D4; S9-3 cites a non-existent command), `apply_patch`
+extractor called unconditionally (B1), filePath-extraction priority
+drift (B2), `InMemoryGateway` lock granularity (C-2), no real-gateway
+round-trip test (C-4), FIRM/FINAL escalation tiers inert because
+`attemptIndex` is never fed (E-10), grant-ledger wired write-only —
+`get` never called (E-11), idempotency-key `:${decision}` suffix vs
+in-host upsert-by-`approvalId` (D5), etc. Full detail in the per-slice
+reports. Wave 3 triages P2s (fix-now vs defer-with-issue).
+
+---
+
+## Build-specs (Wave 4 + Wave 5 inputs)
+
+### S16 — channel-native approval (`buildspec-S16-channel-native.md`)
+
+**Key reframe**: in-host PR-70071 itself **never rendered native
+interactive buttons on Telegram/Slack** — PR-13 deferred it; the
+in-host shipped a read-only markdown attachment + the universal
+`/plan accept|revise` text commands. So "in-host parity" for
+cross-platform = working `/plan` commands + a visible approval prompt,
+NOT native buttons.
+
+**SDK seam**: `ChannelApprovalCapability` exists on `2026.5.18` but is
+the exec/tool-approval subsystem (`approvalKind: "exec" | "plugin"` —
+no `"plan"`) and attaches only via channel ownership. True native
+plan-approval buttons on built-in Telegram/Slack **need an upstream
+OpenClaw PR**. Path A (shippable now, ~260-340 LOC): channel-aware
+approval-prompt renderer + markdown bridge + reply-driven reject.
+
+### S17 — webchat inline UI (`buildspec-S17-webchat-ui.md`)
+
+The arch-v2 `10-UI_GAP_ANALYSIS.md` 25-element catalog is **still
+valid** (LOC counts re-verified). 4 components: mode-switcher chip,
+plan-cards, plan-approval-inline, plan-resume — **~2,595 LOC total**
+(6-PR ladder). **Biggest risk**: upstream PR `#80982` is still OPEN
+and its API drifted — the patcher manifest cherry-picks a stale
+"3-named-surface" design; the live PR is now a `registerChatStreamRenderer`
+seam. Also the content-hashed bundle names already rotated
+(`2026.5.18` ships `loader-CxUWY2_6.js`, not the manifest's
+`loader-DdN5GTsW.js`). The patcher MUST be regenerated and may need
+re-porting when `#80982` merges.
+
+### S18 — per-channel /plan routing (`buildspec-S18-S9-commands-ui.md`)
+
+`/plan` works on webchat YES, Telegram YES (text pipeline, Path A),
+Slack UNKNOWN (Slack plugin not installed locally to confirm — the
+universal path almost certainly works). The Telegram-menu-visibility
+risk is catalogued as W1-S18-1 above.
+
+---
+
+## What this means for the waves
+
+- **Wave 3 (Fix)** closes the 2 P0 + 17 P1. The "ported but never
+  wired" cluster (A5, C-1, D1, E-10, E-11) is fast — the code exists,
+  it just needs connecting + a test. The behavioral bugs (D2, E-6,
+  E-2, S9-2) are the careful ones.
+- **Wave 4 (cross-platform)** uses the S16 build-spec — and now knows
+  the honest target is `/plan` + markdown + a ping, with native
+  buttons as a separate upstream-gated enhancement.
+- **Wave 5 (webchat UI)** uses the S17 build-spec — and must resolve
+  the `#80982` upstream-PR drift before the patcher work.
+- **Benchmark verdict**: Smarter-Claw's enforcement core (mutation
+  gate, accept-edits gate, escalating retry, archetype steering)
+  genuinely beats Codex + Claude Code. It loses on the last-mile
+  surface — notification, multi-surface, plan persistence. All but
+  the inline cards are fixable without a new SDK seam.


### PR DESCRIPTION
## Summary

Parity-refresh **Wave 1** — 9 parallel adversarial audit agents across 3 tracks. Docs-only (no `src/` changes); the consolidated catalog feeds Wave 3.

## Headline

- **0 P0 correctness/security regressions.** Gates byte-identical to in-host; all 10 `persistApprovalRequest` invariants present + correct; system-prompt block byte-identical (execution-diff verified).
- **2 P0** (both UX-class): no action-required notification on a pending plan; the archetype prompt promises a persisted `plan-*.md` file no code writes.
- **17 P1** — dominated by a **"ported but never wired"** defect class: in-host functions copied byte-faithfully then never called (auto-enable matcher, stale-event guard, FIRM/FINAL tiers, grant-ledger `get`, the reject-injection emitter).
- **~30 P2** — stale citations, test-gaps, polish.

## Tracks

- **Track 1** — 5 cluster parity audits (`slice-audit-{A..E}.md`).
- **Track 2** — build-specs for S16 channel-native approval, S17 webchat inline UI, S18 `/plan` routing + S9 UI audit.
- **Track 3** — formal Codex CLI / Claude Code benchmark (16 rows: 8 ✅ / 5 ⚠️ / 3 ❌).

## Two prior findings withdrawn

- Wave-1 "S12 P0 #2" (plain-Accept gate bypass) — misdiagnosis.
- `plan-resume` visible-message leak — verified false.

## Notable

- The honest cross-platform target: in-host PR-70071 itself never shipped native Telegram/Slack buttons — `/plan` + markdown + a ping is in-host parity; native buttons need an upstream PR.
- The webchat UI (Wave 5) is genuinely blocked on upstream PR `#80982` drift + rotated `2026.5.18` bundle hashes.

## Test plan

- [x] Docs-only — no code changed
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive internal audit reports and benchmarks documenting feature parity analysis, implementation specifications, and findings catalogs for future development cycles.

---

**Note:** These are internal documentation updates with no direct impact to end-user functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/Smarter-Claw/pull/98?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->