### PR TITLE
Wave 3: ui cluster — W1-S9-1 + W1-S18-1 + W1-B4 (closes #103)

### DIFF
--- a/src/ui/sidebar-descriptor.ts
+++ b/src/ui/sidebar-descriptor.ts
@@ -59,6 +59,15 @@ export function buildPlanModeSidebarDescriptor(): PluginControlUiDescriptor {
       "mutations are blocked until you approve the proposed plan. " +
       "Approve / Edit / Reject / Cancel through the sidebar actions.",
     // No placement — let the host's Control UI decide based on surface.
+    //
+    // The `properties` block MUST mirror `PlanModeSessionState`
+    // (`src/types.ts`) field-for-field — the store writes every field
+    // declared there, and a UI client doing strict schema validation
+    // against this descriptor would otherwise reject or silently drop
+    // any field the schema omits. There is no in-host equivalent for
+    // this descriptor (the in-host plan-mode UI lived in the webchat
+    // chip + approval-card surfaces, not a registered sidebar slot);
+    // the parity target is internal consistency with `types.ts`.
     schema: {
       type: "object",
       properties: {
@@ -74,8 +83,20 @@ export function buildPlanModeSidebarDescriptor(): PluginControlUiDescriptor {
             "timed_out",
           ],
         },
+        // Unix ms timestamps. Written by the PlanModeStore on enter /
+        // approval-confirmation / any mutation (see store.ts). Optional
+        // on a fresh session, so NOT in `required`.
+        enteredAt: { type: "integer" },
+        confirmedAt: { type: "integer" },
+        updatedAt: { type: "integer" },
         rejectionCount: { type: "integer", minimum: 0 },
         approvalId: { type: "string" },
+        // Parent run id captured from exit_plan_mode — used by the
+        // gateway-side approval handler for the in-flight-subagent gate.
+        approvalRunId: { type: "string" },
+        // SHA-1 prefix (12 chars) of the most-recent exit_plan_mode
+        // payload — duplicate-exit detection.
+        lastPlanPayloadHash: { type: "string" },
         title: { type: "string" },
         feedback: { type: "string" },
         lastPlanSteps: {

--- a/src/ui/slash-commands.ts
+++ b/src/ui/slash-commands.ts
@@ -34,13 +34,39 @@
  * enter` is the exception: there is no `plan.enter` session-action, so
  * it calls `PlanModeStore.enterPlanMode` directly.
  *
- * # Channel scope
+ * # Channel scope & dispatch
  *
- * Registered without a `channels` filter → available on every channel
- * surface (webchat, Telegram, Slack, etc.).
+ * A plugin-registered command has TWO independent dispatch paths in
+ * OpenClaw:
+ *   - Path A — the universal auto-reply text pipeline
+ *     (`handlePluginCommand`). This runs on every channel that routes
+ *     inbound text through auto-reply (webchat, Telegram, Slack,
+ *     Discord, CLI). Typing `/plan accept` as a normal message is
+ *     dispatched here. This — NOT the absence of a `channels` filter —
+ *     is what makes `/plan` work everywhere.
+ *   - Path B — the channel's NATIVE command surface (e.g. Telegram's
+ *     "/" autocomplete menu + `bot.command()` handler).
  *
- * host_ref: in-host /plan slash commands (the in-host wired these into
- *   its native command surface; this is the plugin equivalent).
+ * `/plan` sets no `channels` filter, so it is eligible for every
+ * channel's native menu AND the text pipeline — it is the canonical
+ * command on all channels, Telegram included.
+ *
+ * W1-S18-1: Telegram caps a bot's native menu at 100 commands. On a
+ * gateway that exceeds that, plugin commands (appended after host
+ * built-ins) can be sliced off the "/" menu. To avoid `/plan` +
+ * `/plan-mode` consuming TWO scarce Telegram menu slots, the
+ * `/plan-mode` ALIAS carries a `channels` filter that excludes
+ * Telegram (see `createPlanModeSlashCommand`). `/plan` is unaffected;
+ * if it ever drops off the Telegram menu it still works when typed,
+ * and its `agentPromptGuidance` lets the agent tell the user so.
+ *
+ * host_ref: in-host /plan slash commands lived in a bespoke built-in
+ *   handler in the same `loadCommandHandlers()` chain
+ *   (`src/auto-reply/reply/commands-plan.ts`,
+ *   `commands-handlers.runtime.ts`); the plugin rides the generic
+ *   `handlePluginCommand` slot for functionally equivalent
+ *   universality. The Telegram 100-command cap is a host-side
+ *   constraint with no in-host plugin-side equivalent.
  */
 
 import type {
@@ -70,7 +96,34 @@ export interface CreatePlanSlashCommandInput {
 }
 
 /**
+ * `agentPromptGuidance` for `/plan` — injected into the agent's system
+ * prompt by the host (`listRegisteredPluginAgentPromptGuidance`) so the
+ * agent knows the command exists and can tell the user how to invoke
+ * it. This is the discoverability fallback for the case where the
+ * Telegram native "/" menu is full (see the W1-S18-1 note in the file
+ * header): even with no menu entry, the agent can still surface
+ * `/plan accept | reject` to the user.
+ */
+const PLAN_AGENT_PROMPT_GUIDANCE: readonly string[] = [
+  "Plan mode is available. When a plan is awaiting the user's decision, " +
+    "the user can resolve it by typing a slash command directly in chat: " +
+    "`/plan accept` (approve verbatim), `/plan edit <new plan text>` " +
+    "(approve with edits), `/plan reject [reason]` (reject for revision), " +
+    "or `/plan cancel` (exit plan mode). `/plan enter` enters plan mode. " +
+    "These work on every channel even if the channel's native command " +
+    "menu does not list them — if a user cannot find `/plan` in an " +
+    "autocomplete menu, tell them to type it as a normal message.",
+];
+
+/**
  * Build the `/plan` command definition. Pass into `api.registerCommand`.
+ *
+ * `/plan` is the PRIMARY plan-mode command on every channel, including
+ * Telegram. `channels` is intentionally NOT set — `/plan` must be
+ * eligible for every channel's native menu and the universal text
+ * pipeline. `/plan-mode` (the alias) is the one that takes a `channels`
+ * filter, to free a scarce Telegram native-menu slot — see
+ * `createPlanModeSlashCommand` below and the W1-S18-1 header note.
  */
 export function createPlanSlashCommand(
   input: CreatePlanSlashCommandInput,
@@ -81,13 +134,63 @@ export function createPlanSlashCommand(
       "Plan-mode controls: /plan enter | accept | edit | reject | cancel | auto on|off",
     acceptsArgs: true,
     // Available on every channel; do NOT restrict via `channels`.
+    agentPromptGuidance: PLAN_AGENT_PROMPT_GUIDANCE,
     handler: async (ctx) => handlePlanCommand(ctx, input),
   };
 }
 
 /**
+ * Channels on which the `/plan-mode` alias is registered. Telegram is
+ * DELIBERATELY EXCLUDED — see `createPlanModeSlashCommand` below.
+ *
+ * (`pluginCommandSupportsChannel` lowercase-normalizes channel ids, so
+ * these are the canonical ids the host's channel plugins use.)
+ */
+const PLAN_MODE_ALIAS_CHANNELS: readonly string[] = [
+  "webchat",
+  "slack",
+  "discord",
+  "cli",
+];
+
+/**
  * Companion command: `/plan-mode` as an alias-shorthand for `/plan`.
- * Users who memorize `/plan-mode` from the in-host UX find it works.
+ * Users who memorize `/plan-mode` from the in-host UX find it works on
+ * webchat / Slack / Discord / CLI.
+ *
+ * # W1-S18-1 — why `channels` excludes Telegram
+ *
+ * Telegram caps a bot's native "/" command menu at 100 commands
+ * (`TELEGRAM_MAX_COMMANDS`). A gateway with many channels/plugins can
+ * exceed that; host built-ins are listed first and plugin commands are
+ * appended, so plugin commands land in the dropped tail. Registering
+ * BOTH `/plan` and `/plan-mode` consumes TWO scarce Telegram menu
+ * slots and doubles the chance one of them is sliced off. `/plan` is
+ * the canonical command; `/plan-mode` is a redundant convenience
+ * alias. So we keep `/plan-mode` OFF Telegram entirely — freeing the
+ * second slot for `/plan`.
+ *
+ * IMPORTANT — honest residual limitation: the SDK exposes exactly ONE
+ * per-command channel-scoping mechanism, the `channels` allowlist, and
+ * `pluginCommandSupportsChannel` gates BOTH dispatch paths with it:
+ *   - Path B, the native "/" menu (`getPluginCommandSpecs` →
+ *     `listProviderPluginCommandSpecs`); and
+ *   - Path A, the universal auto-reply text pipeline, on channel-aware
+ *     call sites — `handlePluginCommand` calls
+ *     `matchPluginCommand(body, { channel })` with the Telegram channel.
+ * There is NO SDK field for "functional via text but hidden from the
+ * native menu". Consequently, excluding `telegram` here means the
+ * literal string `/plan-mode` is non-functional on Telegram (both menu
+ * AND typed-as-text). This is acceptable: `/plan` IS the Telegram
+ * surface and is fully functional there (menu, native handler, and
+ * text pipeline), and `/plan-mode` remains fully functional on every
+ * other channel. A Telegram user who types `/plan-mode` gets no match;
+ * they should use `/plan`. (An earlier build-spec draft claimed the
+ * text pipeline would still serve `/plan-mode` on Telegram — that is
+ * incorrect; `matchPluginCommand` applies the same `channels` gate.)
+ *
+ * `/plan` itself is unaffected — it sets no `channels` filter and
+ * stays eligible for the Telegram native menu and text pipeline.
  */
 export function createPlanModeSlashCommand(
   input: CreatePlanSlashCommandInput,
@@ -97,6 +200,9 @@ export function createPlanModeSlashCommand(
     description:
       "Alias for `/plan` — enter plan mode and inspect/resolve approvals.",
     acceptsArgs: true,
+    // Excludes "telegram" — see the doc comment above (W1-S18-1).
+    channels: PLAN_MODE_ALIAS_CHANNELS,
+    agentPromptGuidance: PLAN_AGENT_PROMPT_GUIDANCE,
     handler: async (ctx) => handlePlanCommand(ctx, input),
   };
 }

--- a/src/ui/sweep-command.ts
+++ b/src/ui/sweep-command.ts
@@ -17,13 +17,17 @@
  * the targeted single-session sweep, which is the common rollback case
  * (operator sees a stuck session in the sidebar and clears it).
  *
- * # In-host parity
+ * # In-host parity — none
  *
- * The in-host equivalent is `openclaw session sweep --plan-mode-clear`
- * (referenced in P-12's spec in glistening-swimming-rivest.md). The
- * plugin port renames to `openclaw plan-clear` since we register under
- * the root CLI namespace (not nested under `session`), avoiding name
- * collision with host-owned subcommands.
+ * This is a plugin-native operator tool. There is NO in-host
+ * equivalent: `git grep` for `plan-mode-clear` / `sweep` under
+ * `src/cli/**` and `src/agents/plan-mode/**` at the in-host
+ * source-of-truth commit `ea04ea52c7` returns nothing. An earlier
+ * comment here cited `openclaw session sweep --plan-mode-clear` as the
+ * host original — that command does not exist in-host and was never
+ * shipped; the citation was stale (it referenced a P-12 spec draft,
+ * not real host code). `plan-clear` is a net-new plugin command, not a
+ * port, so it carries no `host_ref:`.
  *
  * # Type discipline
  *
@@ -34,9 +38,7 @@
  * version re-exports the type at the public path we can collapse to
  * a single import.
  *
- * host_ref: in-host operator command in `src/cli/session.ts` (the
- *   `--plan-mode-clear` flag). Plugin port consolidates into a
- *   focused `plan-clear` command.
+ * (No `host_ref:` — see "In-host parity — none" above.)
  */
 
 import type { PlanModeStore } from "../state/store.js";

--- a/tests/gates/accept-edits-trigger.test.ts
+++ b/tests/gates/accept-edits-trigger.test.ts
@@ -1,0 +1,238 @@
+/**
+ * W1-B4 — accept-edits gate TRIGGER-predicate test.
+ *
+ * # What this pins
+ *
+ * The accept-edits gate (`checkAcceptEditsConstraint`, layer 2 of the
+ * `before_tool_call` hook in `src/index.ts`) is fail-OPEN and only
+ * gates the 3 hard-constraint categories. WHETHER it runs at all is
+ * decided by the trigger predicate:
+ *
+ *   const isAcceptEditsPhase = approval === "edited";
+ *   if (!isAcceptEditsPhase) return undefined;
+ *
+ * That predicate is the contract: PR #90 changed it from the prior
+ * over-firing `autoApprove === true || approval === "edited"` to the
+ * in-host-parity `approval === "edited"` alone. In-host, only an
+ * EDIT-approval sets `postApprovalPermissions.acceptEdits = true`; a
+ * plain APPROVE explicitly CLEARS it (verbatim execution — the user
+ * did not opt into edits). See `sessions-patch.ts:982-993`.
+ *
+ * The full 72-case adversarial corpus for the gate's pure function is
+ * in `tests/gates/accept-edits-gate.test.ts`, and `smoke-4` exercises
+ * the WIRED hook for the `edited` state. But nothing in CI pinned the
+ * PREDICATE itself across approval states — in particular the
+ * `approved` negative case (smoke-4's "does NOT fire" test uses a
+ * fresh `none`-state session, not an `approved` one). A refactor that
+ * re-broadened the predicate — re-introducing the exact bug PR #90
+ * fixed — would ship green. This file closes that gap.
+ *
+ * host_ref: trigger semantics — `sessions-patch.ts:982-993`
+ *   (acceptEdits is set by `action === "edit"`, explicitly cleared by
+ *    `action === "approve"`).
+ * host_ref: in-host trigger site —
+ *   `pi-tools.before-tool-call.ts:324`
+ *   (`latestPlanMode === "normal" && getLatestAcceptEdits?.()`).
+ *
+ * # Layer interaction (why some states are tested via the mutation gate)
+ *
+ * The accept-edits predicate is layer 2 and is only REACHED when
+ * `mode === "normal"`. Layer 1 (the plan-mode mutation gate) handles
+ * `mode === "plan"` and returns before layer 2. So the plan-mode
+ * approval states (`pending`, `rejected`, `none`) can never reach the
+ * `isAcceptEditsPhase` check at all — for those, this test asserts a
+ * destructive tool is intercepted by the MUTATION gate (a distinct,
+ * log-distinguishable code path), which proves the accept-edits
+ * trigger is not what fired. The two normal-mode states — `edited`
+ * (gate fires) and `approved` (gate must NOT fire) — are the direct
+ * predicate test.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createHarness } from "../eva-live-smokes/harness.js";
+
+const SESSION_KEY = "agent:main:main";
+
+interface ToolFactory {
+  (ctx: { sessionKey?: string }): {
+    execute: (
+      callId: string,
+      args: unknown,
+    ) => Promise<{ details: { status?: string; approvalId?: string } }>;
+  };
+}
+
+type Harness = ReturnType<typeof createHarness>;
+
+/** Drive a fresh session to `mode: "plan", approval: "pending"`. */
+async function driveToPending(harness: Harness): Promise<string> {
+  const enter = harness.findTool("enter_plan_mode") as ToolFactory;
+  await enter({ sessionKey: SESSION_KEY }).execute("enter-1", {});
+  const exit = harness.findTool("exit_plan_mode") as ToolFactory;
+  const exitResult = await exit({ sessionKey: SESSION_KEY }).execute("exit-1", {
+    title: "Trigger-predicate setup",
+    plan: [{ step: "do the work", status: "pending" }],
+  });
+  const approvalId = exitResult.details.approvalId;
+  if (!approvalId) {
+    throw new Error(
+      `exit_plan_mode produced no approvalId: ${JSON.stringify(exitResult)}`,
+    );
+  }
+  return approvalId;
+}
+
+/**
+ * Fire a destructive Bash command through the WIRED before_tool_call
+ * hook and return the hook's decision plus the captured log lines —
+ * the log lines let us tell WHICH gate (mutation vs accept-edits)
+ * fired.
+ */
+async function triggerDestructive(harness: Harness): Promise<{
+  decision: { block?: boolean; blockReason?: string } | undefined;
+  loggedAcceptEdits: boolean;
+  loggedMutationGate: boolean;
+}> {
+  const ret = await harness.triggerHook(
+    "before_tool_call",
+    { toolName: "Bash", params: { command: "rm -rf /important/data" } },
+    { sessionKey: SESSION_KEY, getSessionExtension: () => undefined },
+  );
+  const decision = ret[0] as
+    | { block?: boolean; blockReason?: string }
+    | undefined;
+  return {
+    decision,
+    loggedAcceptEdits: harness.captures.loggerInfo.some((m) =>
+      /accept-edits gate blocked/.test(m),
+    ),
+    loggedMutationGate: harness.captures.loggerInfo.some((m) =>
+      /mutation gate blocked/.test(m),
+    ),
+  };
+}
+
+describe("W1-B4 — accept-edits trigger predicate (approval === 'edited')", () => {
+  let harness: Harness;
+
+  beforeEach(() => {
+    harness = createHarness({ forceInMemory: true });
+  });
+
+  afterEach(() => {
+    delete process.env.SMARTER_CLAW_USE_INMEMORY;
+  });
+
+  describe("FIRES when approval === 'edited'", () => {
+    it("blocks a destructive command after an EDIT-approval", async () => {
+      const approvalId = await driveToPending(harness);
+      const edit = (await harness.invokeAction("plan.edit", {
+        sessionKey: SESSION_KEY,
+        payload: { approvalId, body: "Edited plan body" },
+      })) as { ok: boolean; result?: { approval?: string } };
+      expect(edit.ok).toBe(true);
+      // Sanity: the edit-approval put the session in approval="edited".
+      expect(edit.result?.approval).toBe("edited");
+
+      const { decision, loggedAcceptEdits } =
+        await triggerDestructive(harness);
+      // The trigger predicate fired → the accept-edits gate evaluated
+      // the command → destructive command blocked.
+      expect(decision?.block).toBe(true);
+      expect(decision?.blockReason).toMatch(/destructive/i);
+      expect(loggedAcceptEdits).toBe(true);
+    });
+  });
+
+  describe("does NOT fire for any other approval state", () => {
+    it("approval === 'approved' (plain Accept): destructive command PASSES — gate skipped", async () => {
+      // This is the load-bearing negative case + the exact PR #90
+      // regression: a plain Accept must NOT grant acceptEdits, so the
+      // gate must NOT fire. Session ends in mode="normal" so layer 1
+      // is also skipped — the command passes through the plugin
+      // entirely (fail-OPEN). If a refactor re-broadened the predicate
+      // to include `approved`, this destructive command would be
+      // blocked and this test would fail.
+      const approvalId = await driveToPending(harness);
+      const accept = (await harness.invokeAction("plan.accept", {
+        sessionKey: SESSION_KEY,
+        payload: { approvalId },
+      })) as { ok: boolean; result?: { approval?: string } };
+      expect(accept.ok).toBe(true);
+      expect(accept.result?.approval).toBe("approved");
+
+      const { decision, loggedAcceptEdits } =
+        await triggerDestructive(harness);
+      expect(decision).toBeUndefined();
+      expect(loggedAcceptEdits).toBe(false);
+    });
+
+    it("approval === 'none' (fresh session, normal mode): gate skipped", async () => {
+      // Brand-new session: mode="normal", approval defaults to "none".
+      // isAcceptEditsPhase is false → layer 2 returns undefined.
+      const { decision, loggedAcceptEdits } =
+        await triggerDestructive(harness);
+      expect(decision).toBeUndefined();
+      expect(loggedAcceptEdits).toBe(false);
+    });
+
+    it("approval === 'pending' (mode plan): mutation gate fires, NOT the accept-edits trigger", async () => {
+      // A pending plan keeps mode="plan", so layer 1 (the mutation
+      // gate) intercepts and returns before layer 2's
+      // isAcceptEditsPhase check is ever evaluated. The block here is
+      // the MUTATION gate's, distinguishable by its log line.
+      await driveToPending(harness);
+      const { decision, loggedAcceptEdits, loggedMutationGate } =
+        await triggerDestructive(harness);
+      expect(decision?.block).toBe(true);
+      expect(loggedMutationGate).toBe(true);
+      // The accept-edits trigger never ran — it is unreachable in plan
+      // mode.
+      expect(loggedAcceptEdits).toBe(false);
+    });
+
+    it("approval === 'rejected' (mode plan): mutation gate fires, NOT the accept-edits trigger", async () => {
+      // A rejected plan also keeps mode="plan" (fail-closed: the agent
+      // stays in plan mode and revises). Same as pending — layer 1
+      // intercepts; the accept-edits trigger is never reached.
+      const approvalId = await driveToPending(harness);
+      const reject = (await harness.invokeAction("plan.reject", {
+        sessionKey: SESSION_KEY,
+        payload: { approvalId, feedback: "too risky" },
+      })) as { ok: boolean; result?: { approval?: string } };
+      expect(reject.ok).toBe(true);
+      expect(reject.result?.approval).toBe("rejected");
+
+      const { decision, loggedAcceptEdits, loggedMutationGate } =
+        await triggerDestructive(harness);
+      expect(decision?.block).toBe(true);
+      expect(loggedMutationGate).toBe(true);
+      expect(loggedAcceptEdits).toBe(false);
+    });
+  });
+
+  describe("predicate is exact — only the literal 'edited' state arms the gate", () => {
+    it("an EDIT-approved session blocks; an ACCEPT-approved session does not (same destructive input)", async () => {
+      // Two sessions, identical destructive command, differing ONLY in
+      // approve-vs-edit. The divergence proves the predicate keys on
+      // the approval STATE, not on "post-approval" generally.
+      const editApproval = await driveToPending(harness);
+      await harness.invokeAction("plan.edit", {
+        sessionKey: SESSION_KEY,
+        payload: { approvalId: editApproval, body: "Edited body" },
+      });
+      const edited = await triggerDestructive(harness);
+      expect(edited.decision?.block).toBe(true);
+
+      // Fresh, fully independent harness for the accept branch.
+      const acceptHarness = createHarness({ forceInMemory: true });
+      const acceptApproval = await driveToPending(acceptHarness);
+      await acceptHarness.invokeAction("plan.accept", {
+        sessionKey: SESSION_KEY,
+        payload: { approvalId: acceptApproval },
+      });
+      const accepted = await triggerDestructive(acceptHarness);
+      expect(accepted.decision).toBeUndefined();
+    });
+  });
+});

--- a/tests/ui/sidebar-descriptor.test.ts
+++ b/tests/ui/sidebar-descriptor.test.ts
@@ -60,6 +60,66 @@ describe("P-12 sidebar-descriptor", () => {
     expect(schema.required).toEqual(["mode", "approval", "rejectionCount"]);
   });
 
+  // W1-S9-1: the descriptor schema must mirror `PlanModeSessionState`
+  // (src/types.ts) field-for-field — the store writes all 5 of these
+  // and a strict-validating UI client would otherwise drop them.
+  it("schema declares the 5 previously-omitted state fields (W1-S9-1)", () => {
+    const d = buildPlanModeSidebarDescriptor();
+    const props = (
+      d.schema as { properties: Record<string, { type?: string }> }
+    ).properties;
+    // Timestamps — Unix ms integers.
+    expect(props.enteredAt).toEqual({ type: "integer" });
+    expect(props.confirmedAt).toEqual({ type: "integer" });
+    expect(props.updatedAt).toEqual({ type: "integer" });
+    // Ids / hash — strings.
+    expect(props.approvalRunId).toEqual({ type: "string" });
+    expect(props.lastPlanPayloadHash).toEqual({ type: "string" });
+  });
+
+  it("the 5 added fields are OPTIONAL (not in `required`)", () => {
+    const d = buildPlanModeSidebarDescriptor();
+    const required = (d.schema as { required: string[] }).required;
+    for (const field of [
+      "enteredAt",
+      "confirmedAt",
+      "updatedAt",
+      "approvalRunId",
+      "lastPlanPayloadHash",
+    ]) {
+      expect(required).not.toContain(field);
+    }
+  });
+
+  it("schema mirrors PlanModeSessionState field-for-field (no drift)", () => {
+    // Every non-`__schemaVersion` key the descriptor declares must be a
+    // real `PlanModeSessionState` field, and every state field must be
+    // declared. `__schemaVersion` is a store-stamped meta field with no
+    // type-level counterpart, so it is allowed as an extra.
+    const d = buildPlanModeSidebarDescriptor();
+    const declared = Object.keys(
+      (d.schema as { properties: Record<string, unknown> }).properties,
+    )
+      .filter((k) => k !== "__schemaVersion")
+      .sort();
+    const stateFields = [
+      "mode",
+      "approval",
+      "enteredAt",
+      "confirmedAt",
+      "updatedAt",
+      "feedback",
+      "rejectionCount",
+      "approvalId",
+      "title",
+      "approvalRunId",
+      "lastPlanPayloadHash",
+      "lastPlanSteps",
+      "autoApprove",
+    ].sort();
+    expect(declared).toEqual(stateFields);
+  });
+
   it("mode enum matches the PlanMode union", () => {
     const d = buildPlanModeSidebarDescriptor();
     const schema = d.schema as {

--- a/tests/ui/slash-commands.test.ts
+++ b/tests/ui/slash-commands.test.ts
@@ -76,9 +76,41 @@ describe("/plan slash command — registration shape", () => {
     expect(cmd.acceptsArgs).toBe(true);
   });
 
-  it("neither command sets a `channels` filter (available everywhere)", () => {
+  it("`/plan` sets NO `channels` filter — canonical command on every channel", () => {
+    // `/plan` must stay eligible for every channel's native menu AND
+    // the universal text pipeline. A `channels` filter would narrow
+    // both. It is the primary plan-mode command on Telegram included.
     expect(createPlanSlashCommand(makeInput()).channels).toBeUndefined();
-    expect(createPlanModeSlashCommand(makeInput()).channels).toBeUndefined();
+  });
+
+  it("`/plan-mode` alias EXCLUDES telegram from `channels` (W1-S18-1)", () => {
+    // The alias is scoped off Telegram so it does not consume a second
+    // scarce Telegram native-menu slot (100-command cap). It stays
+    // functional on webchat / Slack / Discord / CLI. `pluginCommand-
+    // SupportsChannel` gates BOTH dispatch paths with this list, so on
+    // Telegram `/plan-mode` is fully off (menu + text) — `/plan` is the
+    // Telegram surface. See the doc comment in slash-commands.ts.
+    const channels = createPlanModeSlashCommand(makeInput()).channels;
+    expect(channels).toBeDefined();
+    expect(channels).not.toContain("telegram");
+    // Positive: the alias is still available on the non-Telegram
+    // channels (it must remain reachable everywhere else).
+    expect(channels).toEqual(
+      expect.arrayContaining(["webchat", "slack", "discord", "cli"]),
+    );
+  });
+
+  it("both commands expose `agentPromptGuidance` (Telegram-menu fallback)", () => {
+    // When the Telegram native "/" menu is full and drops `/plan`, the
+    // host injects this guidance into the agent's system prompt so the
+    // agent can still tell the user to type `/plan accept` etc.
+    const planGuidance = createPlanSlashCommand(makeInput()).agentPromptGuidance;
+    expect(planGuidance).toBeDefined();
+    expect(planGuidance!.length).toBeGreaterThan(0);
+    expect(planGuidance!.join(" ")).toMatch(/\/plan accept/);
+    expect(
+      createPlanModeSlashCommand(makeInput()).agentPromptGuidance,
+    ).toBeDefined();
   });
 });
 


### PR DESCRIPTION
Wave 3 cluster fix. Part of #100. Closes #103.

- **W1-S9-1** — sidebar descriptor schema omitted 5 fields the store writes; added them, schema now mirrors `PlanModeSessionState` (pinned by a no-drift test).
- **W1-S18-1** — Telegram 100-command menu cap could hide `/plan`. `/plan` stays canonical on all channels + gains `agentPromptGuidance`; `/plan-mode` alias gets a `channels` allowlist excluding telegram to free a slot. **The sub-agent caught + corrected a factual error in our own S18 build-spec** (no SDK field for "text-functional but menu-hidden") rather than following it.
- **W1-B4** — the accept-edits trigger predicate had no CI test; added one pinning all approval states incl. the PR #90 regression.
- **W1-S9-3** (P2) — corrected a stale `host_ref` in sweep-command.ts.

## Test plan
- [x] typecheck clean; full suite 746/746 (verified independently after the sub-agent)
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guidance text to `/plan` and `/plan-mode` slash commands to assist users with command usage.
  * Scoped `/plan-mode` command availability to exclude Telegram channels.

* **Bug Fixes**
  * Enhanced session state tracking for plan mode with additional lifecycle and approval metadata fields.

* **Documentation**
  * Updated command documentation to clarify feature parity and availability across platforms.

* **Tests**
  * Added comprehensive test coverage for plan mode functionality and command configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/Smarter-Claw/pull/110?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->