### PR TITLE
Wave 3: runtime — W1-E2 debug-log taxonomy re-ported (part of #102)

### DIFF
--- a/src/runtime/debug-log.ts
+++ b/src/runtime/debug-log.ts
@@ -1,13 +1,40 @@
 /**
  * Plan-Mode debug log — opt-in structured event surface.
  *
- * **Parity contract**: semantic port of the in-host
+ * **Parity contract (corrected per W1-E2)**: semantic port of the in-host
  * `plan-mode-debug-log.ts` at
  * `/Users/lume/repos/openclaw-pr70071-rebase/src/agents/plan-mode/plan-mode-debug-log.ts`
- * (commit `ea04ea52c7`). The event-kind taxonomy + correlation-field
- * design (approvalRunId / approvalId) are preserved verbatim. The
- * plugin port drops the openclaw-config-loader dependency in favor of
- * pluginConfig + env var; the activation contract is the same:
+ * (commit `ea04ea52c7`).
+ *
+ * **Honest divergence note (formerly a false "verbatim" claim — see
+ * `docs/audits/parity-refresh/slice-audit-E-runtime.md` finding E-2 /
+ * `docs/audits/parity-refresh/wave-1-catalog.md` row W1-E2):** earlier
+ * iterations of this file diverged from the in-host event union in four
+ * places:
+ *
+ *   1. `nudge_event` had been renamed to `nudge_phase` with a loose
+ *      `phase: string` and `details?` instead of the in-host's `nudgeId`
+ *      and 3-value phase union.
+ *   2. `toast_event` had been renamed to `ui_toast` with `message` /
+ *      `severity` instead of the in-host's `toast` / 2-value phase union.
+ *   3. `tool_call` had `mode: string` + `meta?` instead of the in-host's
+ *      `runId: string` + `details?` — breaking C7 cross-event runId
+ *      correlation entirely.
+ *   4. `approval_event` was missing — the in-host emits it on every
+ *      operator action (accept/reject/edit) to capture the subagent-gate
+ *      `result` discriminator; the plugin had no equivalent.
+ *
+ * This file now restores the in-host taxonomy verbatim for all eight
+ * kinds (`state_transition`, `gate_decision`, `tool_call`,
+ * `synthetic_injection`, `nudge_event`, `subagent_event`,
+ * `approval_event`, `toast_event`) and additionally retains
+ * `approval_transition` — which IS a legitimately distinct in-host kind
+ * (see host_ref `plan-mode-debug-log.ts:122-141` for its standalone
+ * definition; it captures every write to `SessionEntry.planMode.approval`
+ * and is NOT a rename of `approval_event`).
+ *
+ * The plugin port drops the openclaw-config-loader dependency in favor
+ * of pluginConfig + env var; the activation contract is the same:
  * "env wins over config; either turns it on."
  *
  * # Activation
@@ -54,8 +81,7 @@
  * captures. Add new kinds here when instrumenting a new touch point —
  * the union keeps callers honest about what fields each event needs.
  *
- * Port verbatim from in-host plan-mode-debug-log.ts:63-141 (the C7
- * correlation-field comment block applies here too).
+ * host_ref: src/agents/plan-mode/plan-mode-debug-log.ts:63-141
  */
 export type PlanModeDebugEvent =
   | {
@@ -78,54 +104,106 @@ export type PlanModeDebugEvent =
       approvalId?: string;
     }
   | {
+      // host_ref: src/agents/plan-mode/plan-mode-debug-log.ts:82-95
+      // The plugin previously had `tool: string`, `mode: string`,
+      // `meta?` — none of which match the in-host shape. Restored to
+      // the in-host union (4-value `tool` discriminator + required
+      // `runId` for C7 cross-event correlation + `details?` bag).
       kind: "tool_call";
       sessionKey: string;
-      tool: string;
-      mode: string;
-      meta?: Record<string, unknown>;
-      approvalRunId?: string;
-      approvalId?: string;
+      tool:
+        | "enter_plan_mode"
+        | "exit_plan_mode"
+        | "update_plan"
+        | "ask_user_question";
+      runId: string;
+      details?: Record<string, unknown>;
     }
   | {
+      // host_ref: src/agents/plan-mode/plan-mode-debug-log.ts:96-103
+      // Previously `injectionKind` / `idempotencyKey?`. Restored to
+      // in-host `tag` / `preview` (the human-readable injection
+      // identifier + the leading characters of the injected message).
       kind: "synthetic_injection";
       sessionKey: string;
-      injectionKind: string;
-      idempotencyKey?: string;
+      tag: string;
+      preview: string;
       approvalRunId?: string;
       approvalId?: string;
     }
   | {
-      kind: "approval_transition";
+      // host_ref: src/agents/plan-mode/plan-mode-debug-log.ts:104-110
+      // Previously renamed to `nudge_phase` with a loose `phase: string`
+      // and `details?`. Restored to the in-host kind name + the
+      // 3-value phase union + the required `nudgeId` correlation key.
+      kind: "nudge_event";
       sessionKey: string;
-      from: string;
-      to: string;
-      trigger: string;
-      approvalIdBefore?: string;
-      approvalIdAfter?: string;
+      nudgeId: string;
+      phase: "scheduled" | "fired" | "cleaned";
       approvalRunId?: string;
-      approvalId?: string;
     }
   | {
-      kind: "ui_toast";
-      sessionKey?: string;
-      message: string;
-      severity?: "info" | "warn" | "error";
-      approvalRunId?: string;
-      approvalId?: string;
-    }
-  | {
-      kind: "nudge_phase";
-      sessionKey: string;
-      phase: string;
-      details?: Record<string, unknown>;
-      approvalRunId?: string;
-      approvalId?: string;
-    }
-  | {
+      // host_ref: src/agents/plan-mode/plan-mode-debug-log.ts:111-117
+      // Previously `event: string` + `details?`. Restored to in-host's
+      // explicit `parentRunId` / `childRunId` correlation pair and the
+      // 2-value event discriminator.
       kind: "subagent_event";
       sessionKey: string;
-      event: string;
-      details?: Record<string, unknown>;
+      parentRunId: string;
+      childRunId: string;
+      event: "spawn" | "return";
+      approvalRunId?: string;
+    }
+  | {
+      // host_ref: src/agents/plan-mode/plan-mode-debug-log.ts:118-126
+      // Previously DROPPED ENTIRELY from the plugin (W1-E2 #4). Restored
+      // — fires on every operator action (accept/reject/edit) with the
+      // subagent-gate `result` discriminator. Distinct in concept from
+      // `approval_transition` below: `approval_event` captures the
+      // operator-action attempt + outcome; `approval_transition` captures
+      // the underlying `SessionEntry.planMode.approval` field write
+      // regardless of who triggered it.
+      kind: "approval_event";
+      sessionKey: string;
+      action: string;
+      openSubagentCount: number;
+      result: "accepted" | "rejected_by_subagent_gate" | "other";
+      approvalRunId?: string;
+      approvalId?: string;
+    }
+  | {
+      // host_ref: src/agents/plan-mode/plan-mode-debug-log.ts:127-133
+      // Previously renamed to `ui_toast` with `message` / `severity?`.
+      // Restored to the in-host kind name + the 2-value phase union +
+      // the `toast` identifier (the toast-template name, not the body
+      // text).
+      kind: "toast_event";
+      sessionKey: string;
+      toast: string;
+      phase: "fired" | "dismissed";
+      approvalRunId?: string;
+      approvalId?: string;
+    }
+  | {
+      // host_ref: src/agents/plan-mode/plan-mode-debug-log.ts:122-141
+      // Legitimately distinct from `approval_event` — emitted on every
+      // write to `SessionEntry.planMode.approval` (which can happen via
+      // multiple call-paths beyond operator actions). The plugin
+      // previously had this AND was missing `approval_event`; that gave
+      // the misleading impression of a rename. Both kinds now coexist
+      // matching the in-host.
+      //
+      // The optional `approvalRunId` / `approvalId` correlation keys
+      // are a plugin-side extension (in-host has only the *Before /
+      // *After ids); these are additive and useful for cross-event
+      // correlation when the call-site has them in scope.
+      kind: "approval_transition";
+      sessionKey: string;
+      from: string; // prior approval value, e.g. "none" | "pending" | "approved" | "rejected" | "edited" | "(absent)"
+      to: string; // new approval value
+      trigger: string; // call-site label
+      approvalIdBefore?: string;
+      approvalIdAfter?: string;
       approvalRunId?: string;
       approvalId?: string;
     };

--- a/tests/runtime/debug-log.test.ts
+++ b/tests/runtime/debug-log.test.ts
@@ -3,6 +3,15 @@
  *
  * Validates the activation predicate + structured event emission +
  * approval-transition convenience helper.
+ *
+ * **W1-E2 follow-up (2026-05-20):** the event-kind taxonomy is now
+ * byte-faithful to the in-host union at
+ * `/Volumes/LEXAR/repos/openclaw-pr70071-rebase/src/agents/plan-mode/plan-mode-debug-log.ts`
+ * commit `ea04ea52c7`. The "in-host taxonomy lock" suite below pins
+ * the eight in-host kinds + `approval_transition` so any future
+ * rename / drop fails loudly. See
+ * `docs/audits/parity-refresh/slice-audit-E-runtime.md` E-2 for the
+ * full divergence catalog that this re-port corrected.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -11,6 +20,7 @@ import {
   isPlanModeDebugEnabled,
   logPlanModeApprovalTransition,
   logPlanModeDebug,
+  type PlanModeDebugEvent,
 } from "../../src/runtime/debug-log.js";
 
 function makeLogger() {
@@ -91,41 +101,54 @@ describe("P-14 debug-log — logPlanModeDebug emit", () => {
     expect(logger.info.mock.calls[0][0]).toMatch(/^\[plan-mode\/state_transition\] /);
   });
 
-  it("emits all event kinds with the right tag", () => {
+  it("emits all in-host event kinds with the right tag", () => {
     process.env.OPENCLAW_DEBUG_PLAN_MODE = "1";
     const logger = makeLogger();
-    const events = [
+    const events: PlanModeDebugEvent[] = [
       {
-        kind: "gate_decision" as const,
+        kind: "gate_decision",
         sessionKey: "k",
         tool: "Edit",
         allowed: false,
         planMode: "plan",
       },
       {
-        kind: "tool_call" as const,
+        kind: "tool_call",
         sessionKey: "k",
-        tool: "Read",
-        mode: "plan",
+        tool: "enter_plan_mode",
+        runId: "run-1",
       },
       {
-        kind: "synthetic_injection" as const,
+        kind: "synthetic_injection",
         sessionKey: "k",
-        injectionKind: "plan_decision",
+        tag: "plan_decision",
+        preview: "ok",
       },
       {
-        kind: "ui_toast" as const,
-        message: "approved",
+        kind: "toast_event",
+        sessionKey: "k",
+        toast: "plan-approved",
+        phase: "fired",
       },
       {
-        kind: "nudge_phase" as const,
+        kind: "nudge_event",
         sessionKey: "k",
-        phase: "first",
+        nudgeId: "n-1",
+        phase: "scheduled",
       },
       {
-        kind: "subagent_event" as const,
+        kind: "subagent_event",
         sessionKey: "k",
+        parentRunId: "p-1",
+        childRunId: "c-1",
         event: "spawn",
+      },
+      {
+        kind: "approval_event",
+        sessionKey: "k",
+        action: "accept",
+        openSubagentCount: 0,
+        result: "accepted",
       },
     ];
     for (const e of events) {
@@ -138,9 +161,10 @@ describe("P-14 debug-log — logPlanModeDebug emit", () => {
       "[plan-mode/gate_decision]",
       "[plan-mode/tool_call]",
       "[plan-mode/synthetic_injection]",
-      "[plan-mode/ui_toast]",
-      "[plan-mode/nudge_phase]",
+      "[plan-mode/toast_event]",
+      "[plan-mode/nudge_event]",
       "[plan-mode/subagent_event]",
+      "[plan-mode/approval_event]",
     ]);
   });
 
@@ -150,15 +174,15 @@ describe("P-14 debug-log — logPlanModeDebug emit", () => {
     logPlanModeDebug(logger, undefined, {
       kind: "tool_call",
       sessionKey: "k",
-      tool: "Read",
-      mode: "plan",
-      approvalId: "plan-x",
+      tool: "enter_plan_mode",
+      runId: "run-1",
+      details: { foo: "bar" },
     });
-    // Sorted alphabetically (approvalId comes before mode, sessionKey, tool).
+    // Sorted alphabetically (details, runId, sessionKey, tool).
     const msg = logger.info.mock.calls[0][0] as string;
     const meta = msg.substring("[plan-mode/tool_call] ".length);
     expect(meta).toBe(
-      `approvalId="plan-x" mode="plan" sessionKey="k" tool="Read"`,
+      `details={"foo":"bar"} runId="run-1" sessionKey="k" tool="enter_plan_mode"`,
     );
   });
 
@@ -275,5 +299,279 @@ describe("P-14 debug-log — logPlanModeApprovalTransition", () => {
       "x",
     );
     expect(logger.info).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// W1-E2 follow-up: in-host taxonomy lock.
+//
+// These tests pin the in-host event-kind names and field shapes so that
+// any future re-rename or field-shape divergence fails loudly. The
+// previous "verbatim port" claim slipped through review because there
+// were no tests asserting parity with the in-host taxonomy — only tests
+// asserting the (then-diverged) plugin shape. Locking the in-host names
+// and required fields below closes that hole.
+//
+// host_ref: src/agents/plan-mode/plan-mode-debug-log.ts:63-141
+// ---------------------------------------------------------------------------
+
+describe("W1-E2 — in-host event-kind taxonomy lock", () => {
+  beforeEach(() => {
+    process.env.OPENCLAW_DEBUG_PLAN_MODE = "1";
+  });
+
+  it("emits a tag for each of the 8 in-host kinds + approval_transition", () => {
+    // The exact set of kinds the in-host emits. Any future rename
+    // (e.g. nudge_event → nudge_phase) or drop would fail this test.
+    const expectedKinds = [
+      "state_transition",
+      "gate_decision",
+      "tool_call",
+      "synthetic_injection",
+      "nudge_event",
+      "subagent_event",
+      "approval_event",
+      "toast_event",
+      "approval_transition",
+    ] as const;
+    const logger = makeLogger();
+    const events: PlanModeDebugEvent[] = [
+      {
+        kind: "state_transition",
+        sessionKey: "k",
+        from: "normal",
+        to: "plan",
+        trigger: "t",
+      },
+      {
+        kind: "gate_decision",
+        sessionKey: "k",
+        tool: "Edit",
+        allowed: false,
+        planMode: "plan",
+      },
+      {
+        kind: "tool_call",
+        sessionKey: "k",
+        tool: "exit_plan_mode",
+        runId: "r",
+      },
+      { kind: "synthetic_injection", sessionKey: "k", tag: "t", preview: "p" },
+      {
+        kind: "nudge_event",
+        sessionKey: "k",
+        nudgeId: "n-1",
+        phase: "scheduled",
+      },
+      {
+        kind: "subagent_event",
+        sessionKey: "k",
+        parentRunId: "p",
+        childRunId: "c",
+        event: "spawn",
+      },
+      {
+        kind: "approval_event",
+        sessionKey: "k",
+        action: "accept",
+        openSubagentCount: 0,
+        result: "accepted",
+      },
+      {
+        kind: "toast_event",
+        sessionKey: "k",
+        toast: "plan-approved",
+        phase: "fired",
+      },
+      {
+        kind: "approval_transition",
+        sessionKey: "k",
+        from: "pending",
+        to: "approved",
+        trigger: "t",
+      },
+    ];
+    expect(events.length).toBe(expectedKinds.length);
+    for (const e of events) logPlanModeDebug(logger, undefined, e);
+    const actualKinds = logger.info.mock.calls.map((c) => {
+      const msg = c[0] as string;
+      const m = msg.match(/^\[plan-mode\/([^\]]+)\]/);
+      return m ? m[1] : null;
+    });
+    expect(actualKinds).toEqual([...expectedKinds]);
+  });
+
+  it("tool_call carries runId (C7 correlation)", () => {
+    const logger = makeLogger();
+    logPlanModeDebug(logger, undefined, {
+      kind: "tool_call",
+      sessionKey: "k",
+      tool: "exit_plan_mode",
+      runId: "run-XYZ",
+    });
+    const msg = logger.info.mock.calls[0][0] as string;
+    expect(msg).toMatch(/runId="run-XYZ"/);
+  });
+
+  it("nudge_event carries nudgeId + a phase from the in-host union", () => {
+    const logger = makeLogger();
+    const phases: Array<"scheduled" | "fired" | "cleaned"> = [
+      "scheduled",
+      "fired",
+      "cleaned",
+    ];
+    for (const phase of phases) {
+      logPlanModeDebug(logger, undefined, {
+        kind: "nudge_event",
+        sessionKey: "k",
+        nudgeId: `n-${phase}`,
+        phase,
+      });
+    }
+    expect(logger.info).toHaveBeenCalledTimes(phases.length);
+    const msgs = logger.info.mock.calls.map((c) => c[0] as string);
+    for (let i = 0; i < phases.length; i++) {
+      expect(msgs[i]).toMatch(new RegExp(`nudgeId="n-${phases[i]}"`));
+      expect(msgs[i]).toMatch(new RegExp(`phase="${phases[i]}"`));
+    }
+  });
+
+  it("subagent_event carries parentRunId + childRunId + spawn/return event", () => {
+    const logger = makeLogger();
+    logPlanModeDebug(logger, undefined, {
+      kind: "subagent_event",
+      sessionKey: "k",
+      parentRunId: "parent-1",
+      childRunId: "child-1",
+      event: "spawn",
+    });
+    logPlanModeDebug(logger, undefined, {
+      kind: "subagent_event",
+      sessionKey: "k",
+      parentRunId: "parent-1",
+      childRunId: "child-1",
+      event: "return",
+    });
+    const msgs = logger.info.mock.calls.map((c) => c[0] as string);
+    expect(msgs[0]).toMatch(/parentRunId="parent-1"/);
+    expect(msgs[0]).toMatch(/childRunId="child-1"/);
+    expect(msgs[0]).toMatch(/event="spawn"/);
+    expect(msgs[1]).toMatch(/event="return"/);
+  });
+
+  it("approval_event carries action + openSubagentCount + result discriminator", () => {
+    const logger = makeLogger();
+    const results: Array<"accepted" | "rejected_by_subagent_gate" | "other"> = [
+      "accepted",
+      "rejected_by_subagent_gate",
+      "other",
+    ];
+    for (const result of results) {
+      logPlanModeDebug(logger, undefined, {
+        kind: "approval_event",
+        sessionKey: "k",
+        action: "accept",
+        openSubagentCount: result === "rejected_by_subagent_gate" ? 1 : 0,
+        result,
+      });
+    }
+    const msgs = logger.info.mock.calls.map((c) => c[0] as string);
+    for (let i = 0; i < results.length; i++) {
+      expect(msgs[i]).toMatch(/action="accept"/);
+      expect(msgs[i]).toMatch(new RegExp(`result="${results[i]}"`));
+    }
+    expect(msgs[1]).toMatch(/openSubagentCount=1/);
+  });
+
+  it("toast_event carries toast + fired/dismissed phase", () => {
+    const logger = makeLogger();
+    logPlanModeDebug(logger, undefined, {
+      kind: "toast_event",
+      sessionKey: "k",
+      toast: "plan-approved",
+      phase: "fired",
+    });
+    logPlanModeDebug(logger, undefined, {
+      kind: "toast_event",
+      sessionKey: "k",
+      toast: "plan-approved",
+      phase: "dismissed",
+    });
+    const msgs = logger.info.mock.calls.map((c) => c[0] as string);
+    expect(msgs[0]).toMatch(/toast="plan-approved"/);
+    expect(msgs[0]).toMatch(/phase="fired"/);
+    expect(msgs[1]).toMatch(/phase="dismissed"/);
+  });
+
+  it("synthetic_injection carries tag + preview (not the older injectionKind shape)", () => {
+    const logger = makeLogger();
+    logPlanModeDebug(logger, undefined, {
+      kind: "synthetic_injection",
+      sessionKey: "k",
+      tag: "plan_decision",
+      preview: "approved",
+    });
+    const msg = logger.info.mock.calls[0][0] as string;
+    expect(msg).toMatch(/tag="plan_decision"/);
+    expect(msg).toMatch(/preview="approved"/);
+    // Old plugin-only field names must not appear.
+    expect(msg).not.toMatch(/injectionKind/);
+    expect(msg).not.toMatch(/idempotencyKey/);
+  });
+
+  it("tool_call constrains the tool field to the 4 in-host values (compile-time)", () => {
+    // This test asserts the type at compile time. If the union widens
+    // or a value drops, tsc will fail the typecheck step.
+    const validTools: Array<
+      "enter_plan_mode" | "exit_plan_mode" | "update_plan" | "ask_user_question"
+    > = [
+      "enter_plan_mode",
+      "exit_plan_mode",
+      "update_plan",
+      "ask_user_question",
+    ];
+    const logger = makeLogger();
+    for (const tool of validTools) {
+      logPlanModeDebug(logger, undefined, {
+        kind: "tool_call",
+        sessionKey: "k",
+        tool,
+        runId: "r",
+      });
+    }
+    expect(logger.info).toHaveBeenCalledTimes(validTools.length);
+  });
+
+  it("legacy plugin-only kind names are NOT emittable (regression guard)", () => {
+    // The four kinds the W1-E2 audit found diverged. None should be
+    // valid PlanModeDebugEvent shapes. We validate the *output* — if
+    // a future patch were to add (e.g.) `ui_toast` back as a kind, the
+    // typecheck would fail or the `[plan-mode/ui_toast]` tag would
+    // appear and we'd want this test to flag it.
+    const logger = makeLogger();
+    // We can't construct legacy events through PlanModeDebugEvent (the
+    // union no longer includes them), but we can scan any emitted tag
+    // and assert it's in the in-host set. Below, we emit all known
+    // valid events and assert no legacy tags appear.
+    const events: PlanModeDebugEvent[] = [
+      {
+        kind: "toast_event",
+        sessionKey: "k",
+        toast: "x",
+        phase: "fired",
+      },
+      {
+        kind: "nudge_event",
+        sessionKey: "k",
+        nudgeId: "n",
+        phase: "scheduled",
+      },
+    ];
+    for (const e of events) logPlanModeDebug(logger, undefined, e);
+    const tags = logger.info.mock.calls.map((c) => c[0] as string);
+    for (const t of tags) {
+      expect(t).not.toMatch(/\[plan-mode\/ui_toast\]/);
+      expect(t).not.toMatch(/\[plan-mode\/nudge_phase\]/);
+    }
   });
 });


### PR DESCRIPTION
Wave 3 cluster fix. Part of #100 / #102.

The plugin's debug-log event union claimed verbatim parity but 6 kinds had drifted from the in-host. Sub-agent verified exhaustively (audit named 4; found 2 more) and re-ported the union byte-faithfully:

- `tool_call` lost `runId` (broke C7 correlation) → restored
- `synthetic_injection` field-shape drift → restored
- `nudge_event` renamed to `nudge_phase` + loosened → restored
- `subagent_event` lost required parent/child runIds + loosened → restored
- `approval_event` was missing entirely → restored
- `toast_event` renamed to `ui_toast` + different shape → restored

`approval_transition` is a separate legitimate in-host kind (NOT a rename of `approval_event`); both coexist.

Honest file-header note replaces the false 'verbatim port' claim with a W1-E2-corrected statement.

## Test plan
- [x] typecheck clean; 755/755 tests (verified independently)
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected debug event logging taxonomy to align with in-host standards and improved consistency across event types.

* **Tests**
  * Enhanced test coverage to validate corrected debug event structures and ensure logging accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/Smarter-Claw/pull/111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->