### PR TITLE
Wave 3: W1-F4 — wire the in-host auto-approve runtime (part of #104)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ import {
   extractApplyPatchTargetPaths,
 } from "./gates/accept-edits-gate.js";
 import { checkMutationGate } from "./gates/mutation-gate.js";
+import { buildApprovedPlanInjection } from "./plan-mode/approval.js";
 import {
   buildPlanModeActiveSystemContext,
   buildPlanModeAvailableSystemContext,
@@ -54,6 +55,7 @@ import {
 } from "./runtime/debug-log.js";
 import { decideEscalatingRetry } from "./runtime/escalating-retry.js";
 import { GrantLedger } from "./runtime/grant-ledger.js";
+import { enqueuePlanApprovedInjection } from "./runtime/injection-writer.js";
 import { decidePlanTierModel } from "./runtime/plan-tier-model.js";
 import { createAskUserQuestionTool } from "./tools/ask-user-question.js";
 import { createEnterPlanModeTool } from "./tools/enter-plan-mode.js";
@@ -314,6 +316,31 @@ export default definePluginEntry({
     // approval flow is unaffected.
     //
     // host_ref: src/agents/pi-embedded-subscribe.handlers.tools.ts:1925-1949
+    //
+    // W1-F4 (P1) fix (2026-05-20): wire the in-host auto-approve
+    // trigger. When the operator has flipped `autoApprove: true`
+    // (via `/plan auto on`), `exit_plan_mode` now resolves the
+    // freshly-persisted approval IMMEDIATELY as `approve` so the
+    // agent self-executes instead of waiting for a manual click.
+    //
+    // Pre-W1-F4 the flag was a real flag with a real mutator + a
+    // real slash command, but NO caller — `RELEASE_NOTES.md`
+    // known-limitation #3 acknowledged this gap, and the
+    // benchmark-codex-claude-code.md audit (F4) flagged it as a
+    // "non-functional safety-relevant control".
+    //
+    // Implementation: the trigger callback closes over `store` +
+    // `api` and reuses the exact same two operations that
+    // `plan.accept` uses (recordApproval + enqueuePlanApprovedInjection
+    // with the full buildApprovedPlanInjection preamble). Fires
+    // `approve`, NOT `edit` — auto-approve = verbatim execution of
+    // the submitted plan, never grants the agent acceptEdits.
+    //
+    // host_ref: src/agents/pi-embedded-subscribe.handlers.tools.ts:387-477
+    //   (in-host `autoApproveIfEnabled` — the function this wiring
+    //   ports the behavioral contract of).
+    // host_ref: src/agents/pi-embedded-subscribe.handlers.tools.ts:1949-1962
+    //   (in-host callsite, void-fired after the approval emit).
     api.registerTool(
       createExitPlanModeTool({
         store,
@@ -325,6 +352,66 @@ export default definePluginEntry({
             ...(api.logger.debug
               ? { debug: (msg) => api.logger.debug!(msg) }
               : {}),
+          },
+        },
+        autoApprove: {
+          // The trigger mirrors `plan.accept`'s two-step resolution
+          // (src/ui/session-actions.ts ~260-302):
+          //   1. store.recordApproval (with the expected approvalId
+          //      version-token so the stale-event guard fires if a
+          //      racing /plan reject already landed),
+          //   2. enqueuePlanApprovedInjection with the FULL
+          //      buildApprovedPlanInjection(planSteps) preamble
+          //      (opener + "execute it now without re-planning" +
+          //      numbered step list). Matches the in-host
+          //      `sessions-patch.ts approve` branch which emits the
+          //      same text via `buildApprovedPlanInjection`.
+          trigger: async ({ sessionKey, approvalId, planSteps }) => {
+            const persist = await store.recordApproval({
+              sessionKey,
+              edited: false,
+              expectedApprovalId: approvalId,
+            });
+            if (persist.kind === "failed") {
+              throw persist.error;
+            }
+            if (persist.kind === "skipped") {
+              // The state-machine guard fired (terminal state, stale
+              // id, or session already exited plan-mode). The
+              // fireAutoApproveIfEnabled helper's pre-checks should
+              // have caught most of these — log here so we see any
+              // remaining races and don't enqueue a phantom injection.
+              api.logger.warn(
+                `[smarter-claw] auto-approve recordApproval skipped: ${persist.reason} ` +
+                  `sessionKey=${sessionKey} approvalId=${approvalId}`,
+              );
+              return;
+            }
+            const stepLines = planSteps.map((step) =>
+              step.activeForm
+                ? `${step.step} (${step.activeForm})`
+                : step.step,
+            );
+            const fullText =
+              stepLines.length > 0
+                ? buildApprovedPlanInjection(stepLines)
+                : undefined;
+            await enqueuePlanApprovedInjection(api, {
+              sessionKey,
+              approvalId,
+              edited: false,
+              ...(fullText ? { fullText } : {}),
+            });
+          },
+          log: {
+            info: (msg) => api.logger.info(msg),
+            warn: (msg) => api.logger.warn(msg),
+            error: (msg) =>
+              // OpenClawPluginLogger has `error` as optional but the
+              // SDK shim always provides it; fall back to warn for
+              // defensive completeness.
+              (api.logger as { error?: (msg: string) => void }).error?.(msg) ??
+              api.logger.warn(msg),
           },
         },
       }),

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -646,10 +646,22 @@ export class PlanModeStore {
    * Toggle the autoApprove flag on the session's plan-mode state.
    *
    * When `autoApprove === true`, the next `exit_plan_mode` will resolve
-   * approval immediately without waiting for user input — the runtime
-   * (P-13 wiring) skips the pending-state intermediate and goes
-   * straight to approved + enqueues the [PLAN_DECISION]: approved
-   * injection on the agent's next turn.
+   * approval IMMEDIATELY (W1-F4 wiring, 2026-05-20) — the runtime
+   * persists the approval as `pending` (visible to UI for the brief
+   * window before auto-resolve) and then fires `recordApproval` +
+   * enqueues the [PLAN_DECISION]: approved injection on the agent's
+   * next turn. The agent self-executes the submitted plan verbatim.
+   *
+   * # Safety
+   *
+   * Auto-approve fires `approve` (NOT `edit`), so it does NOT grant
+   * the agent the `acceptEdits` permission. The 3 hard constraints
+   * enforced by the accept-edits gate (no destructive / no
+   * self-restart / no config changes) are scoped to acceptEdits-granted
+   * sessions; auto-approve sessions execute the plan as the operator
+   * pre-approved it. Toggling this flag is a trust delegation — use
+   * `/plan auto off` to revoke at any time. The trigger re-reads the
+   * flag immediately before firing so mid-cycle toggles are honored.
    *
    * Idempotent: setting the flag to its current value still writes
    * (to refresh updatedAt) but emits no audit event (transition is
@@ -659,6 +671,9 @@ export class PlanModeStore {
    *   await store.setAutoApprove({ sessionKey, enabled: true });
    *   // Next exit_plan_mode auto-approves; agent self-executes.
    *
+   * host_ref: src/agents/pi-embedded-subscribe.handlers.tools.ts:387-477
+   *   (`autoApproveIfEnabled` — the in-host trigger this flag now wires
+   *   to via `src/tools/exit-plan-mode.ts ExitPlanModeAutoApproveOptions`).
    * host_ref: in-host `auto-enable.ts` toggle wiring (PR-10 auto-mode).
    */
   async setAutoApprove(input: {

--- a/src/tools/exit-plan-mode.ts
+++ b/src/tools/exit-plan-mode.ts
@@ -114,6 +114,106 @@ export interface ExitPlanModePersisterOptions {
   };
 }
 
+/**
+ * W1-F4 fix (2026-05-20): auto-approve trigger contract.
+ *
+ * When the operator has flipped `autoApprove: true` on the session
+ * (via `/plan auto on` → `plan.auto.toggle` → `setAutoApprove`),
+ * `exit_plan_mode` should resolve the freshly-persisted approval
+ * IMMEDIATELY as `approve` instead of leaving the approval card
+ * armed for a manual click. This contract supplies the callback
+ * the tool fires after a successful persist when the persisted
+ * state's `autoApprove === true`.
+ *
+ * # Semantics
+ *
+ * The trigger fires once per persist (on `kind === "persisted"` AND
+ * `kind === "reused"` — both produce a `pending` approval with the
+ * effective `approvalId` returned by the store). The callback owns
+ * the equivalent of the in-host's
+ * `sessions.patch { planApproval: { action: "approve", approvalId } }`
+ * roundtrip — typically `store.recordApproval` + the approved-plan
+ * injection enqueue. Production wiring lives in `src/index.ts`.
+ *
+ * # Why a callback (not direct api access)
+ *
+ * The tool already accepts a callback-shaped `persister` for the same
+ * reason: keeping `api`-typed surfaces out of `src/tools/` so the tool
+ * stays unit-testable without an `api` stub. The `index.ts` callback
+ * closes over the live `store` + `api` and supplies both the state
+ * mutation (`recordApproval`) and the injection enqueue
+ * (`enqueuePlanApprovedInjection`) in a single seam.
+ *
+ * # Safety
+ *
+ * - Fires `approve`, NOT `edit` — never grants the agent acceptEdits
+ *   permission. The 3 hard constraints (no destructive / no
+ *   self-restart / no config changes) apply only when acceptEdits is
+ *   granted, so this matches the in-host behavior: auto-approve =
+ *   verbatim execution of the submitted plan.
+ * - The accept-edits gate at `src/index.ts` keys on
+ *   `approval === "edited"` and is therefore intentionally bypassed
+ *   when auto-approve fires `approve`. Matches in-host
+ *   `sessions-patch.ts:992-993` where the `approve` path clears
+ *   `postApprovalPermissions`.
+ * - The approvalId emitted in the approval event and the approvalId
+ *   passed to the trigger are the SAME value (returned from
+ *   `store.persistApprovalRequest`). Audit trail thread is intact.
+ * - Toggling `autoApprove` OFF mid-cycle is honored: the in-host
+ *   polls the store immediately before firing the approve patch
+ *   (`autoApproveIfEnabled` re-checks the flag inside the poll loop
+ *   and bails on `false`). The plugin re-reads via `store.readSnapshot`
+ *   inside the trigger for the same guard. If the operator toggled
+ *   off between persist and trigger, the approval card stays armed.
+ *
+ * # Failure handling
+ *
+ * Trigger failures are caught + logged (matching the in-host's
+ * `error`-level log on `autoApproveIfEnabled` exceptions). The
+ * approval card stays on-screen for a manual click — auto-mode
+ * briefly behaves like manual mode. This is the same degradation
+ * contract as the in-host.
+ *
+ * host_ref: src/agents/pi-embedded-subscribe.handlers.tools.ts:387-477
+ *   (`autoApproveIfEnabled` — the in-host trigger, with poll-loop +
+ *   no-op-on-disabled + error-level log on failure).
+ * host_ref: src/agents/pi-embedded-subscribe.handlers.tools.ts:1949-1962
+ *   (the in-host callsite, void-fired after the approval emit).
+ */
+export interface ExitPlanModeAutoApproveOptions {
+  /**
+   * Fired after a successful `persistApprovalRequest` (persisted or
+   * reused) when the persisted plan-mode state has `autoApprove === true`.
+   * Resolves the approval immediately so the agent self-executes.
+   *
+   * Production wiring: calls `store.recordApproval` to flip the
+   * state machine + enqueues the
+   * `buildApprovedPlanInjection(planSteps)` text via
+   * `enqueuePlanApprovedInjection` (same path as `plan.accept`).
+   *
+   * Failures should NOT throw — log + return. The tool catches
+   * defensively but the contract is fail-soft inside the callback.
+   */
+  trigger: (params: {
+    sessionKey: string;
+    approvalId: string;
+    /**
+     * The plan steps from the just-persisted approval (already
+     * materialized — no extra store read required).
+     */
+    planSteps: PlanStep[];
+  }) => Promise<void> | void;
+  /**
+   * Logger seam. Defaults to a no-op so the trigger never spams
+   * stdout in tests. Production wiring injects `api.logger` shims.
+   */
+  log?: {
+    info?: (msg: string) => void;
+    warn?: (msg: string) => void;
+    error?: (msg: string) => void;
+  };
+}
+
 export interface CreateExitPlanModeToolInput {
   store: PlanModeStore;
   /**
@@ -124,6 +224,16 @@ export interface CreateExitPlanModeToolInput {
    * tool-level behavior from filesystem effects.
    */
   persister?: ExitPlanModePersisterOptions;
+  /**
+   * W1-F4: optional auto-approve trigger wiring. When omitted, the
+   * autoApprove flag has no runtime effect (the pre-W1-F4 behavior).
+   * When supplied AND the persisted state has `autoApprove === true`,
+   * the trigger fires after persist to resolve the approval
+   * immediately. Production wiring lives in `src/index.ts`.
+   *
+   * host_ref: src/agents/pi-embedded-subscribe.handlers.tools.ts:1949-1962
+   */
+  autoApprove?: ExitPlanModeAutoApproveOptions;
 }
 
 interface ToolContext {
@@ -519,6 +629,66 @@ export function createExitPlanModeTool(opts: CreateExitPlanModeToolInput) {
         });
       }
 
+      // W1-F4 fix (2026-05-20): auto-approve trigger.
+      //
+      // If the operator pre-toggled `autoApprove: true` (via
+      // `/plan auto on` → `setAutoApprove`), resolve the freshly-
+      // persisted approval IMMEDIATELY as `approve` so the agent
+      // self-executes instead of waiting on a manual click.
+      //
+      // Pre-W1-F4 the flag was a real flag with a real mutator + a
+      // real slash command, but no caller — `RELEASE_NOTES.md`
+      // known-limitation #3 acknowledged this gap. The audit's verdict
+      // ("non-functional safety-relevant control. Wire it or hide it.")
+      // is satisfied here by wiring it.
+      //
+      // # Why fires on BOTH "persisted" and "reused"
+      //
+      // The in-host's `autoApproveIfEnabled` is void-fired after the
+      // approval emit unconditionally (`subscribe.handlers.tools.ts:1956-1962`);
+      // it polls the persisted state for the matching approvalId, which
+      // succeeds for both fresh and duplicate cycles. The reused path
+      // produces a still-pending approval with the original approvalId
+      // — if the user toggled auto-approve AFTER the original card
+      // appeared but BEFORE acting on it, the duplicate-detect retry
+      // is the correct trigger window for auto-approval to fire.
+      //
+      // # Why we re-read `autoApprove` via `store.readSnapshot`
+      //
+      // The in-host's `autoApproveIfEnabled` reads the store inside
+      // its poll loop and bails on `autoApprove === false`
+      // (`subscribe.handlers.tools.ts:435-436`). This is the
+      // "toggled off mid-cycle is honored" contract — even though the
+      // window here is small (we just persisted), the operator could
+      // have raced `/plan auto off` against this very call. Re-read.
+      //
+      // # Why not awaited
+      //
+      // Matches the in-host's `void autoApproveIfEnabled(...)` pattern
+      // (`subscribe.handlers.tools.ts:1956`). The tool result must
+      // return promptly so the agent's tool-call resolves and the UI
+      // sees the approval-requested status before the auto-approve
+      // resolves it. Awaiting would also block on `recordApproval`
+      // and the injection enqueue, which is unnecessary — the
+      // auto-approve completes asynchronously and the injection drains
+      // on the agent's next turn. The trigger callback itself must
+      // never throw (per `ExitPlanModeAutoApproveOptions.trigger`
+      // contract); we wrap defensively anyway.
+      //
+      // host_ref: src/agents/pi-embedded-subscribe.handlers.tools.ts:1949-1962
+      if (
+        opts.autoApprove &&
+        sessionKey &&
+        (r.kind === "persisted" || r.kind === "reused")
+      ) {
+        void fireAutoApproveIfEnabled({
+          opts,
+          sessionKey,
+          approvalId: r.approvalId,
+          planSteps: steps,
+        });
+      }
+
       // Map store outcome → tool result. Plugin uses hyphenated status
       // names (vs in-host underscore) for consistency with the rest of
       // the plugin status vocabulary + the eva-live-smokes assertions.
@@ -686,6 +856,116 @@ async function persistPlanArchetypeIfConfigured(input: {
         err instanceof Error ? err.message : String(err)
       }`,
     );
+  }
+}
+
+/**
+ * W1-F4 fix (2026-05-20): auto-approve trigger helper.
+ *
+ * Faithful port of the in-host `autoApproveIfEnabled` at
+ * `src/agents/pi-embedded-subscribe.handlers.tools.ts:387-477`,
+ * with two simplifications appropriate for the plugin:
+ *
+ *   1. **No poll loop.** The in-host needs to poll the on-disk session
+ *      store because the persister and the auto-approve handler run in
+ *      parallel listeners — the persister may not have landed the
+ *      `approval: "pending"` + `approvalId` write yet when auto-approve
+ *      tries to read it. The plugin's `store.persistApprovalRequest`
+ *      is awaited synchronously before this helper fires, so the
+ *      persisted state is guaranteed visible to `store.readSnapshot`.
+ *      No poll required.
+ *
+ *   2. **Trigger callback owns the patch equivalent.** The in-host
+ *      calls `callGatewayTool("sessions.patch", { planApproval: {
+ *      action: "approve", approvalId }})` — which routes through
+ *      `sessions-patch.ts` → `resolvePlanApproval(approve)` +
+ *      `appendToInjectionQueue([PLAN_DECISION]: approved)`. The
+ *      plugin's `recordApproval` + `enqueuePlanApprovedInjection` do
+ *      exactly the equivalent two operations; the trigger callback in
+ *      `index.ts` wires them.
+ *
+ * # Guard order
+ *
+ * 1. Re-read persisted state. If `autoApprove === false` (operator
+ *    flipped off mid-cycle), no-op. Matches in-host line 435-436 +
+ *    446.
+ * 2. Re-read approval state. If not still `pending` with the
+ *    matching `approvalId` (user already resolved on another
+ *    channel), no-op. Matches in-host line 446-454.
+ * 3. Fire the callback. Failures log at `error` level (matching
+ *    in-host's `params.log?.error ?? params.log?.warn` selection on
+ *    `autoApproveIfEnabled` catch — operators must notice the silent
+ *    degradation to manual mode).
+ *
+ * # Why approvalId correlation matters
+ *
+ * The persisted state's `approvalId` may differ from the candidate
+ * we minted if `persistApprovalRequest` hit the reuse path
+ * (duplicate `payloadHash`). The trigger fires with `r.approvalId`
+ * (returned by the store, == effective approvalId on disk). The
+ * helper re-confirms by re-reading; if a NEW exit_plan_mode landed
+ * between the persist and the read (the rotate path), the approvalId
+ * mismatch bails and the new card is left armed for the user. The
+ * audit trail stays threaded on the effective approvalId.
+ *
+ * host_ref: src/agents/pi-embedded-subscribe.handlers.tools.ts:387-477
+ *   (`autoApproveIfEnabled`).
+ */
+async function fireAutoApproveIfEnabled(input: {
+  opts: CreateExitPlanModeToolInput;
+  sessionKey: string;
+  approvalId: string;
+  planSteps: PlanStep[];
+}): Promise<void> {
+  const { opts, sessionKey, approvalId, planSteps } = input;
+  const trigger = opts.autoApprove?.trigger;
+  const log = opts.autoApprove?.log;
+  if (!trigger) {
+    return; // Caller already gated on this, but defensive.
+  }
+  try {
+    // Guard 1+2: re-read the persisted state to honor mid-cycle
+    // toggles. The store read is lock-protected (readSnapshot via
+    // gateway.withLock) so we see a coherent post-persist snapshot.
+    const snap = await opts.store.readSnapshot(sessionKey);
+    if (!snap?.autoApprove) {
+      // Auto-approve flipped off between persist and trigger (or was
+      // never on — caller's check raced). Manual card stays armed.
+      log?.info?.(
+        `[smarter-claw] auto-approve skipped: autoApprove=${snap?.autoApprove ?? "(no state)"} ` +
+          `sessionKey=${sessionKey} approvalId=${approvalId}`,
+      );
+      return;
+    }
+    if (snap.approval !== "pending" || snap.approvalId !== approvalId) {
+      // Another channel resolved this cycle (or a new exit_plan_mode
+      // rotated the approvalId). Bail — don't auto-approve a state
+      // we don't recognize.
+      log?.warn?.(
+        `[smarter-claw] auto-approve aborted: state moved before trigger ` +
+          `sessionKey=${sessionKey} expectedApprovalId=${approvalId} ` +
+          `currentApproval=${snap.approval} currentApprovalId=${snap.approvalId ?? "(none)"}`,
+      );
+      return;
+    }
+    // Fire — callback owns recordApproval + enqueuePlanApprovedInjection.
+    await trigger({
+      sessionKey,
+      approvalId,
+      planSteps,
+    });
+    log?.info?.(
+      `[smarter-claw] auto-approve fired sessionKey=${sessionKey} approvalId=${approvalId} steps=${planSteps.length}`,
+    );
+  } catch (err) {
+    // Use error-level logging (matching in-host's
+    // `autoApproveIfEnabled` catch) so operators notice the silent
+    // fall-back to manual mode. The approval card stays on-screen;
+    // user can click Approve manually. Auto-mode briefly degrades.
+    const message =
+      `[smarter-claw] auto-approve FAILED — approval card requires manual resolve. ` +
+      `sessionKey=${sessionKey} approvalId=${approvalId}: ${err instanceof Error ? err.message : String(err)}`;
+    (log?.error ?? log?.warn)?.(message);
   }
 }
 

--- a/tests/eva-live-smokes/smoke-5-auto-approve.test.ts
+++ b/tests/eva-live-smokes/smoke-5-auto-approve.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Eva Live-Smoke #5 — End-to-end `/plan auto on` → exit_plan_mode →
+ *                      auto-approve → injection enqueued.
+ *
+ * Scenario (W1-F4 fix, 2026-05-20):
+ *   1. Plugin loads.
+ *   2. Operator dispatches `plan.auto.toggle` with `{ enabled: true }`
+ *      (the same action `/plan auto on` routes to). State picks up
+ *      `autoApprove: true`.
+ *   3. Agent calls `enter_plan_mode`. State.mode === "plan",
+ *      autoApprove preserved across the mode flip.
+ *   4. Agent calls `exit_plan_mode` with a proposed plan.
+ *      `persistApprovalRequest` lands the pending approval, the
+ *      auto-approve trigger void-fires after the persist returns,
+ *      and the trigger callback (wired in `src/index.ts`) runs the
+ *      `recordApproval` + `enqueuePlanApprovedInjection` pair —
+ *      exactly the same two operations `plan.accept` runs.
+ *   5. The captured injection is the FULL `buildApprovedPlanInjection`
+ *      preamble (opener + "execute it now" guidance + numbered step
+ *      list) — byte-identical to the `plan.accept` path.
+ *   6. The state machine has advanced from `pending` → `approved` /
+ *      `mode === "normal"`. `autoApprove` is preserved on the state
+ *      so the NEXT cycle also auto-approves (in-host PR-10 carry
+ *      semantics).
+ *
+ * Pre-W1-F4 behavior: step 4's exit_plan_mode left state in
+ * `approval: "pending"` with no injection enqueued. The operator
+ * had to click Approve in the UI to advance — auto-approve was a
+ * flag with no caller. This smoke is the proof that W1-F4 wired
+ * the missing caller.
+ *
+ * # What this proves vs. the tool unit tests
+ *
+ * `tests/tools/exit-plan-mode.test.ts` (W1-F4 group) pins the tool-
+ * layer firing rules (when does the trigger run / not run). This
+ * smoke pins the END-TO-END contract: the trigger, when wired in
+ * `src/index.ts` to `recordApproval` + `enqueuePlanApprovedInjection`,
+ * produces the same observable agent-facing state as the manual
+ * `plan.accept` flow.
+ *
+ * host_ref: src/agents/pi-embedded-subscribe.handlers.tools.ts:387-477
+ *   (`autoApproveIfEnabled` — the in-host trigger).
+ * host_ref: src/agents/pi-embedded-subscribe.handlers.tools.ts:1949-1962
+ *   (the in-host callsite, void-fired after the approval emit).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createHarness } from "./harness.js";
+
+const SESSION_KEY = "agent:main:main";
+
+interface ToolFactory {
+  (ctx: { sessionKey?: string }): {
+    execute: (
+      callId: string,
+      args: unknown,
+    ) => Promise<{
+      details: {
+        status?: string;
+        approvalId?: string;
+        mode?: string;
+      };
+    }>;
+  };
+}
+
+/**
+ * Wait one tick for the void-fired auto-approve trigger to drain.
+ * The trigger is fire-and-forget (matches in-host
+ * `void autoApproveIfEnabled(...)` at
+ * `subscribe.handlers.tools.ts:1956`), so the test loop has to
+ * yield once to let the microtask queue flush before asserting on
+ * post-trigger state.
+ *
+ * 25ms is the same flush-cushion the smoke #4 accept-edits suite
+ * uses for void-fired plan-archetype dispatches. It's deliberately
+ * loose — the in-host's poll-loop is 50ms intervals + 2s cap, which
+ * doesn't apply here (plugin has no poll loop) — and gives slow CI
+ * boxes plenty of headroom.
+ */
+async function drainAutoApprove(): Promise<void> {
+  await new Promise((r) => setTimeout(r, 25));
+}
+
+describe("Eva live-smoke #5 — auto-approve end-to-end (W1-F4)", () => {
+  let harness: ReturnType<typeof createHarness>;
+  let enter: ToolFactory;
+  let exit: ToolFactory;
+
+  beforeEach(() => {
+    harness = createHarness({ forceInMemory: true });
+    enter = harness.findTool("enter_plan_mode") as ToolFactory;
+    exit = harness.findTool("exit_plan_mode") as ToolFactory;
+  });
+
+  afterEach(() => {
+    delete process.env.SMARTER_CLAW_USE_INMEMORY;
+  });
+
+  it("happy path: /plan auto on → enter → exit → auto-approved injection enqueued", async () => {
+    // Step 1: operator toggles autoApprove on (no plan mode active yet
+    // — `setAutoApprove` lazy-inits a normal-mode payload with the
+    // flag set; the next enterPlanMode carries it over).
+    const toggleResult = (await harness.invokeAction("plan.auto.toggle", {
+      sessionKey: SESSION_KEY,
+      payload: { enabled: true },
+    })) as { ok: boolean; result?: { kind?: string } };
+    expect(toggleResult.ok).toBe(true);
+    expect(toggleResult.result?.kind).toBe("updated");
+
+    // Step 2: enter plan mode. autoApprove carries over via spread.
+    const enterResult = await enter({ sessionKey: SESSION_KEY }).execute(
+      "call-enter",
+      {},
+    );
+    expect(enterResult.details.mode).toBe("plan");
+
+    // Step 3: exit_plan_mode with a real plan. The trigger void-fires
+    // after persist; we drain a tick before asserting on the injection.
+    const exitResult = await exit({ sessionKey: SESSION_KEY }).execute(
+      "call-exit",
+      {
+        title: "Bump deps",
+        plan: [
+          { step: "Update package.json", status: "pending" },
+          { step: "Run pnpm install", status: "pending" },
+        ],
+        summary: "Two-step dep bump.",
+      },
+    );
+    expect(exitResult.details.status).toBe("approval-requested");
+    const approvalId = exitResult.details.approvalId;
+    expect(typeof approvalId).toBe("string");
+
+    await drainAutoApprove();
+
+    // Step 4: the injection should be enqueued — same payload as the
+    // manual `plan.accept` path produces.
+    expect(harness.captures.enqueuedInjections).toHaveLength(1);
+    const inj = harness.captures.enqueuedInjections[0] as {
+      sessionKey: string;
+      text: string;
+      idempotencyKey: string;
+      placement: string;
+      metadata?: { decision?: string; approvalId?: string };
+    };
+    expect(inj.sessionKey).toBe(SESSION_KEY);
+    // Full preamble (opener + "execute it now" + step list) —
+    // matches the plan.accept path exactly (surgical-port S5 parity).
+    expect(inj.text).toMatch(/^\[PLAN_DECISION\]: approved\n/);
+    expect(inj.text).toMatch(
+      /The user has approved the following plan\. Execute it now without re-planning\./,
+    );
+    expect(inj.text).toMatch(/1\. Update package\.json/);
+    expect(inj.text).toMatch(/2\. Run pnpm install/);
+    // approvalId thread: the injection key is keyed on the SAME
+    // approvalId the exit_plan_mode result reported (audit trail
+    // stays threaded).
+    expect(inj.idempotencyKey).toBe(
+      `smarter-claw:plan_decision:${approvalId}:approved`,
+    );
+    expect(inj.metadata?.approvalId).toBe(approvalId);
+    expect(inj.metadata?.decision).toBe("approved");
+    expect(inj.placement).toBe("prepend_context");
+
+    // Step 5: an info log line marks the auto-approve fire (for
+    // operator visibility). The text contract is loose — we only
+    // pin the diagnostic prefix that telemetry / log-grep relies on.
+    expect(
+      harness.captures.loggerInfo.some((m) =>
+        /auto-approve fired/i.test(m),
+      ),
+    ).toBe(true);
+  });
+
+  it("a subsequent manual /plan accept on the same approvalId is rejected (already-resolved)", async () => {
+    // Auto-approve has fired — the state machine moved to
+    // mode:"normal" / approval:"approved". A LATER manual plan.accept
+    // (e.g. UI was slow to update + user clicked the stale card)
+    // should be cleanly rejected by the session-action layer's
+    // NOT_IN_PLAN_MODE gate.
+    await harness.invokeAction("plan.auto.toggle", {
+      sessionKey: SESSION_KEY,
+      payload: { enabled: true },
+    });
+    await enter({ sessionKey: SESSION_KEY }).execute("call-enter", {});
+    const exitResult = await exit({ sessionKey: SESSION_KEY }).execute(
+      "call-exit",
+      {
+        title: "X",
+        plan: [{ step: "a", status: "pending" }],
+      },
+    );
+    const approvalId = exitResult.details.approvalId;
+    await drainAutoApprove();
+
+    const stale = (await harness.invokeAction("plan.accept", {
+      sessionKey: SESSION_KEY,
+      payload: { approvalId },
+    })) as { ok: boolean; code?: string };
+    expect(stale.ok).toBe(false);
+    expect(stale.code).toBe("NOT_IN_PLAN_MODE");
+  });
+
+  it("autoApprove flag carries across cycles — second exit_plan_mode also auto-approves", async () => {
+    // The in-host's PR-10 carry contract
+    // (`pi-embedded-subscribe.handlers.tools.ts:313-345`) preserves
+    // `autoApprove` across plan cycles. The plugin's resolvePlanApproval
+    // does the same via `...current` spread on the approve branch. So
+    // a SECOND enter_plan_mode → exit_plan_mode under the same session
+    // should also fire the auto-approve.
+    await harness.invokeAction("plan.auto.toggle", {
+      sessionKey: SESSION_KEY,
+      payload: { enabled: true },
+    });
+
+    // Cycle 1
+    await enter({ sessionKey: SESSION_KEY }).execute("c1-enter", {});
+    await exit({ sessionKey: SESSION_KEY }).execute("c1-exit", {
+      title: "Cycle 1",
+      plan: [{ step: "first", status: "pending" }],
+    });
+    await drainAutoApprove();
+
+    // Cycle 2 — re-enter (autoApprove carries) + re-exit.
+    await enter({ sessionKey: SESSION_KEY }).execute("c2-enter", {});
+    await exit({ sessionKey: SESSION_KEY }).execute("c2-exit", {
+      title: "Cycle 2",
+      plan: [{ step: "second", status: "pending" }],
+    });
+    await drainAutoApprove();
+
+    // Both cycles fired the trigger → two injections enqueued.
+    expect(harness.captures.enqueuedInjections).toHaveLength(2);
+    const [first, second] = harness.captures.enqueuedInjections as Array<{
+      text: string;
+    }>;
+    expect(first.text).toMatch(/1\. first/);
+    expect(second.text).toMatch(/1\. second/);
+  });
+
+  it("toggling auto OFF mid-session disables the trigger for the next cycle", async () => {
+    // Toggle on → cycle 1 (auto fires) → toggle off → cycle 2
+    // (auto does NOT fire, approval stays pending).
+    await harness.invokeAction("plan.auto.toggle", {
+      sessionKey: SESSION_KEY,
+      payload: { enabled: true },
+    });
+
+    // Cycle 1: auto fires.
+    await enter({ sessionKey: SESSION_KEY }).execute("c1-enter", {});
+    await exit({ sessionKey: SESSION_KEY }).execute("c1-exit", {
+      title: "Cycle 1",
+      plan: [{ step: "first", status: "pending" }],
+    });
+    await drainAutoApprove();
+    expect(harness.captures.enqueuedInjections).toHaveLength(1);
+
+    // Toggle off.
+    const toggleOff = (await harness.invokeAction("plan.auto.toggle", {
+      sessionKey: SESSION_KEY,
+      payload: { enabled: false },
+    })) as { ok: boolean };
+    expect(toggleOff.ok).toBe(true);
+
+    // Cycle 2: manual mode expected.
+    await enter({ sessionKey: SESSION_KEY }).execute("c2-enter", {});
+    const exitR = await exit({ sessionKey: SESSION_KEY }).execute(
+      "c2-exit",
+      {
+        title: "Cycle 2",
+        plan: [{ step: "second", status: "pending" }],
+      },
+    );
+    expect(exitR.details.status).toBe("approval-requested");
+    await drainAutoApprove();
+    // STILL only the cycle-1 injection — cycle 2 awaits manual click.
+    expect(harness.captures.enqueuedInjections).toHaveLength(1);
+  });
+});

--- a/tests/tools/exit-plan-mode.test.ts
+++ b/tests/tools/exit-plan-mode.test.ts
@@ -756,3 +756,382 @@ describe("exit_plan_mode — W1-F2 markdown persister", () => {
     }
   });
 });
+
+/**
+ * W1-F4 (P1) fix (2026-05-20): the `autoApprove` flag had a real
+ * mutator + a real `/plan auto on|off` command, but no caller —
+ * RELEASE_NOTES known-limitation #3 said "the runtime side that
+ * actually FIRES auto-approve on `exit_plan_mode` … lands at
+ * P-final." `benchmark-codex-claude-code.md` audit row F4 escalated
+ * this to a "non-functional safety-relevant control" P1.
+ *
+ * These tests pin the trigger contract at the tool layer:
+ *   - When `autoApprove` is OFF (or unset), the trigger never fires.
+ *   - When `autoApprove` is ON and the persist succeeds, the trigger
+ *     fires with the persisted approvalId + the plan steps.
+ *   - Fires on BOTH the "persisted" and "reused" paths (matching the
+ *     in-host's unconditional void-fire after the approval emit).
+ *   - Re-reads the flag immediately before firing (operator toggle
+ *     off mid-cycle is honored — no auto-approve on a flipped state).
+ *   - The trigger callback's failures DO NOT propagate out of execute.
+ *
+ * The end-to-end "auto-approve produces an approved injection +
+ * advances the state machine" coverage lives in the eva-live-smokes
+ * (see `tests/eva-live-smokes/smoke-5-auto-approve.test.ts`); these
+ * unit tests are scoped to the tool layer's trigger-firing rules.
+ *
+ * host_ref: src/agents/pi-embedded-subscribe.handlers.tools.ts:387-477
+ *   (`autoApproveIfEnabled`)
+ * host_ref: src/agents/pi-embedded-subscribe.handlers.tools.ts:1949-1962
+ *   (the in-host callsite, void-fired after the approval emit)
+ */
+describe("exit_plan_mode — W1-F4 auto-approve trigger", () => {
+  /**
+   * Build a tool with both an in-mem store and an optional
+   * pre-existing `autoApprove` flag on the seeded session. Capture
+   * trigger calls + log lines for assertion.
+   */
+  function buildWithAutoApprove(
+    seedAutoApprove: boolean,
+  ): {
+    gw: InMemoryGateway;
+    store: PlanModeStore;
+    factory: ReturnType<typeof createExitPlanModeTool>;
+    triggerCalls: Array<{
+      sessionKey: string;
+      approvalId: string;
+      planSteps: unknown[];
+    }>;
+    triggerErrors: Error[];
+    info: string[];
+    warn: string[];
+    error: string[];
+    /** Mutator that lets a test simulate the operator toggling
+     *  autoApprove OFF mid-cycle, between persist and trigger. */
+    setAutoApprove(enabled: boolean): Promise<void>;
+  } {
+    const gw = new InMemoryGateway();
+    gw.seed(SESSION_KEY, {
+      mode: "plan",
+      approval: "none",
+      rejectionCount: 0,
+      enteredAt: 1_700_000_000_000,
+      ...(seedAutoApprove ? { autoApprove: true } : {}),
+    });
+    const store = new PlanModeStore(gw);
+    const triggerCalls: Array<{
+      sessionKey: string;
+      approvalId: string;
+      planSteps: unknown[];
+    }> = [];
+    const triggerErrors: Error[] = [];
+    const info: string[] = [];
+    const warn: string[] = [];
+    const error: string[] = [];
+    const factory = createExitPlanModeTool({
+      store,
+      autoApprove: {
+        trigger: async (params) => {
+          triggerCalls.push({
+            sessionKey: params.sessionKey,
+            approvalId: params.approvalId,
+            // Materialize a shallow copy so tests assert on a snapshot.
+            planSteps: [...params.planSteps],
+          });
+          if (triggerErrors.length > 0) {
+            throw triggerErrors.shift();
+          }
+        },
+        log: {
+          info: (m) => info.push(m),
+          warn: (m) => warn.push(m),
+          error: (m) => error.push(m),
+        },
+      },
+    });
+    return {
+      gw,
+      store,
+      factory,
+      triggerCalls,
+      triggerErrors,
+      info,
+      warn,
+      error,
+      async setAutoApprove(enabled: boolean) {
+        await store.setAutoApprove({ sessionKey: SESSION_KEY, enabled });
+      },
+    };
+  }
+
+  it("does NOT fire when autoApprove option is unwired (pre-W1-F4 baseline preserved)", async () => {
+    // Build a tool WITHOUT autoApprove wired AND with the flag
+    // pre-set on the seed. The flag exists in state but the tool
+    // option is absent — no trigger should run.
+    const gw = new InMemoryGateway();
+    gw.seed(SESSION_KEY, {
+      mode: "plan",
+      approval: "none",
+      rejectionCount: 0,
+      enteredAt: 1_700_000_000_000,
+      autoApprove: true,
+    });
+    const store = new PlanModeStore(gw);
+    const triggerCalls: unknown[] = [];
+    const factory = createExitPlanModeTool({ store }); // no autoApprove opt
+    const tool = factory({ sessionKey: SESSION_KEY });
+    const result = await tool.execute("c1", {
+      title: TITLE,
+      plan: [{ step: "a", status: "pending" }],
+    });
+    expect((result.details as { status: string }).status).toBe(
+      "approval-requested",
+    );
+    // The trigger captures bucket is local to the test (no trigger
+    // was wired) — confirm via the persisted state, which should
+    // STILL be pending (no auto-resolve happened).
+    expect(triggerCalls).toEqual([]);
+    expect(gw.peek(SESSION_KEY)?.approval).toBe("pending");
+  });
+
+  it("does NOT fire when autoApprove is unset on the session state", async () => {
+    const t = buildWithAutoApprove(false);
+    const tool = t.factory({ sessionKey: SESSION_KEY });
+    const result = await tool.execute("c1", {
+      title: TITLE,
+      plan: [{ step: "a", status: "pending" }],
+    });
+    expect((result.details as { status: string }).status).toBe(
+      "approval-requested",
+    );
+    // Give the void-fired trigger a tick to potentially run.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(t.triggerCalls).toEqual([]);
+    // The skip should be logged at info (not warn/error) — toggling
+    // off is the expected operator-driven path, not a failure.
+    expect(
+      t.info.some((m) => /auto-approve skipped/i.test(m)),
+    ).toBe(true);
+  });
+
+  it("fires with the persisted approvalId + plan steps when autoApprove is on (persisted path)", async () => {
+    const t = buildWithAutoApprove(true);
+    const tool = t.factory({ sessionKey: SESSION_KEY });
+    const result = await tool.execute("c1", {
+      title: TITLE,
+      plan: [
+        { step: "Bump eslint", status: "pending" },
+        { step: "Bump prettier", status: "pending" },
+      ],
+    });
+    expect((result.details as { status: string }).status).toBe(
+      "approval-requested",
+    );
+    const approvalId = (result.details as { approvalId: string }).approvalId;
+    // Void-fired trigger: drain a tick.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(t.triggerCalls).toHaveLength(1);
+    expect(t.triggerCalls[0]?.sessionKey).toBe(SESSION_KEY);
+    expect(t.triggerCalls[0]?.approvalId).toBe(approvalId);
+    expect(t.triggerCalls[0]?.planSteps).toEqual([
+      { step: "Bump eslint", status: "pending" },
+      { step: "Bump prettier", status: "pending" },
+    ]);
+    expect(
+      t.info.some((m) => /auto-approve fired/i.test(m)),
+    ).toBe(true);
+  });
+
+  it("fires on the reused path (duplicate detection) when autoApprove is on", async () => {
+    const t = buildWithAutoApprove(true);
+    const tool = t.factory({ sessionKey: SESSION_KEY });
+    const input = {
+      title: TITLE,
+      plan: [{ step: "a", status: "pending" }],
+    };
+    const first = await tool.execute("c1", input);
+    const firstId = (first.details as { approvalId: string }).approvalId;
+    await new Promise((r) => setTimeout(r, 10));
+    // First call fired the trigger. But to test the reused branch we
+    // need to roll the state back to "pending" (the test trigger
+    // doesn't change state, so it's still pending — perfect for
+    // simulating an unresolved duplicate submit).
+    expect(t.gw.peek(SESSION_KEY)?.approval).toBe("pending");
+    expect(t.gw.peek(SESSION_KEY)?.approvalId).toBe(firstId);
+
+    const second = await tool.execute("c2", input);
+    expect((second.details as { status: string }).status).toBe(
+      "duplicate-detected",
+    );
+    expect((second.details as { approvalId: string }).approvalId).toBe(firstId);
+    await new Promise((r) => setTimeout(r, 10));
+    // BOTH calls fired the trigger (matching in-host's unconditional
+    // void-fire after the approval emit).
+    expect(t.triggerCalls).toHaveLength(2);
+    expect(t.triggerCalls[1]?.approvalId).toBe(firstId);
+  });
+
+  it("does NOT fire when autoApprove is flipped OFF between persist and trigger", async () => {
+    // Simulate the operator hitting `/plan auto off` in the brief
+    // window between exit_plan_mode's persist and the auto-approve
+    // trigger. The helper's re-read guard must honor the toggle.
+    const t = buildWithAutoApprove(true);
+    const tool = t.factory({ sessionKey: SESSION_KEY });
+    // Wrap the original trigger so we can toggle off BEFORE it runs.
+    // The cleanest seam: monkey-patch readSnapshot to return
+    // autoApprove=false on the trigger's re-read. The trigger reads
+    // the store AFTER persist; we intercept that read.
+    const originalReadSnapshot = t.store.readSnapshot.bind(t.store);
+    let readCount = 0;
+    (t.store as { readSnapshot: typeof t.store.readSnapshot }).readSnapshot =
+      async (sessionKey: string) => {
+        readCount++;
+        const snap = await originalReadSnapshot(sessionKey);
+        if (!snap) return snap;
+        // First read happens in the trigger helper — pretend
+        // autoApprove flipped off in the meantime.
+        return { ...snap, autoApprove: false };
+      };
+    const result = await tool.execute("c1", {
+      title: TITLE,
+      plan: [{ step: "a", status: "pending" }],
+    });
+    expect((result.details as { status: string }).status).toBe(
+      "approval-requested",
+    );
+    await new Promise((r) => setTimeout(r, 10));
+    expect(t.triggerCalls).toEqual([]);
+    expect(readCount).toBeGreaterThan(0);
+    // The bail-out should be info-level (operator action, not error).
+    expect(
+      t.info.some((m) => /auto-approve skipped/i.test(m)),
+    ).toBe(true);
+  });
+
+  it("does NOT fire when the approvalId has rotated between persist and trigger", async () => {
+    // Simulate a fast-follow exit_plan_mode that rotated the
+    // approvalId before the trigger re-reads. The mismatch guard
+    // should bail.
+    const t = buildWithAutoApprove(true);
+    const tool = t.factory({ sessionKey: SESSION_KEY });
+    const originalReadSnapshot = t.store.readSnapshot.bind(t.store);
+    (t.store as { readSnapshot: typeof t.store.readSnapshot }).readSnapshot =
+      async (sessionKey: string) => {
+        const snap = await originalReadSnapshot(sessionKey);
+        if (!snap) return snap;
+        // Pretend a new exit_plan_mode landed with a different approvalId.
+        return { ...snap, approvalId: "plan-other-rotated-id" };
+      };
+    const result = await tool.execute("c1", {
+      title: TITLE,
+      plan: [{ step: "a", status: "pending" }],
+    });
+    expect((result.details as { status: string }).status).toBe(
+      "approval-requested",
+    );
+    await new Promise((r) => setTimeout(r, 10));
+    expect(t.triggerCalls).toEqual([]);
+    // Mismatch is logged at warn (it's a race we didn't expect, not
+    // a user-intended toggle).
+    expect(
+      t.warn.some((m) => /auto-approve aborted/i.test(m)),
+    ).toBe(true);
+  });
+
+  it("trigger callback failures DO NOT propagate out of execute (fail-soft)", async () => {
+    const t = buildWithAutoApprove(true);
+    // Queue a synthetic trigger failure.
+    t.triggerErrors.push(new Error("simulated recordApproval failure"));
+    const tool = t.factory({ sessionKey: SESSION_KEY });
+    // execute must still return a successful result; the trigger is
+    // void-fired and errors caught.
+    const result = await tool.execute("c1", {
+      title: TITLE,
+      plan: [{ step: "a", status: "pending" }],
+    });
+    expect((result.details as { status: string }).status).toBe(
+      "approval-requested",
+    );
+    await new Promise((r) => setTimeout(r, 10));
+    // The trigger captured the call before throwing.
+    expect(t.triggerCalls).toHaveLength(1);
+    // Error logged at error level (not just warn) so operators
+    // notice the silent degradation to manual mode.
+    expect(t.error.length).toBeGreaterThan(0);
+    expect(
+      t.error.some((m) => /auto-approve FAILED/i.test(m)),
+    ).toBe(true);
+    expect(
+      t.error.some((m) => /simulated recordApproval failure/.test(m)),
+    ).toBe(true);
+  });
+
+  it("does NOT fire when the persist itself failed (kind === 'failed')", async () => {
+    // Build a broken gateway so persistApprovalRequest returns
+    // kind:"failed". The trigger gate excludes failed (and skipped)
+    // so no trigger should run.
+    const triggerCalls: unknown[] = [];
+    const brokenGw = {
+      async withLock<T>(): Promise<{ transition?: T }> {
+        throw new Error("simulated IO failure");
+      },
+    };
+    const store = new PlanModeStore(brokenGw as never);
+    const factory = createExitPlanModeTool({
+      store,
+      autoApprove: {
+        trigger: async () => {
+          triggerCalls.push("should-not-fire");
+        },
+      },
+    });
+    const tool = factory({ sessionKey: SESSION_KEY });
+    const result = await tool.execute("c1", {
+      title: TITLE,
+      plan: [{ step: "a", status: "pending" }],
+    });
+    expect((result.details as { status: string }).status).toBe("failed");
+    await new Promise((r) => setTimeout(r, 10));
+    expect(triggerCalls).toEqual([]);
+  });
+
+  it("does NOT fire when the persist was skipped (kind === 'skipped' / not in plan mode)", async () => {
+    // Unseeded gateway: persistApprovalRequest returns kind:"skipped".
+    const gw = new InMemoryGateway();
+    const store = new PlanModeStore(gw);
+    const triggerCalls: unknown[] = [];
+    const factory = createExitPlanModeTool({
+      store,
+      autoApprove: {
+        trigger: async () => {
+          triggerCalls.push("should-not-fire");
+        },
+      },
+    });
+    const tool = factory({ sessionKey: SESSION_KEY });
+    const result = await tool.execute("c1", {
+      title: TITLE,
+      plan: [{ step: "a", status: "pending" }],
+    });
+    expect((result.details as { status: string }).status).toBe(
+      "not-in-plan-mode",
+    );
+    await new Promise((r) => setTimeout(r, 10));
+    expect(triggerCalls).toEqual([]);
+  });
+
+  it("preserves the audit-trail approvalId — the trigger receives the SAME id emitted in the result", async () => {
+    const t = buildWithAutoApprove(true);
+    const tool = t.factory({ sessionKey: SESSION_KEY });
+    const result = await tool.execute("c1", {
+      title: TITLE,
+      plan: [{ step: "a", status: "pending" }],
+    });
+    const emittedApprovalId = (result.details as { approvalId: string })
+      .approvalId;
+    await new Promise((r) => setTimeout(r, 10));
+    expect(t.triggerCalls[0]?.approvalId).toBe(emittedApprovalId);
+    // Also matches the persisted state's approvalId.
+    expect(t.gw.peek(SESSION_KEY)?.approvalId).toBe(emittedApprovalId);
+  });
+});


### PR DESCRIPTION
Wave 3 fix. Part of #100 / #104.

Sub-agent verified the in-host has full auto-approve wiring at `ea04ea52c7` (4 specific host_refs cited in commit body) and ported it faithfully. All safety properties preserved: approve-only (no auto-edit, so accept-edits gate scope unchanged), approvalId correlation threaded, mid-cycle toggle-off honored via readSnapshot re-read, fail-soft on errors.

+13 tests including a new `smoke-5-auto-approve.test.ts` e2e file.

**Note re W1-E1**: F4 was the prerequisite for E-1 reopen (E-1's premise required the auto-rejection loop to exist). With F4 shipped, the loop is technically possible; in practice auto-approve fires APPROVE not EDIT, so a reject-and-revise cycle isn't auto-triggered unless something else re-arms it. Real-world testing in Wave 6 will tell us if E-1 needs revisiting.

## Test plan
- [x] typecheck clean; 837/837 (verified independently)
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plan mode now supports automatic approval. When enabled, plans will be automatically approved upon exit from plan mode without requiring manual approval intervention.
  * The auto-approve setting can be enabled or disabled at any time during a session, with all approvals maintaining complete audit trail documentation for compliance and review.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/Smarter-Claw/pull/116?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->