### PR TITLE
Wave 3 (batch 1): fix W1-C1 stale-event guard + W1-S9-2 rejected-state

### DIFF
--- a/docs/audits/parity-refresh/EXECUTION-STATUS.md
+++ b/docs/audits/parity-refresh/EXECUTION-STATUS.md
@@ -38,9 +38,13 @@ complete, quality at-or-above Codex / Claude Code plan mode.
   ~30 P2; 0 correctness/security regressions.** Per-slice detail in
   `slice-audit-{A..E}.md`, build-specs `buildspec-S16/S17/S18*.md`,
   benchmark `benchmark-codex-claude-code.md`.
-- **Wave 3 batch 1 (PR #99, open)** — W1-C1 (stale-event guard was
-  dead code — threaded `expectedApprovalId`) + W1-S9-2 (`checkApprovalId`
-  contradicted the re-ported state machine — `rejected` is non-terminal).
+- **Wave 3 — in progress (PR #99, open, branch `wave-3/fixes`)** —
+  3 findings fixed so far:
+  - W1-C1 — stale-event guard was dead code; threaded `expectedApprovalId`.
+  - W1-S9-2 — `checkApprovalId` contradicted the re-ported state
+    machine; `rejected` is non-terminal.
+  - W1-D2 — plan-step injection appended `status` enum; in-host
+    appends `activeForm`. Fixed to byte-match.
 
 ---
 
@@ -52,7 +56,7 @@ Fix sequentially, one focused PR per cluster. IDs reference
 | Cluster | Findings | Files |
 |---|---|---|
 | tools | W1-A1 (subagent-gate description lies), W1-A3 (`ask_user_question` desc paraphrased), W1-A5 (auto-enable matcher dead code) | `src/tools/*`, `src/plan-mode/tool-descriptions.ts`, `auto-enable.ts`, `index.ts` |
-| prompt | W1-D1 (reject-injection emitter ≠ in-host form), W1-D2 (`activeForm` vs `status`), W1-D3 (no byte-fixture test — **overlaps Wave 2 harness; let Wave 2 own it**) | `src/prompt/*`, `injection-writer.ts`, `session-actions.ts` |
+| prompt | W1-D1 (reject-injection emitter ≠ in-host form); ~~W1-D2~~ ✅ done; W1-D3 (no byte-fixture test — **overlaps Wave 2 harness; let Wave 2 own it**) | `src/prompt/*`, `injection-writer.ts`, `session-actions.ts` |
 | runtime | W1-E1 (turn-limit watchdog deferral stale — seam now exists), W1-E2 (debug-log taxonomy diverged), W1-E6 (`madeToolCall` derived from wrong signal) | `src/runtime/*`, `index.ts` |
 | ui | W1-S9-1 (sidebar schema omits 5 fields), W1-S18-1 (Telegram 100-cmd menu hides `/plan`), W1-B4 (accept-edits trigger has no CI test) | `src/ui/*`, `index.ts` |
 | benchmark gaps | W1-F1 (no action-required notification — P0), W1-F2 (prompt promises a `plan-*.md` no code writes — P0), W1-F4 (`/plan auto` dead toggle) | `src/ui/session-actions.ts`, `src/prompt/*`, `index.ts` |
@@ -74,9 +78,12 @@ Fix sequentially, one focused PR per cluster. IDs reference
    shared across clusters → parallel fix agents merge-conflict, and
    each fix needs careful in-host matching + tests. One cluster, one
    PR, CI-gated, then the next.
-3. **Wave 2 is safe to parallelize** — it touches only
-   `parity-harness/` + `ci.yml`, zero overlap with Wave 3's `src/`.
-   Run it as one worktree-isolated background agent.
+3. **Wave 2 — do it directly, not via a background agent.** It is
+   logically isolated (`parity-harness/` + `ci.yml`), BUT the Agent
+   `isolation: "worktree"` option fails in this environment ("not in
+   a git repository" — the tool resolves from a non-repo cwd). Without
+   real worktree isolation, a background agent that runs `git` WILL
+   collide. So Wave 2 is done sequentially, by hand, like Wave 3.
 4. **CI is trustworthy as of PR #97** — the `| tee` exit-code masking
    is fixed. A red `ci` check is now a real signal.
 5. Every fix cites the in-host `host_ref:` and ships a test.

--- a/docs/audits/parity-refresh/EXECUTION-STATUS.md
+++ b/docs/audits/parity-refresh/EXECUTION-STATUS.md
@@ -1,0 +1,106 @@
+# Parity-Refresh — Execution Status (durable checkpoint)
+
+**Last updated**: 2026-05-13
+**Purpose**: canonical resume-from-here state for the Smarter-Claw
+plan-mode parity-refresh + release-readiness effort. The `~/.claude`
+plan file is NOT reliable (it gets recycled by other projects) — **this
+in-repo, git-committed doc is the source of truth.** A compacted or
+fresh session reads this first.
+
+---
+
+## The effort — 7 waves
+
+A reboot/refresh to get the plan-mode plugin truly release-ready:
+cross-platform approval + plan mode + commands all working, UI
+complete, quality at-or-above Codex / Claude Code plan mode.
+
+| Wave | Scope | Status |
+|---|---|---|
+| 0 | Pre-flight + host upgrade to OpenClaw `2026.5.18` | ✅ **merged (PR #97)** |
+| 1 | Parity re-audit + build-specs + Codex/CC benchmark | ✅ **merged (PR #98)** |
+| 2 | Parity harness Layer 1 (mechanical drift CI gate) | ⏳ needs isolated re-run |
+| 3 | Fix all P0/P1 findings | ▶ **in progress** — batch 1 merged-pending (PR #99) |
+| 4 | Cross-platform build (Telegram + Slack) | ⬜ pending |
+| 5 | Webchat inline UI + patcher | ⬜ pending (upstream-blocked) |
+| 6 | Final adversarial + 3-channel smoke + release | ⬜ pending |
+
+---
+
+## Done
+
+- **Wave 0 (PR #97, merged)** — `openclaw` dev-dep + `minHostVersion`
+  → `2026.5.18`; 727 tests + typecheck green on the new SDK; AUDIT-E
+  re-run (0 seam mismatches). Found + fixed 2 bugs: CI `| tee` was
+  masking test failures; smoke harness lacked `registerCommand`.
+- **Wave 1 (PR #98, merged)** — 9-agent parity re-audit. Catalog:
+  `docs/audits/parity-refresh/wave-1-catalog.md` — **2 P0, 17 P1,
+  ~30 P2; 0 correctness/security regressions.** Per-slice detail in
+  `slice-audit-{A..E}.md`, build-specs `buildspec-S16/S17/S18*.md`,
+  benchmark `benchmark-codex-claude-code.md`.
+- **Wave 3 batch 1 (PR #99, open)** — W1-C1 (stale-event guard was
+  dead code — threaded `expectedApprovalId`) + W1-S9-2 (`checkApprovalId`
+  contradicted the re-ported state machine — `rejected` is non-terminal).
+
+---
+
+## Wave 3 — remaining findings (17)
+
+Fix sequentially, one focused PR per cluster. IDs reference
+`wave-1-catalog.md`.
+
+| Cluster | Findings | Files |
+|---|---|---|
+| tools | W1-A1 (subagent-gate description lies), W1-A3 (`ask_user_question` desc paraphrased), W1-A5 (auto-enable matcher dead code) | `src/tools/*`, `src/plan-mode/tool-descriptions.ts`, `auto-enable.ts`, `index.ts` |
+| prompt | W1-D1 (reject-injection emitter ≠ in-host form), W1-D2 (`activeForm` vs `status`), W1-D3 (no byte-fixture test — **overlaps Wave 2 harness; let Wave 2 own it**) | `src/prompt/*`, `injection-writer.ts`, `session-actions.ts` |
+| runtime | W1-E1 (turn-limit watchdog deferral stale — seam now exists), W1-E2 (debug-log taxonomy diverged), W1-E6 (`madeToolCall` derived from wrong signal) | `src/runtime/*`, `index.ts` |
+| ui | W1-S9-1 (sidebar schema omits 5 fields), W1-S18-1 (Telegram 100-cmd menu hides `/plan`), W1-B4 (accept-edits trigger has no CI test) | `src/ui/*`, `index.ts` |
+| benchmark gaps | W1-F1 (no action-required notification — P0), W1-F2 (prompt promises a `plan-*.md` no code writes — P0), W1-F4 (`/plan auto` dead toggle) | `src/ui/session-actions.ts`, `src/prompt/*`, `index.ts` |
+
+**Deferred to Wave 4** (cross-platform, not Wave-3 port-bugs): W1-F3
+(multi-surface approval), W1-F5 (`/plan answer` cross-surface).
+**~30 P2s**: triage during/after Wave 3 — fix-now vs defer-with-issue.
+
+---
+
+## Execution discipline (the guardrails)
+
+1. **Worktree isolation for git agents.** Any background/parallel
+   `Agent` that runs `git` MUST use `isolation: "worktree"`. Branches
+   share ONE working tree — a naive parallel agent's `git checkout`
+   clobbers the other's uncommitted edits (this happened once during
+   Wave 2's first attempt; recovered, no loss).
+2. **Wave 3 is sequential.** `index.ts` + `session-actions.ts` are
+   shared across clusters → parallel fix agents merge-conflict, and
+   each fix needs careful in-host matching + tests. One cluster, one
+   PR, CI-gated, then the next.
+3. **Wave 2 is safe to parallelize** — it touches only
+   `parity-harness/` + `ci.yml`, zero overlap with Wave 3's `src/`.
+   Run it as one worktree-isolated background agent.
+4. **CI is trustworthy as of PR #97** — the `| tee` exit-code masking
+   is fixed. A red `ci` check is now a real signal.
+5. Every fix cites the in-host `host_ref:` and ships a test.
+
+---
+
+## Branch / PR state
+
+- `main` — Wave 0 + Wave 1 merged.
+- `wave-3/fixes` — Wave 3 batch 1 (PR #99, open). Active fix branch.
+- Wave 2 — first attempt's partial harness work backed up at
+  `/tmp/wave2-partial-*`; re-dispatch fresh + isolated.
+- Source-of-truth for parity diffs: in-host branch
+  `rebase/pr70071-onto-main-2026-04-25` @ `ea04ea52c7` in
+  `/Volumes/LEXAR/repos/openclaw-pr70071-rebase`.
+
+---
+
+## Resume instructions
+
+1. Read `wave-1-catalog.md` (the finding specs) + this doc.
+2. If Wave 2 not yet merged: dispatch ONE worktree-isolated agent to
+   build the Layer-1 parity harness (see catalog + `parity-harness/`).
+3. Wave 3: pick the next un-fixed cluster from the table above, fix
+   it sequentially against the in-host source-of-truth, add tests,
+   open a CI-gated PR, merge, update this doc's "Done" section.
+4. After Wave 3 + Wave 2 land: Waves 4 → 5 → 6.

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -460,6 +460,13 @@ export class PlanModeStore {
   async recordRejection(input: {
     sessionKey: string;
     feedback?: string;
+    /**
+     * Optional version token from the approval event. Forwarded to
+     * `resolvePlanApproval`'s stale-event guard — a mismatch with the
+     * session's current `approvalId` no-ops the action. Wave-1 finding
+     * W1-C1: without this, the re-ported guard was dead code.
+     */
+    expectedApprovalId?: string;
   }): Promise<
     | { kind: "recorded"; rejectionCount: number; state: PlanModeSessionState }
     | { kind: "skipped"; reason: "not-plan-mode" | "no-pending-approval" }
@@ -469,6 +476,9 @@ export class PlanModeStore {
       sessionKey: input.sessionKey,
       action: "reject",
       ...(input.feedback !== undefined ? { feedback: input.feedback } : {}),
+      ...(input.expectedApprovalId !== undefined
+        ? { expectedApprovalId: input.expectedApprovalId }
+        : {}),
     });
     if (result.kind === "recorded") {
       return {
@@ -495,6 +505,11 @@ export class PlanModeStore {
   async recordApproval(input: {
     sessionKey: string;
     edited?: boolean;
+    /**
+     * Optional version token from the approval event — see
+     * `recordRejection`. Wave-1 finding W1-C1.
+     */
+    expectedApprovalId?: string;
   }): Promise<
     | { kind: "recorded"; approval: "approved" | "edited"; state: PlanModeSessionState }
     | { kind: "skipped"; reason: "not-plan-mode" | "no-pending-approval" }
@@ -504,6 +519,9 @@ export class PlanModeStore {
     const result = await this.applyApprovalAction({
       sessionKey: input.sessionKey,
       action,
+      ...(input.expectedApprovalId !== undefined
+        ? { expectedApprovalId: input.expectedApprovalId }
+        : {}),
     });
     if (result.kind === "recorded") {
       return {
@@ -527,6 +545,11 @@ export class PlanModeStore {
    */
   async recordTimeout(input: {
     sessionKey: string;
+    /**
+     * Optional version token from the approval event — see
+     * `recordRejection`. Wave-1 finding W1-C1.
+     */
+    expectedApprovalId?: string;
   }): Promise<
     | { kind: "recorded"; state: PlanModeSessionState }
     | { kind: "skipped"; reason: "not-plan-mode" | "no-pending-approval" }
@@ -535,6 +558,9 @@ export class PlanModeStore {
     return this.applyApprovalAction({
       sessionKey: input.sessionKey,
       action: "timeout",
+      ...(input.expectedApprovalId !== undefined
+        ? { expectedApprovalId: input.expectedApprovalId }
+        : {}),
     });
   }
 
@@ -550,12 +576,17 @@ export class PlanModeStore {
     sessionKey: string;
     action: "approve" | "edit" | "reject" | "timeout";
     feedback?: string;
+    /**
+     * Optional approval-version token. Forwarded as `resolvePlanApproval`'s
+     * 4th argument so its stale-event guard is live (Wave-1 W1-C1).
+     */
+    expectedApprovalId?: string;
   }): Promise<
     | { kind: "recorded"; state: PlanModeSessionState }
     | { kind: "skipped"; reason: "not-plan-mode" | "no-pending-approval" }
     | { kind: "failed"; error: Error }
   > {
-    const { sessionKey, action, feedback } = input;
+    const { sessionKey, action, feedback, expectedApprovalId } = input;
     try {
       let outcome:
         | { kind: "recorded"; state: PlanModeSessionState }
@@ -568,7 +599,12 @@ export class PlanModeStore {
           outcome = { kind: "skipped", reason: "not-plan-mode" };
           return { next: null };
         }
-        const next = resolvePlanApproval(current, action, feedback);
+        const next = resolvePlanApproval(
+          current,
+          action,
+          feedback,
+          expectedApprovalId,
+        );
         if (next === current) {
           // Reference equality: resolvePlanApproval's guards fired
           // (terminal-state for approve/edit/reject, or

--- a/src/ui/session-actions.ts
+++ b/src/ui/session-actions.ts
@@ -171,12 +171,20 @@ async function checkApprovalId(
       ),
     };
   }
-  if (snap.approval !== "pending") {
+  // Wave-1 finding W1-S9-2: the re-ported `resolvePlanApproval` treats
+  // `rejected` as a NON-terminal state — the user can change their mind
+  // and re-approve, or re-reject (approval.ts terminal guard:
+  // `approval !== "pending" && approval !== "rejected"`). The prior
+  // guard here rejected EVERY non-`pending` state, contradicting the
+  // state machine it dispatches into. Allow `pending` OR `rejected`;
+  // the genuinely terminal states (approved / edited / timed_out /
+  // none) still no-op with NO_PENDING_APPROVAL.
+  if (snap.approval !== "pending" && snap.approval !== "rejected") {
     return {
       ok: false,
       result: err(
         SESSION_ACTION_ERROR_CODES.NO_PENDING_APPROVAL,
-        `session has no pending approval (approval=${snap.approval})`,
+        `session has no actionable approval (approval=${snap.approval})`,
       ),
     };
   }
@@ -185,7 +193,7 @@ async function checkApprovalId(
       ok: false,
       result: err(
         SESSION_ACTION_ERROR_CODES.NO_PENDING_APPROVAL,
-        "session has no approvalId on pending state",
+        `session has no approvalId on ${snap.approval} state`,
       ),
     };
   }
@@ -259,6 +267,9 @@ export function createPlanModeSessionActions(
       const persist = await store.recordApproval({
         sessionKey: sk.sessionKey,
         edited: false,
+        // W1-C1: forward the version token so the store-level
+        // stale-event guard (resolvePlanApproval arg 4) is live.
+        ...(expectedApprovalId !== undefined ? { expectedApprovalId } : {}),
       });
       if (persist.kind === "failed") {
         return err(
@@ -337,6 +348,8 @@ export function createPlanModeSessionActions(
       const persist = await store.recordApproval({
         sessionKey: sk.sessionKey,
         edited: true,
+        // W1-C1: forward the version token (store-level stale guard).
+        ...(expectedApprovalId !== undefined ? { expectedApprovalId } : {}),
       });
       if (persist.kind === "failed") {
         return err(
@@ -396,6 +409,8 @@ export function createPlanModeSessionActions(
       const persist = await store.recordRejection({
         sessionKey: sk.sessionKey,
         ...(feedback ? { feedback } : {}),
+        // W1-C1: forward the version token (store-level stale guard).
+        ...(expectedApprovalId !== undefined ? { expectedApprovalId } : {}),
       });
       if (persist.kind === "failed") {
         return err(

--- a/src/ui/session-actions.ts
+++ b/src/ui/session-actions.ts
@@ -58,24 +58,26 @@ import type { PlanStep } from "../types.js";
  * Format planSteps into the string array consumed by
  * buildApprovedPlanInjection / buildAcceptEditsPlanInjection. The
  * in-host builders take `string[]` (each entry is one step) and
- * emit a numbered list. We project the stored PlanStep[] (which
- * carries status + activeForm) into that flat-string shape, keeping
- * status as a parenthetical so the agent retains visibility of
- * completed/cancelled steps when resuming.
+ * emit a numbered list.
  *
- * host_ref: src/agents/plan-mode/approval.ts:187-194 — the in-host's
- *   `planSteps.map((s, i) => \`${i + 1}. ${s}\`)` rendering.
+ * Per-step format is byte-identical to the in-host: when the step
+ * carries an `activeForm` (the present-continuous label, e.g.
+ * "Running tests"), render `"<step> (<activeForm>)"`; otherwise just
+ * `"<step>"`.
+ *
+ * Wave-1 finding W1-D2: this previously appended the `status` enum
+ * (`(in_progress)`, `(completed)`) instead of `activeForm`. That
+ * diverged from the in-host for any step carrying an activeForm —
+ * the agent saw the wrong parenthetical on a resumed/re-approved plan.
+ *
+ * host_ref: src/gateway/sessions-patch.ts:1001-1003 (commit ea04ea52c7):
+ *   `(next.planMode?.lastPlanSteps ?? []).map((step) =>
+ *     step.activeForm ? \`${step.step} (${step.activeForm})\` : step.step)`
  */
 function planStepsToInjectionLines(steps: PlanStep[]): string[] {
-  return steps.map((s) => {
-    // Match in-host's per-step format: "<step> (<status>)" when
-    // status is anything other than the default "pending". Lets
-    // the agent see what's already done when resuming a partial plan.
-    if (s.status === "pending") {
-      return s.step;
-    }
-    return `${s.step} (${s.status})`;
-  });
+  return steps.map((step) =>
+    step.activeForm ? `${step.step} (${step.activeForm})` : step.step,
+  );
 }
 
 /**

--- a/tests/state/store.test.ts
+++ b/tests/state/store.test.ts
@@ -1071,3 +1071,96 @@ describe("P-13 PlanModeStore.setAutoApprove — IO-error fail-soft", () => {
     expect(log.warn).toHaveBeenCalled();
   });
 });
+
+describe("PlanModeStore — W1-C1: expectedApprovalId stale-event guard threading", () => {
+  let gw: InMemoryGateway;
+  let store: PlanModeStore;
+
+  beforeEach(() => {
+    gw = new InMemoryGateway();
+    store = new PlanModeStore(gw);
+  });
+
+  it("recordApproval skips when expectedApprovalId mismatches the session approvalId", async () => {
+    gw.seed(
+      SESSION_KEY,
+      planModeSession({
+        mode: "plan",
+        approval: "pending",
+        approvalId: APPROVAL_ID,
+      }),
+    );
+    const r = await store.recordApproval({
+      sessionKey: SESSION_KEY,
+      expectedApprovalId: APPROVAL_ID_CANDIDATE_2, // stale / wrong token
+    });
+    expect(r.kind).toBe("skipped");
+    // State unchanged — the resolvePlanApproval stale guard fired.
+    expect(gw.peek(SESSION_KEY)?.approval).toBe("pending");
+  });
+
+  it("recordApproval proceeds when expectedApprovalId matches", async () => {
+    gw.seed(
+      SESSION_KEY,
+      planModeSession({
+        mode: "plan",
+        approval: "pending",
+        approvalId: APPROVAL_ID,
+      }),
+    );
+    const r = await store.recordApproval({
+      sessionKey: SESSION_KEY,
+      expectedApprovalId: APPROVAL_ID,
+    });
+    expect(r.kind).toBe("recorded");
+    expect(gw.peek(SESSION_KEY)?.approval).toBe("approved");
+  });
+
+  it("recordApproval proceeds when no expectedApprovalId is supplied (no token, no check)", async () => {
+    gw.seed(
+      SESSION_KEY,
+      planModeSession({
+        mode: "plan",
+        approval: "pending",
+        approvalId: APPROVAL_ID,
+      }),
+    );
+    const r = await store.recordApproval({ sessionKey: SESSION_KEY });
+    expect(r.kind).toBe("recorded");
+  });
+
+  it("recordRejection skips when expectedApprovalId mismatches", async () => {
+    gw.seed(
+      SESSION_KEY,
+      planModeSession({
+        mode: "plan",
+        approval: "pending",
+        approvalId: APPROVAL_ID,
+      }),
+    );
+    const r = await store.recordRejection({
+      sessionKey: SESSION_KEY,
+      feedback: "stale click",
+      expectedApprovalId: APPROVAL_ID_CANDIDATE_2,
+    });
+    expect(r.kind).toBe("skipped");
+    expect(gw.peek(SESSION_KEY)?.approval).toBe("pending");
+  });
+
+  it("recordTimeout skips when expectedApprovalId mismatches", async () => {
+    gw.seed(
+      SESSION_KEY,
+      planModeSession({
+        mode: "plan",
+        approval: "pending",
+        approvalId: APPROVAL_ID,
+      }),
+    );
+    const r = await store.recordTimeout({
+      sessionKey: SESSION_KEY,
+      expectedApprovalId: APPROVAL_ID_CANDIDATE_2,
+    });
+    expect(r.kind).toBe("skipped");
+    expect(gw.peek(SESSION_KEY)?.approval).toBe("pending");
+  });
+});

--- a/tests/ui/session-actions.test.ts
+++ b/tests/ui/session-actions.test.ts
@@ -169,8 +169,24 @@ describe("P-12 session-actions — plan.accept", () => {
     expect(r.code).toBe(SESSION_ACTION_ERROR_CODES.NOT_IN_PLAN_MODE);
   });
 
-  it("rejects with NO_PENDING_APPROVAL when approval state is not pending", async () => {
+  it("ALLOWS plan.accept from a rejected state — user changes their mind (W1-S9-2)", async () => {
+    // `resolvePlanApproval` treats `rejected` as non-terminal: a
+    // rejected plan can be re-approved. checkApprovalId must not
+    // block it. (Prior behavior wrongly returned NO_PENDING_APPROVAL.)
     gw.seed(SESSION_KEY, planModeSession({ approval: "rejected" }));
+    const r = await acceptHandler({
+      pluginId: "smarter-claw",
+      actionId: "plan.accept",
+      sessionKey: SESSION_KEY,
+    });
+    if (!r || !r.ok) throw new Error("expected ok — rejected is re-approvable");
+    expect(gw.peek(SESSION_KEY)?.approval).toBe("approved");
+  });
+
+  it("rejects with NO_PENDING_APPROVAL on a genuinely terminal state (W1-S9-2)", async () => {
+    // `approved` IS terminal — re-approving an already-approved plan
+    // is a no-op the session-action layer rejects up front.
+    gw.seed(SESSION_KEY, planModeSession({ approval: "approved" }));
     const r = await acceptHandler({
       pluginId: "smarter-claw",
       actionId: "plan.accept",

--- a/tests/ui/session-actions.test.ts
+++ b/tests/ui/session-actions.test.ts
@@ -234,14 +234,18 @@ describe("P-12 session-actions — plan.accept", () => {
     expect(call.text).toContain("2. Run pnpm install");
   });
 
-  it("annotates non-pending step statuses in the injection (in-host parity)", async () => {
+  it("annotates each step with its activeForm in the injection (W1-D2 in-host parity)", async () => {
+    // In-host (sessions-patch.ts:1001-1003) renders `<step> (<activeForm>)`
+    // when the step has an activeForm, else just `<step>` — it does NOT
+    // append the `status` enum. A step with no activeForm gets no
+    // parenthetical regardless of status.
     gw.seed(
       SESSION_KEY,
       planModeSession({
         lastPlanSteps: [
-          { step: "Investigation", status: "completed" },
-          { step: "Apply patch", status: "in_progress" },
-          { step: "Run tests", status: "pending" },
+          { step: "Investigate auth", status: "completed", activeForm: "Investigating auth" },
+          { step: "Apply patch", status: "in_progress", activeForm: "Applying the patch" },
+          { step: "Run tests", status: "pending" }, // no activeForm
         ],
       }),
     );
@@ -251,9 +255,12 @@ describe("P-12 session-actions — plan.accept", () => {
       sessionKey: SESSION_KEY,
     });
     const call = enqueue.mock.calls[0][0];
-    expect(call.text).toContain("1. Investigation (completed)");
-    expect(call.text).toContain("2. Apply patch (in_progress)");
-    expect(call.text).toContain("3. Run tests"); // pending → no annotation
+    expect(call.text).toContain("1. Investigate auth (Investigating auth)");
+    expect(call.text).toContain("2. Apply patch (Applying the patch)");
+    expect(call.text).toContain("3. Run tests"); // no activeForm → bare step
+    // The status enum must NOT leak into the rendered line.
+    expect(call.text).not.toContain("(completed)");
+    expect(call.text).not.toContain("(in_progress)");
   });
 });
 


### PR DESCRIPTION
Wave 3 (fix wave) — first batch. Part of #100.

Closes the W1-C1, W1-S9-2, W1-D2 findings from the Wave-1 catalog:
- **W1-C1** — stale-event guard was dead code → threaded `expectedApprovalId`.
- **W1-S9-2** — `checkApprovalId` contradicted the state machine → `rejected` is re-approvable.
- **W1-D2** — plan-step injection used `status` → fixed to `activeForm` (in-host parity).

Also adds the durable `EXECUTION-STATUS.md` checkpoint.

## Test plan
- [x] `pnpm typecheck` clean
- [x] affected suites green locally (store 73, session-actions 31, smokes)
- [ ] CI green