### PR TITLE
Wave 3: tools cluster — W1-A1 + W1-A3 (closes #101)

### DIFF
--- a/src/plan-mode/auto-enable.ts
+++ b/src/plan-mode/auto-enable.ts
@@ -31,10 +31,24 @@
  * # Surgical-port rationale (2026-05-12)
  *
  * Wave-1 audit slice S5 found the plugin had no equivalent of this
- * helper. The in-host wires `evaluateAutoEnableForMatch` into session-
- * start so models matching configured patterns auto-enter plan mode.
- * The plugin's `before_prompt_build` hook reads plan-mode state but
- * can't proactively enter — this helper restores that capability.
+ * helper. The in-host wires `evaluateAutoEnableForMatch` into
+ * session-start so models matching configured patterns auto-enter
+ * plan mode.
+ *
+ * # Wiring status — NOT YET WIRED (Wave-1 finding W1-A5)
+ *
+ * This helper is a correct, tested port — but it currently has NO
+ * caller in `src/`. A configured `autoEnableFor` pattern therefore
+ * has no effect yet. Wiring it needs three pieces the plugin doesn't
+ * yet have cleanly: (1) an `autoEnableFor` entry in the plugin's
+ * `configSchema`, (2) a once-per-session trigger (auto-enable must
+ * fire at session start, NOT every turn — a per-turn caller would
+ * drag the user back into plan mode after they exit), (3) reliable
+ * access to the resolved model id at that trigger point. Tracked as
+ * a dedicated issue; until then this file is a building block, not
+ * a live feature. (Previously this header claimed it "restores that
+ * capability" — it does not, yet. Corrected to avoid the false
+ * claim that W1-A5 flagged.)
  *
  * host_ref: src/agents/plan-mode/auto-enable.ts (commit ea04ea52c7)
  */

--- a/src/plan-mode/tool-descriptions.ts
+++ b/src/plan-mode/tool-descriptions.ts
@@ -73,7 +73,14 @@ export function describeExitPlanModeTool(): string {
     // PR-8 follow-up: belt-and-suspenders steer paired with a hard-block
     // runtime check. Eva's post-mortem flagged treating "research
     // launched" as "research complete" as the exact bug this prevents.
-    "WAIT FOR SPAWNED SUBAGENTS BEFORE CALLING THIS TOOL. If you used sessions_spawn during plan-mode investigation (research, adversarial review, etc.), wait for ALL of them to return their completion messages before calling exit_plan_mode. The runtime rejects submission with an error listing pending child run ids if any are still in flight. Treat unresolved children as a blocking dependency of the investigation phase — 'research launched' is not 'research complete.'",
+    // W1-A1: the in-host description claims "the runtime rejects
+    // submission with an error listing pending child run ids" — true
+    // in-host (it has a tool-side subagent gate) but FALSE in the
+    // plugin, which has no such gate. Shipping that sentence would
+    // tell the model the runtime enforces something it doesn't. The
+    // steering is kept (the agent SHOULD wait); the false
+    // runtime-enforcement claim is dropped.
+    "WAIT FOR SPAWNED SUBAGENTS BEFORE CALLING THIS TOOL. If you used sessions_spawn during plan-mode investigation (research, adversarial review, etc.), wait for ALL of them to return their completion messages before calling exit_plan_mode. Treat unresolved children as a blocking dependency of the investigation phase — 'research launched' is not 'research complete.'",
     "Pass the full plan via `plan` using the same shape as update_plan (array of {step, status, activeForm?}).",
     // PR-9 Tier 1: explicit title field. Without this, the agent's chat
     // text leaked into the title slot ("I checked all five VMs..." as
@@ -84,5 +91,32 @@ export function describeExitPlanModeTool(): string {
     "Calling this without an active plan-mode session is a no-op; calling it without `plan` content is rejected.",
     // Iter-3 D3: pointer to reference card + self-test for full context.
     "For the full plan-mode reference (state diagram, [PLAN_*]: tag taxonomy, /plan slash commands, common pitfalls, debugging tips): see the bootstrap-injected reference card visible on every in-mode turn. To inspect live plan-mode state at runtime, call `plan_mode_status` (read-only diagnostic).",
+  ].join(" ");
+}
+
+/**
+ * `ask_user_question` tool description.
+ *
+ * **Parity contract**: byte-identical port of the in-host
+ * `describeAskUserQuestionTool()` at
+ * `src/agents/tool-description-presets.ts:32-42` (commit `ea04ea52c7`).
+ *
+ * Wave-1 finding W1-A3: the prior plugin description was a ~70-word
+ * paraphrase that dropped the structured USE FOR / DO NOT USE FOR
+ * lists, the channel-answer mechanics, and the `allowFreetext`
+ * pointer. Re-ported verbatim — same drift class PR #87 fixed for
+ * enter/exit.
+ *
+ * host_ref: src/agents/tool-description-presets.ts:32-42
+ */
+export function describeAskUserQuestionTool(): string {
+  return [
+    "Ask the user a clarifying question with 2-6 selectable options.",
+    "The runtime emits a pending question interaction and pauses your run until the user answers. Control UI shows an inline card; non-web channels answer through `/plan answer` text commands (or free text when allowed).",
+    "The chosen answer arrives in your next turn as a synthetic user message tagged `[QUESTION_ANSWER]: <answer text>`.",
+    "USE FOR: tradeoffs you cannot resolve via local investigation (product/scope choices, design preferences, organizational priorities, ambiguous user intent).",
+    "DO NOT USE FOR: things you could grep / read / web_search yourself, trivial defaults already covered by AGENTS.md, or confirmation requests (that's what exit_plan_mode does).",
+    "Plan-mode safe: asking a question DOES NOT exit plan mode. The session stays armed and you can submit `exit_plan_mode` after receiving the answer.",
+    "Pass `allowFreetext: true` to add an 'Other...' affordance when your N options might not cover the user's intent.",
   ].join(" ");
 }

--- a/src/tools/ask-user-question.ts
+++ b/src/tools/ask-user-question.ts
@@ -27,6 +27,7 @@
  */
 
 import { Type } from "typebox";
+import { describeAskUserQuestionTool } from "../plan-mode/tool-descriptions.js";
 import { ToolInputError, readStringParam } from "./common.js";
 
 interface ToolContext {
@@ -67,22 +68,14 @@ const SCHEMA = Type.Object(
   { additionalProperties: false },
 );
 
-const TOOL_DESCRIPTION =
-  "Ask the user a clarifying question with 2-6 option buttons. The " +
-  "user's choice arrives in the next turn as a synthetic " +
-  "`[QUESTION_ANSWER]:` message. Use during plan-mode investigation " +
-  "for genuine product/scope tradeoffs where the answer changes the " +
-  "plan shape. The session STAYS in plan mode while waiting (this " +
-  "tool does NOT exit plan mode). NOT for confirmation requests — " +
-  "that's what exit_plan_mode is for.";
-
 export function createAskUserQuestionTool(
   _opts: CreateAskUserQuestionToolInput = {},
 ) {
   return (_ctx: ToolContext) => ({
     label: "Ask User Question",
     name: "ask_user_question",
-    description: TOOL_DESCRIPTION,
+    // W1-A3: verbatim in-host description (was a paraphrase).
+    description: describeAskUserQuestionTool(),
     parameters: SCHEMA,
     execute: async (
       toolCallId: string,

--- a/tests/tools/ask-user-question.test.ts
+++ b/tests/tools/ask-user-question.test.ts
@@ -30,6 +30,16 @@ describe("P-8 ask_user_question — shape", () => {
     expect(t.description).toMatch(/does NOT exit plan mode/i);
   });
 
+  it("description carries the in-host structured clauses (W1-A3 verbatim port)", () => {
+    const t = build();
+    // The prior paraphrase dropped these; the verbatim in-host
+    // description restores the structured guidance.
+    expect(t.description).toMatch(/USE FOR:/);
+    expect(t.description).toMatch(/DO NOT USE FOR:/);
+    expect(t.description).toMatch(/allowFreetext/);
+    expect(t.description).toMatch(/\[QUESTION_ANSWER\]:/);
+  });
+
   it("schema enforces additionalProperties: false", () => {
     const t = build();
     const params = t.parameters as { additionalProperties?: boolean };

--- a/tests/tools/exit-plan-mode.test.ts
+++ b/tests/tools/exit-plan-mode.test.ts
@@ -63,6 +63,19 @@ describe("exit_plan_mode — tool shape", () => {
     expect(tool.description).toMatch(/do NOT write the plan as a markdown list/);
     expect(tool.description).toMatch(/WAIT FOR SPAWNED SUBAGENTS/);
   });
+
+  it("description does NOT claim a runtime subagent gate the plugin lacks (W1-A1)", () => {
+    // The in-host description says "the runtime rejects submission with
+    // an error listing pending child run ids" — TRUE in-host, FALSE in
+    // the plugin (no such gate). The plugin keeps the wait-for-subagents
+    // steering but must not assert runtime enforcement that doesn't exist.
+    const { factory } = build();
+    const tool = factory({ sessionKey: SESSION_KEY });
+    expect(tool.description).not.toMatch(/runtime rejects submission/);
+    expect(tool.description).not.toMatch(/pending child run ids/);
+    // …but the steering itself is retained:
+    expect(tool.description).toMatch(/research launched.*is not.*research complete/);
+  });
 });
 
 describe("exit_plan_mode — title required (surgical-port S1 fix)", () => {


### PR DESCRIPTION
Wave 3 cluster fix. Part of #100. Closes #101.

- **W1-A1** — `exit_plan_mode` description claimed the runtime rejects submission when subagents are in flight. True in-host, false here (no such gate). Dropped the false sentence; kept the wait-for-subagents steering.
- **W1-A3** — `ask_user_question` description was a paraphrase. Re-ported the in-host `describeAskUserQuestionTool()` verbatim.
- **W1-A5** — auto-enable matcher is a tested port with no caller. Wiring has real design questions; corrected the false header claim, filed #107 for the wiring (not faked).

## Test plan
- [x] typecheck + 59 tool tests green locally
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that auto-enable patterns are not yet active in the plugin.
  * Corrected exit_plan_mode tool guidance to accurately reflect implementation.
  * Enhanced ask_user_question tool guidance with detailed usage instructions.

* **Tests**
  * Added validation tests for tool descriptions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/Smarter-Claw/pull/108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->