### PR TITLE
Wave 2: Layer-1 parity harness — 8 checks, 156 cases, CI-gated (closes #106 + W1-D3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,21 @@ jobs:
           fi
           echo "vitest discovered $numTests tests"
 
+      # Wave-2 hard gate: Layer-1 parity harness. Pins ~100+ plugin
+      # surfaces against the in-host source-of-truth at commit
+      # `ea04ea52c7`. Any byte-level drift fails the build.
+      #
+      # IMPORTANT: NO `| tee ...` here — the Wave 0 audit found that
+      # piping through tee MASKED the exit code (tee always returns 0)
+      # and let failing tests ship green. `set -eo pipefail` is set as
+      # belt-and-suspenders; the command is unpiped so a non-zero exit
+      # from `pnpm parity-harness` propagates directly to the step's
+      # exit status.
+      - name: Layer-1 parity harness
+        run: |
+          set -eo pipefail
+          pnpm parity-harness
+
       # Pack the package as users would receive it. Verifies the
       # tarball contains the expected files for direct-install
       # consumption.

--- a/parity-harness/README.md
+++ b/parity-harness/README.md
@@ -5,34 +5,62 @@ reference at `rebase/pr70071-onto-main-2026-04-25` tip `ea04ea52c7`.
 
 ## Layers
 
-- **Layer 1 (P-3.5, here)**: unit-level diff. Shared `inputs.json`
-  table; both the plugin's `PlanModeStore.persistApprovalRequest` AND a
-  faithful TypeScript reference impl of the in-host
-  `persistPlanApprovalRequest` are run against each input. Outputs are
-  snapshotted as `{ stateAfter, approvalId, reused, audit }`. Any
-  unexplained diff fails the build.
+- **Layer 1 (Wave 2 — here)**: unit-level diff. ~155+ cases across 8
+  checks pin the plugin's plan-mode surface against an in-host
+  reference. Reference comes from EITHER (a) a vendored snapshot of
+  in-host code committed alongside the harness, OR (b) a byte fixture
+  captured from the in-host source via `git show`. Any unexplained
+  diff fails the CI gate (`pnpm parity-harness`).
 
-- **Layer 2 (P-5)**: scenario-level diff. YAML scenarios drive both a
-  host gateway session AND a plugin-loaded session; trace diff'd.
+- **Layer 2 (future, P-5)**: scenario-level diff. YAML scenarios drive
+  both a host gateway session AND a plugin-loaded session; trace
+  diff'd.
 
-- **Layer 3 (P-14)**: continuous-drift. Periodic CI job pulls latest
-  in-host source; regenerates reference snapshots; alerts on diff.
+- **Layer 3 (future, P-14)**: continuous-drift. Periodic CI job pulls
+  latest in-host source; regenerates reference snapshots; alerts on
+  diff.
 
 ## Layer 1 layout
 
 ```
 parity-harness/
-├── README.md                                — this file
+├── README.md                                   — this file
+├── diff.ts                                     — multi-check driver (CLI + lib entry)
+├── checks/
+│   ├── types.ts                                — Check + CheckReport contract
+│   ├── persist-approval-request.ts             — Wave-1 P-3.5
+│   ├── resolve-plan-approval.ts                — Wave-2
+│   ├── accept-edits-gate.ts                    — Wave-2
+│   ├── escalating-retry.ts                     — Wave-2 (resolvers + constant byte-pins)
+│   ├── sanitize-and-approval-id.ts             — Wave-2
+│   ├── prompts.ts                              — Wave-2 (CLOSES W1-D3)
+│   ├── mutation-gate.ts                        — Wave-2
+│   └── runtime-reject-and-plan-steps.ts        — Wave-2 bonus (W1-D1 + W1-D2 byte-pins)
 ├── inputs/
-│   └── persistApprovalRequest.json          — shared input table
+│   ├── persistApprovalRequest.json
+│   ├── resolvePlanApproval.json
+│   ├── acceptEditsGate.json
+│   ├── escalatingRetry.json
+│   ├── sanitize.json
+│   ├── mutationGate.json
+│   └── runtimeRejectAndPlanSteps.json
 ├── runners/
-│   ├── host-reference.ts                    — faithful in-host logic port
-│   ├── plugin-under-test.ts                 — exercises PlanModeStore
-│   └── shared.ts                            — common output snapshot shape
-├── snapshots/                               — generated; .gitignored
-│   ├── host-reference.json
-│   └── plugin-under-test.json
-└── diff.ts                                  — runs both, diffs, fails on drift
+│   ├── shared.ts                               — persist-approval shared types
+│   ├── host-reference.ts                       — persist-approval host port
+│   ├── plugin-under-test.ts                    — persist-approval plugin driver
+│   ├── resolve-plan-approval.reference.ts      — verbatim port of in-host resolvePlanApproval
+│   ├── accept-edits-gate.reference.ts          — VENDORED in-host file (git show)
+│   ├── mutation-gate.reference.ts              — VENDORED in-host file (git show)
+│   ├── escalating-retry.reference.ts           — constants + resolvers verbatim from in-host
+│   ├── sanitize-and-approval-id.reference.ts   — verbatim port of in-host sanitize + shape regex
+│   └── runtime-reject-and-plan-steps.reference.ts — verbatim port of in-host sessions-patch helpers
+└── host-snapshots/
+    ├── README.md                               — snapshot-file directory
+    ├── capture.ts                              — tsx script: pulls bytes from in-host via `git show`
+    ├── PLAN_ARCHETYPE_PROMPT.txt               — byte fixture
+    ├── PLAN_MODE_REFERENCE_CARD.txt            — byte fixture
+    ├── plan-mode-active-system-context.txt     — byte fixture (attempt.ts:692-732 inline)
+    └── plan-mode-available-system-context.txt  — byte fixture (attempt.ts:735-748 inline)
 ```
 
 ## Run
@@ -42,28 +70,79 @@ pnpm parity-harness
 ```
 
 Returns non-zero on diff. Wired into `pnpm test` via vitest config so
-the CI gate fails when parity breaks.
+the CI gate fails when parity breaks. The standalone script
+(`parity-harness/diff.ts`) is for humans debugging locally:
+
+```bash
+npx tsx parity-harness/diff.ts
+# → [parity-harness] ✓ 156/156 cases parity-clean across 8 checks
+```
+
+## CI gate
+
+`.github/workflows/ci.yml` adds a dedicated `Layer-1 parity harness`
+step AFTER the unit-test step. The step is unpiped (no `tee`, no
+chained commands) so a non-zero exit from `pnpm parity-harness`
+propagates straight to the step's exit code. Wave 0 found that a
+prior pipe-through-tee masked test failures with tee's always-zero
+exit — that masking is structurally avoided here.
 
 ## Adding a case
 
-1. Append a `{id, description, input, state_before}` entry to
-   `inputs/persistApprovalRequest.json`. `id` must be unique.
-2. Re-run `pnpm parity-harness`. Both runners produce a snapshot for
-   the new case. Diff passes.
-3. Commit the input change. Snapshots regenerate per-run; not checked
-   in.
+For an existing check:
+
+1. Append a new entry to the corresponding `inputs/*.json`.
+2. Re-run `pnpm parity-harness`. The new case must show as parity-clean.
+
+## Adding a new check
+
+1. Build `parity-harness/checks/<name>.ts` exporting a `ParityCheck`
+   per `checks/types.ts`. Mirror the structure of an existing check
+   (e.g. `accept-edits-gate.ts`).
+2. Vendor or port the in-host reference into `runners/<name>.reference.ts`.
+   Prefer `git -C /Volumes/LEXAR/repos/openclaw-pr70071-rebase show
+   ea04ea52c7:<path>` for files that are pure functions; for files with
+   side effects, hand-port the relevant subset.
+3. Add the check to `ALL_CHECKS` in `diff.ts`.
+4. Add a per-check `describe()/it()` block in
+   `tests/parity/parity-harness.test.ts`.
+5. Re-run `pnpm parity-harness` and `pnpm typecheck`. Both must be clean.
+
+## Re-capturing byte fixtures
+
+When the in-host source changes (rare per Wave-0 Decision A — we
+pinned at `ea04ea52c7`):
+
+```bash
+npx tsx parity-harness/host-snapshots/capture.ts
+```
+
+Then `git diff parity-harness/host-snapshots/`. Verify the diff is
+intentional and reflects an in-host change you've already agreed to
+absorb. Commit the new snapshots alongside the plugin-side update
+that matches them.
 
 ## When this fails
 
-- **Plugin diverged from in-host**: fix the plugin to match the
-  reference. The reference IS the contract.
-- **Reference diverged from in-host source**: update the reference,
-  citing the new `host_ref:` lines. Commit both.
+- **Plugin diverged from in-host**: fix `src/` to match the reference.
+  The reference IS the contract.
+- **Reference diverged from in-host source-of-truth** (rare): re-capture
+  via `host-snapshots/capture.ts` and update the relevant `runners/*.reference.ts`
+  files. Cite the in-host line range in your commit message.
 - **Input is malformed**: validate it parses; fix the JSON.
 
 ## Anti-pattern guardrail
 
-The reference impl is updated by **reading the in-host source** at the
-cited `host_ref:` line range, NOT by inspecting the plugin code and
-back-filling. Reverse-engineering the reference from the plugin defeats
-the parity check.
+The reference impl + snapshots are updated by **reading the in-host
+source** at the cited `host_ref:` line range, NOT by inspecting the
+plugin code and back-filling. Reverse-engineering the reference from
+the plugin defeats the parity check.
+
+## Vendored snapshot files
+
+`runners/accept-edits-gate.reference.ts` and `runners/mutation-gate.reference.ts`
+are direct `git show` extractions from the in-host source. They carry
+a "DO NOT EDIT BY HAND" header and re-capture instructions. The single
+allowed local edit is the import path (`./types.js` → `../../src/types.js`)
+because the plugin's `PlanMode`/`PlanModeSessionState` types live at
+the top-level `src/types.ts` rather than in a plan-mode subdirectory.

--- a/parity-harness/checks/accept-edits-gate.ts
+++ b/parity-harness/checks/accept-edits-gate.ts
@@ -1,0 +1,73 @@
+/**
+ * Layer-1 check: `checkAcceptEditsConstraint` (accept-edits gate).
+ *
+ * Drives both the plugin's `src/gates/accept-edits-gate.ts` AND the
+ * vendored in-host reference at
+ * `runners/accept-edits-gate.reference.ts` across the case table at
+ * `inputs/acceptEditsGate.json`. The gate is a fail-OPEN security
+ * boundary — diverging from in-host means either over-blocking (UX
+ * regression) or under-blocking (security regression).
+ *
+ * host_ref: src/agents/plan-mode/accept-edits-gate.ts (commit ea04ea52c7)
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { checkAcceptEditsConstraint as pluginCheck } from "../../src/gates/accept-edits-gate.js";
+import { checkAcceptEditsConstraint as hostCheck } from "../runners/accept-edits-gate.reference.js";
+import type { CheckCaseResult, CheckReport, ParityCheck } from "./types.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+interface AcceptEditsGateCase {
+  id: string;
+  description: string;
+  toolName: string;
+  execCommand?: string;
+  filePath?: string;
+  additionalPaths?: string[];
+}
+
+function loadCases(): AcceptEditsGateCase[] {
+  const path = join(__dirname, "..", "inputs", "acceptEditsGate.json");
+  return JSON.parse(readFileSync(path, "utf8")) as AcceptEditsGateCase[];
+}
+
+export const acceptEditsGateCheck: ParityCheck = {
+  name: "acceptEditsGate",
+  run(): CheckReport {
+    const cases = loadCases();
+    const results: CheckCaseResult[] = cases.map((c) => {
+      const params = {
+        toolName: c.toolName,
+        execCommand: c.execCommand,
+        filePath: c.filePath,
+        additionalPaths: c.additionalPaths,
+      };
+      const refOut = hostCheck(params);
+      const plugOut = pluginCheck(params);
+      // Compare blocked + constraint + reason (the exact bytes
+      // returned to the runtime).
+      const ok =
+        refOut.blocked === plugOut.blocked &&
+        refOut.constraint === plugOut.constraint &&
+        refOut.reason === plugOut.reason;
+      const diff = ok
+        ? ""
+        : [
+            "outputs differ:",
+            `      reference=${JSON.stringify(refOut)}`,
+            `      plugin   =${JSON.stringify(plugOut)}`,
+          ].join("\n    ");
+      return {
+        caseId: c.id,
+        description: c.description,
+        ok,
+        diff,
+      };
+    });
+    return { name: "acceptEditsGate", cases: results };
+  },
+};

--- a/parity-harness/checks/escalating-retry.ts
+++ b/parity-harness/checks/escalating-retry.ts
@@ -1,0 +1,210 @@
+/**
+ * Layer-1 check: escalating-retry instruction selection + constants.
+ *
+ * Pins all three resolvers (planning-retry, plan-ack-only, plan-yield)
+ * across attempt 0/1/2/3 against the vendored in-host reference values.
+ * Also pins each individual instruction constant byte-for-byte (so a
+ * single-character drift in the bytes the agent sees is caught even if
+ * the resolver shape is unchanged).
+ *
+ * # Why the constant checks live here, not in a separate prompt-bytes check
+ *
+ * The escalating-retry constants ARE prompt bytes — same byte-fixture
+ * pattern as PLAN_ARCHETYPE_PROMPT. Combining the resolver dispatch
+ * check with the byte-pinning check in ONE place keeps both side-by-
+ * side; a drift in either fails the check.
+ *
+ * host_ref:
+ *   - src/agents/pi-embedded-runner/run/incomplete-turn.ts:66-267 (constants)
+ *   - src/agents/pi-embedded-runner/run/incomplete-turn.ts:731-739 (resolveEscalatingPlanningRetryInstruction)
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  ACK_EXECUTION_FAST_PATH_INSTRUCTION,
+  AUTO_CONTINUE_FAST_PATH_INSTRUCTION,
+  DEFAULT_EMPTY_RESPONSE_RETRY_LIMIT,
+  DEFAULT_PLAN_APPROVED_YIELD_RETRY_LIMIT,
+  DEFAULT_PLAN_MODE_ACK_ONLY_RETRY_LIMIT,
+  DEFAULT_PLANNING_ONLY_RETRY_LIMIT,
+  DEFAULT_REASONING_ONLY_RETRY_LIMIT,
+  EMPTY_RESPONSE_RETRY_INSTRUCTION,
+  PLAN_APPROVED_YIELD_RETRY_INSTRUCTION,
+  PLAN_APPROVED_YIELD_RETRY_INSTRUCTION_FIRM,
+  PLAN_MODE_ACK_ONLY_RETRY_INSTRUCTION,
+  PLAN_MODE_ACK_ONLY_RETRY_INSTRUCTION_FIRM,
+  PLAN_MODE_INVESTIGATIVE_TOOL_NAMES,
+  PLANNING_ONLY_RETRY_INSTRUCTION,
+  PLANNING_ONLY_RETRY_INSTRUCTION_FINAL,
+  PLANNING_ONLY_RETRY_INSTRUCTION_FIRM,
+  REASONING_ONLY_RETRY_INSTRUCTION,
+  resolveEscalatingPlanAckOnlyInstruction,
+  resolveEscalatingPlanningRetryInstruction,
+  resolveEscalatingPlanYieldInstruction,
+  STRICT_AGENTIC_BLOCKED_TEXT,
+  STRICT_AGENTIC_PLANNING_ONLY_RETRY_LIMIT,
+} from "../../src/runtime/escalating-retry-constants.js";
+import {
+  ACK_EXECUTION_FAST_PATH_INSTRUCTION_REF,
+  AUTO_CONTINUE_FAST_PATH_INSTRUCTION_REF,
+  DEFAULT_EMPTY_RESPONSE_RETRY_LIMIT_REF,
+  DEFAULT_PLAN_APPROVED_YIELD_RETRY_LIMIT_REF,
+  DEFAULT_PLAN_MODE_ACK_ONLY_RETRY_LIMIT_REF,
+  DEFAULT_PLANNING_ONLY_RETRY_LIMIT_REF,
+  DEFAULT_REASONING_ONLY_RETRY_LIMIT_REF,
+  EMPTY_RESPONSE_RETRY_INSTRUCTION_REF,
+  PLAN_APPROVED_YIELD_RETRY_INSTRUCTION_FIRM_REF,
+  PLAN_APPROVED_YIELD_RETRY_INSTRUCTION_REF,
+  PLAN_MODE_ACK_ONLY_RETRY_INSTRUCTION_FIRM_REF,
+  PLAN_MODE_ACK_ONLY_RETRY_INSTRUCTION_REF,
+  PLAN_MODE_INVESTIGATIVE_TOOL_NAMES_REF,
+  PLANNING_ONLY_RETRY_INSTRUCTION_FINAL_REF,
+  PLANNING_ONLY_RETRY_INSTRUCTION_FIRM_REF,
+  PLANNING_ONLY_RETRY_INSTRUCTION_REF,
+  REASONING_ONLY_RETRY_INSTRUCTION_REF,
+  resolveEscalatingPlanAckOnlyInstructionReference,
+  resolveEscalatingPlanningRetryInstructionReference,
+  resolveEscalatingPlanYieldInstructionReference,
+  STRICT_AGENTIC_BLOCKED_TEXT_REF,
+  STRICT_AGENTIC_PLANNING_ONLY_RETRY_LIMIT_REF,
+} from "../runners/escalating-retry.reference.js";
+import type { CheckCaseResult, CheckReport, ParityCheck } from "./types.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+interface EscalatingRetryCase {
+  id: string;
+  description: string;
+  resolver: "planning" | "planAckOnly" | "planYield";
+  attemptIndex: number;
+}
+
+function loadCases(): EscalatingRetryCase[] {
+  const path = join(__dirname, "..", "inputs", "escalatingRetry.json");
+  return JSON.parse(readFileSync(path, "utf8")) as EscalatingRetryCase[];
+}
+
+function diffStrings(a: string, b: string): string {
+  if (a === b) return "";
+  if (a.length !== b.length) {
+    return `length differs: plugin=${a.length}, reference=${b.length}`;
+  }
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) {
+      const ctx = (s: string) =>
+        JSON.stringify(s.slice(Math.max(0, i - 20), i + 20));
+      return `first byte-diff at index ${i}: plugin=${ctx(a)}, reference=${ctx(b)}`;
+    }
+  }
+  return "strings differ but no per-byte diff found (codepoint mismatch?)";
+}
+
+function arraysEqual(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
+  if (a.size !== b.size) return false;
+  for (const x of a) {
+    if (!b.has(x)) return false;
+  }
+  return true;
+}
+
+export const escalatingRetryCheck: ParityCheck = {
+  name: "escalatingRetry",
+  run(): CheckReport {
+    const cases = loadCases();
+    const results: CheckCaseResult[] = [];
+
+    // Resolver-shape cases (from the JSON input table).
+    for (const c of cases) {
+      let plug: string;
+      let ref: string;
+      switch (c.resolver) {
+        case "planning":
+          plug = resolveEscalatingPlanningRetryInstruction(c.attemptIndex);
+          ref = resolveEscalatingPlanningRetryInstructionReference(c.attemptIndex);
+          break;
+        case "planAckOnly":
+          plug = resolveEscalatingPlanAckOnlyInstruction(c.attemptIndex);
+          ref = resolveEscalatingPlanAckOnlyInstructionReference(c.attemptIndex);
+          break;
+        case "planYield":
+          plug = resolveEscalatingPlanYieldInstruction(c.attemptIndex);
+          ref = resolveEscalatingPlanYieldInstructionReference(c.attemptIndex);
+          break;
+      }
+      const diff = diffStrings(plug, ref);
+      results.push({
+        caseId: c.id,
+        description: c.description,
+        ok: diff === "",
+        diff,
+      });
+    }
+
+    // Constant byte-pin cases — every exported instruction string + limit
+    // constant must match the reference. Generated programmatically so
+    // adding a new constant is a one-line edit on both sides.
+    const constPairs: Array<[string, string, string]> = [
+      ["PLANNING_ONLY_RETRY_INSTRUCTION", PLANNING_ONLY_RETRY_INSTRUCTION, PLANNING_ONLY_RETRY_INSTRUCTION_REF],
+      ["PLANNING_ONLY_RETRY_INSTRUCTION_FIRM", PLANNING_ONLY_RETRY_INSTRUCTION_FIRM, PLANNING_ONLY_RETRY_INSTRUCTION_FIRM_REF],
+      ["PLANNING_ONLY_RETRY_INSTRUCTION_FINAL", PLANNING_ONLY_RETRY_INSTRUCTION_FINAL, PLANNING_ONLY_RETRY_INSTRUCTION_FINAL_REF],
+      ["REASONING_ONLY_RETRY_INSTRUCTION", REASONING_ONLY_RETRY_INSTRUCTION, REASONING_ONLY_RETRY_INSTRUCTION_REF],
+      ["EMPTY_RESPONSE_RETRY_INSTRUCTION", EMPTY_RESPONSE_RETRY_INSTRUCTION, EMPTY_RESPONSE_RETRY_INSTRUCTION_REF],
+      ["ACK_EXECUTION_FAST_PATH_INSTRUCTION", ACK_EXECUTION_FAST_PATH_INSTRUCTION, ACK_EXECUTION_FAST_PATH_INSTRUCTION_REF],
+      ["AUTO_CONTINUE_FAST_PATH_INSTRUCTION", AUTO_CONTINUE_FAST_PATH_INSTRUCTION, AUTO_CONTINUE_FAST_PATH_INSTRUCTION_REF],
+      ["STRICT_AGENTIC_BLOCKED_TEXT", STRICT_AGENTIC_BLOCKED_TEXT, STRICT_AGENTIC_BLOCKED_TEXT_REF],
+      ["PLAN_MODE_ACK_ONLY_RETRY_INSTRUCTION", PLAN_MODE_ACK_ONLY_RETRY_INSTRUCTION, PLAN_MODE_ACK_ONLY_RETRY_INSTRUCTION_REF],
+      ["PLAN_MODE_ACK_ONLY_RETRY_INSTRUCTION_FIRM", PLAN_MODE_ACK_ONLY_RETRY_INSTRUCTION_FIRM, PLAN_MODE_ACK_ONLY_RETRY_INSTRUCTION_FIRM_REF],
+      ["PLAN_APPROVED_YIELD_RETRY_INSTRUCTION", PLAN_APPROVED_YIELD_RETRY_INSTRUCTION, PLAN_APPROVED_YIELD_RETRY_INSTRUCTION_REF],
+      ["PLAN_APPROVED_YIELD_RETRY_INSTRUCTION_FIRM", PLAN_APPROVED_YIELD_RETRY_INSTRUCTION_FIRM, PLAN_APPROVED_YIELD_RETRY_INSTRUCTION_FIRM_REF],
+    ];
+    for (const [name, plug, ref] of constPairs) {
+      const diff = diffStrings(plug, ref);
+      results.push({
+        caseId: `const:${name}`,
+        description: `constant ${name} must match in-host byte-for-byte`,
+        ok: diff === "",
+        diff,
+      });
+    }
+
+    // Retry-limit numeric constants.
+    const limitPairs: Array<[string, number, number]> = [
+      ["DEFAULT_PLANNING_ONLY_RETRY_LIMIT", DEFAULT_PLANNING_ONLY_RETRY_LIMIT, DEFAULT_PLANNING_ONLY_RETRY_LIMIT_REF],
+      ["STRICT_AGENTIC_PLANNING_ONLY_RETRY_LIMIT", STRICT_AGENTIC_PLANNING_ONLY_RETRY_LIMIT, STRICT_AGENTIC_PLANNING_ONLY_RETRY_LIMIT_REF],
+      ["DEFAULT_REASONING_ONLY_RETRY_LIMIT", DEFAULT_REASONING_ONLY_RETRY_LIMIT, DEFAULT_REASONING_ONLY_RETRY_LIMIT_REF],
+      ["DEFAULT_EMPTY_RESPONSE_RETRY_LIMIT", DEFAULT_EMPTY_RESPONSE_RETRY_LIMIT, DEFAULT_EMPTY_RESPONSE_RETRY_LIMIT_REF],
+      ["DEFAULT_PLAN_MODE_ACK_ONLY_RETRY_LIMIT", DEFAULT_PLAN_MODE_ACK_ONLY_RETRY_LIMIT, DEFAULT_PLAN_MODE_ACK_ONLY_RETRY_LIMIT_REF],
+      ["DEFAULT_PLAN_APPROVED_YIELD_RETRY_LIMIT", DEFAULT_PLAN_APPROVED_YIELD_RETRY_LIMIT, DEFAULT_PLAN_APPROVED_YIELD_RETRY_LIMIT_REF],
+    ];
+    for (const [name, plug, ref] of limitPairs) {
+      const ok = plug === ref;
+      results.push({
+        caseId: `limit:${name}`,
+        description: `retry-limit constant ${name} must match in-host`,
+        ok,
+        diff: ok ? "" : `plugin=${plug}, reference=${ref}`,
+      });
+    }
+
+    // Investigative-tool catalog (set equality).
+    {
+      const ok = arraysEqual(
+        PLAN_MODE_INVESTIGATIVE_TOOL_NAMES,
+        PLAN_MODE_INVESTIGATIVE_TOOL_NAMES_REF,
+      );
+      results.push({
+        caseId: "set:PLAN_MODE_INVESTIGATIVE_TOOL_NAMES",
+        description: "investigative-tool catalog must match in-host set",
+        ok,
+        diff: ok
+          ? ""
+          : `plugin=${JSON.stringify([...PLAN_MODE_INVESTIGATIVE_TOOL_NAMES].sort())}, reference=${JSON.stringify([...PLAN_MODE_INVESTIGATIVE_TOOL_NAMES_REF].sort())}`,
+      });
+    }
+
+    return { name: "escalatingRetry", cases: results };
+  },
+};

--- a/parity-harness/checks/mutation-gate.ts
+++ b/parity-harness/checks/mutation-gate.ts
@@ -1,0 +1,62 @@
+/**
+ * Layer-1 check: `checkMutationGate` (plan-mode mutation gate).
+ *
+ * Drives both the plugin's `src/gates/mutation-gate.ts:checkMutationGate`
+ * AND the vendored in-host reference at
+ * `runners/mutation-gate.reference.ts` across the case table at
+ * `inputs/mutationGate.json`. The gate is fail-CLOSED in plan mode —
+ * diverging from in-host risks either over-blocking (UX regression) or
+ * under-blocking (security regression).
+ *
+ * host_ref: src/agents/plan-mode/mutation-gate.ts (commit ea04ea52c7)
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { checkMutationGate as pluginGate } from "../../src/gates/mutation-gate.js";
+import type { PlanMode } from "../../src/types.js";
+import { checkMutationGate as hostGate } from "../runners/mutation-gate.reference.js";
+import type { CheckCaseResult, CheckReport, ParityCheck } from "./types.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+interface MutationGateCase {
+  id: string;
+  description: string;
+  toolName: string;
+  currentMode: PlanMode;
+  execCommand?: string;
+}
+
+function loadCases(): MutationGateCase[] {
+  const path = join(__dirname, "..", "inputs", "mutationGate.json");
+  return JSON.parse(readFileSync(path, "utf8")) as MutationGateCase[];
+}
+
+export const mutationGateCheck: ParityCheck = {
+  name: "mutationGate",
+  run(): CheckReport {
+    const cases = loadCases();
+    const results: CheckCaseResult[] = cases.map((c) => {
+      const ref = hostGate(c.toolName, c.currentMode, c.execCommand);
+      const plug = pluginGate(c.toolName, c.currentMode, c.execCommand);
+      const ok = ref.blocked === plug.blocked && ref.reason === plug.reason;
+      const diff = ok
+        ? ""
+        : [
+            "outputs differ:",
+            `      reference=${JSON.stringify(ref)}`,
+            `      plugin   =${JSON.stringify(plug)}`,
+          ].join("\n    ");
+      return {
+        caseId: c.id,
+        description: c.description,
+        ok,
+        diff,
+      };
+    });
+    return { name: "mutationGate", cases: results };
+  },
+};

--- a/parity-harness/checks/persist-approval-request.ts
+++ b/parity-harness/checks/persist-approval-request.ts
@@ -1,0 +1,99 @@
+/**
+ * Layer-1 check: `PlanModeStore.persistApprovalRequest`.
+ *
+ * Wraps the existing `runners/host-reference.ts` + `runners/plugin-under-test.ts`
+ * pair as a uniform `ParityCheck`. The input table at
+ * `inputs/persistApprovalRequest.json` carries 11 cases covering the
+ * 10-invariant in-host algorithm.
+ *
+ * host_ref: src/agents/pi-embedded-subscribe.handlers.tools.ts:130-237
+ *   (commit ea04ea52c7) — the in-host `persistPlanApprovalRequest`.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { runReferenceCases } from "../runners/host-reference.js";
+import { runPluginCases } from "../runners/plugin-under-test.js";
+import type { ParityCase, ParityOutcome } from "../runners/shared.js";
+import type { CheckCaseResult, CheckReport, ParityCheck } from "./types.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+function loadCases(): ParityCase[] {
+  const path = join(__dirname, "..", "inputs", "persistApprovalRequest.json");
+  return JSON.parse(readFileSync(path, "utf8")) as ParityCase[];
+}
+
+function computeDiff(ref: ParityOutcome, plug: ParityOutcome): string {
+  const issues: string[] = [];
+  if (ref.result.kind !== plug.result.kind) {
+    issues.push(`kind: reference=${ref.result.kind}, plugin=${plug.result.kind}`);
+  }
+  if (ref.result.approvalId !== plug.result.approvalId) {
+    issues.push(
+      `approvalId: reference=${ref.result.approvalId}, plugin=${plug.result.approvalId}`,
+    );
+  }
+  if (
+    ref.result.kind === "skipped" &&
+    plug.result.kind === "skipped" &&
+    ref.result.reason !== plug.result.reason
+  ) {
+    issues.push(
+      `skipped reason: reference=${ref.result.reason}, plugin=${plug.result.reason}`,
+    );
+  }
+  if (ref.auditEmitted !== plug.auditEmitted) {
+    issues.push(
+      `auditEmitted: reference=${ref.auditEmitted}, plugin=${plug.auditEmitted}`,
+    );
+  }
+  if (!deepEqual(ref.stateAfter, plug.stateAfter)) {
+    issues.push(
+      `stateAfter differs:\n      reference=${JSON.stringify(ref.stateAfter)}\n      plugin   =${JSON.stringify(plug.stateAfter)}`,
+    );
+  }
+  return issues.join("\n    ");
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a == null || b == null) return false;
+  if (typeof a !== "object" || typeof b !== "object") return false;
+  if (Array.isArray(a) !== Array.isArray(b)) return false;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    return a.every((v, i) => deepEqual(v, b[i]));
+  }
+  const ak = Object.keys(a as object).sort();
+  const bk = Object.keys(b as object).sort();
+  if (ak.length !== bk.length) return false;
+  if (!ak.every((k, i) => k === bk[i])) return false;
+  return ak.every((k) =>
+    deepEqual(
+      (a as Record<string, unknown>)[k],
+      (b as Record<string, unknown>)[k],
+    ),
+  );
+}
+
+export const persistApprovalRequestCheck: ParityCheck = {
+  name: "persistApprovalRequest",
+  async run(): Promise<CheckReport> {
+    const cases = loadCases();
+    const ref = runReferenceCases(cases);
+    const plug = await runPluginCases(cases);
+    const results: CheckCaseResult[] = cases.map((c, i) => {
+      const diff = computeDiff(ref[i]!, plug[i]!);
+      return {
+        caseId: c.id,
+        description: c.description,
+        ok: diff.length === 0,
+        diff,
+      };
+    });
+    return { name: "persistApprovalRequest", cases: results };
+  },
+};

--- a/parity-harness/checks/prompts.ts
+++ b/parity-harness/checks/prompts.ts
@@ -1,0 +1,127 @@
+/**
+ * Layer-1 check: byte-identical prompt artifacts.
+ *
+ * Closes Wave-1 finding W1-D3: "no byte-fixture test pins the prompt
+ * artifacts against in-host bytes". This check reads four committed
+ * snapshots from `parity-harness/host-snapshots/` (captured by
+ * `host-snapshots/capture.ts` via `git show` from the in-host source-
+ * of-truth at commit `ea04ea52c7`) and diffs them against the plugin's
+ * runtime output byte-for-byte.
+ *
+ * Artifacts pinned:
+ *   - `PLAN_ARCHETYPE_PROMPT` (from `src/prompt/archetype-prompt.ts`)
+ *   - `PLAN_MODE_REFERENCE_CARD` (from `src/prompt/reference-card.ts`)
+ *   - `buildPlanModeActiveSystemContext()` (from `src/prompt/plan-mode-injection.ts`)
+ *   - `buildPlanModeAvailableSystemContext()` (from `src/prompt/plan-mode-injection.ts`)
+ *
+ * # Why bytes matter
+ *
+ * Prompt-cache keys are prefix hashes of the system context. A single
+ * character drift bumps the hash and forces a full prefix re-evaluation
+ * on every plan-mode turn — and steers agent behavior differently
+ * because the agent reads the bytes verbatim.
+ *
+ * host_ref:
+ *   - src/agents/plan-mode/plan-archetype-prompt.ts
+ *   - src/agents/plan-mode/reference-card.ts
+ *   - src/agents/pi-embedded-runner/run/attempt.ts:692-748
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { PLAN_ARCHETYPE_PROMPT } from "../../src/prompt/archetype-prompt.js";
+import {
+  buildPlanModeActiveSystemContext,
+  buildPlanModeAvailableSystemContext,
+} from "../../src/prompt/plan-mode-injection.js";
+import { PLAN_MODE_REFERENCE_CARD } from "../../src/prompt/reference-card.js";
+import type { CheckCaseResult, CheckReport, ParityCheck } from "./types.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+function snapshot(name: string): string {
+  const path = join(__dirname, "..", "host-snapshots", name);
+  return readFileSync(path, "utf8");
+}
+
+function diffBytes(plugin: string, host: string): string {
+  if (plugin === host) return "";
+  if (plugin.length !== host.length) {
+    // Still find first byte-diff so the failure message is actionable.
+    const min = Math.min(plugin.length, host.length);
+    for (let i = 0; i < min; i++) {
+      if (plugin[i] !== host[i]) {
+        const ctx = (s: string) =>
+          JSON.stringify(s.slice(Math.max(0, i - 30), i + 30));
+        return `length differs (plugin=${plugin.length}, host=${host.length}); first byte-diff at index ${i}: plugin=${ctx(plugin)}, host=${ctx(host)}`;
+      }
+    }
+    return `length differs (plugin=${plugin.length}, host=${host.length}); prefix identical, ${plugin.length > host.length ? "plugin" : "host"} has extra trailing bytes`;
+  }
+  for (let i = 0; i < plugin.length; i++) {
+    if (plugin[i] !== host[i]) {
+      const ctx = (s: string) =>
+        JSON.stringify(s.slice(Math.max(0, i - 30), i + 30));
+      return `first byte-diff at index ${i}: plugin=${ctx(plugin)}, host=${ctx(host)}`;
+    }
+  }
+  return "strings differ but no per-character diff found (codepoint mismatch?)";
+}
+
+interface PromptCase {
+  caseId: string;
+  description: string;
+  pluginValue: string;
+  hostSnapshot: string;
+}
+
+function buildCases(): PromptCase[] {
+  return [
+    {
+      caseId: "PLAN_ARCHETYPE_PROMPT",
+      description:
+        "PLAN_ARCHETYPE_PROMPT (src/prompt/archetype-prompt.ts) must match in-host plan-archetype-prompt.ts byte-for-byte",
+      pluginValue: PLAN_ARCHETYPE_PROMPT,
+      hostSnapshot: snapshot("PLAN_ARCHETYPE_PROMPT.txt"),
+    },
+    {
+      caseId: "PLAN_MODE_REFERENCE_CARD",
+      description:
+        "PLAN_MODE_REFERENCE_CARD (src/prompt/reference-card.ts) must match in-host reference-card.ts byte-for-byte",
+      pluginValue: PLAN_MODE_REFERENCE_CARD,
+      hostSnapshot: snapshot("PLAN_MODE_REFERENCE_CARD.txt"),
+    },
+    {
+      caseId: "buildPlanModeActiveSystemContext",
+      description:
+        "buildPlanModeActiveSystemContext() must match in-host attempt.ts:692-732 inline-array output (with archetype + reference-card substituted) byte-for-byte",
+      pluginValue: buildPlanModeActiveSystemContext(),
+      hostSnapshot: snapshot("plan-mode-active-system-context.txt"),
+    },
+    {
+      caseId: "buildPlanModeAvailableSystemContext",
+      description:
+        "buildPlanModeAvailableSystemContext() must match in-host attempt.ts:735-748 inline-array output byte-for-byte",
+      pluginValue: buildPlanModeAvailableSystemContext(),
+      hostSnapshot: snapshot("plan-mode-available-system-context.txt"),
+    },
+  ];
+}
+
+export const promptsCheck: ParityCheck = {
+  name: "prompts",
+  run(): CheckReport {
+    const results: CheckCaseResult[] = buildCases().map((c) => {
+      const diff = diffBytes(c.pluginValue, c.hostSnapshot);
+      return {
+        caseId: c.caseId,
+        description: c.description,
+        ok: diff === "",
+        diff,
+      };
+    });
+    return { name: "prompts", cases: results };
+  },
+};

--- a/parity-harness/checks/resolve-plan-approval.ts
+++ b/parity-harness/checks/resolve-plan-approval.ts
@@ -1,0 +1,116 @@
+/**
+ * Layer-1 check: `resolvePlanApproval`.
+ *
+ * Drives the plugin's `src/plan-mode/approval.ts:resolvePlanApproval`
+ * AND the vendored in-host reference at
+ * `runners/resolve-plan-approval.reference.ts` across the case table
+ * at `inputs/resolvePlanApproval.json`. Diffs structural fields.
+ *
+ * # Determinism
+ *
+ * The plugin's `resolvePlanApproval` calls `Date.now()` directly; the
+ * reference accepts an injected `now`. To keep the diff deterministic
+ * we pin a FROZEN_NOW value for the reference, and call the plugin
+ * under `vi.useFakeTimers()`-style monkey patching of `Date.now`. The
+ * harness does the monkey-patch itself (no test-framework dep) so the
+ * CLI invocation and the vitest invocation both see the same value.
+ *
+ * host_ref: src/agents/plan-mode/approval.ts:36-145 (commit ea04ea52c7)
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { resolvePlanApproval } from "../../src/plan-mode/approval.js";
+import type { PlanModeSessionState } from "../../src/types.js";
+import { resolvePlanApprovalReference } from "../runners/resolve-plan-approval.reference.js";
+import type { CheckCaseResult, CheckReport, ParityCheck } from "./types.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+interface ResolvePlanApprovalCase {
+  id: string;
+  description: string;
+  state_before: PlanModeSessionState;
+  action: "approve" | "edit" | "reject" | "timeout";
+  feedback?: string;
+  expectedApprovalId?: string;
+}
+
+const FROZEN_NOW = 1_700_000_000_000;
+
+function loadCases(): ResolvePlanApprovalCase[] {
+  const path = join(__dirname, "..", "inputs", "resolvePlanApproval.json");
+  return JSON.parse(readFileSync(path, "utf8")) as ResolvePlanApprovalCase[];
+}
+
+function withFrozenNow<T>(fn: () => T): T {
+  const originalNow = Date.now;
+  Date.now = () => FROZEN_NOW;
+  try {
+    return fn();
+  } finally {
+    Date.now = originalNow;
+  }
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a == null || b == null) return false;
+  if (typeof a !== "object" || typeof b !== "object") return false;
+  if (Array.isArray(a) !== Array.isArray(b)) return false;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    return a.every((v, i) => deepEqual(v, b[i]));
+  }
+  const ak = Object.keys(a as object).sort();
+  const bk = Object.keys(b as object).sort();
+  if (ak.length !== bk.length) return false;
+  if (!ak.every((k, i) => k === bk[i])) return false;
+  return ak.every((k) =>
+    deepEqual(
+      (a as Record<string, unknown>)[k],
+      (b as Record<string, unknown>)[k],
+    ),
+  );
+}
+
+export const resolvePlanApprovalCheck: ParityCheck = {
+  name: "resolvePlanApproval",
+  run(): CheckReport {
+    const cases = loadCases();
+    const results: CheckCaseResult[] = cases.map((c) => {
+      const refOut = resolvePlanApprovalReference(
+        c.state_before,
+        c.action,
+        c.feedback,
+        c.expectedApprovalId,
+        FROZEN_NOW,
+      );
+      const plugOut = withFrozenNow(() =>
+        resolvePlanApproval(
+          c.state_before,
+          c.action,
+          c.feedback,
+          c.expectedApprovalId,
+        ),
+      );
+      const ok = deepEqual(refOut, plugOut);
+      const diff = ok
+        ? ""
+        : [
+            "outputs differ:",
+            `      reference=${JSON.stringify(refOut)}`,
+            `      plugin   =${JSON.stringify(plugOut)}`,
+          ].join("\n    ");
+      return {
+        caseId: c.id,
+        description: c.description,
+        ok,
+        diff,
+      };
+    });
+    return { name: "resolvePlanApproval", cases: results };
+  },
+};

--- a/parity-harness/checks/runtime-reject-and-plan-steps.ts
+++ b/parity-harness/checks/runtime-reject-and-plan-steps.ts
@@ -1,0 +1,109 @@
+/**
+ * Layer-1 check: bonus targets from the wave brief.
+ *
+ *   - `buildPlanRuntimeRejectInjection` — the runtime reject text
+ *     emitter ported in W1-D1. Pinning prevents future drift back to
+ *     the wrong (verbose, JSON-quoted) `buildPlanDecisionInjection`
+ *     form.
+ *
+ *   - `planStepsToInjectionLines` — the activeForm-vs-status logic
+ *     just fixed in W1-D2. Pinning prevents regression to the wrong
+ *     parenthetical label on resumed/re-approved plans.
+ *
+ * host_ref:
+ *   - sessions-patch.ts:1045-1050 (reject form)
+ *   - sessions-patch.ts:1001-1003 (planSteps → lines)
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildPlanRuntimeRejectInjection } from "../../src/runtime/injection-writer.js";
+import type { PlanStep } from "../../src/types.js";
+import { planStepsToInjectionLines } from "../../src/ui/session-actions.js";
+import {
+  buildPlanRuntimeRejectInjectionReference,
+  planStepsToInjectionLinesReference,
+} from "../runners/runtime-reject-and-plan-steps.reference.js";
+import type { CheckCaseResult, CheckReport, ParityCheck } from "./types.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+interface RuntimeRejectCase {
+  id: string;
+  description: string;
+  kind: "runtimeReject";
+  feedback: string | null;
+}
+
+interface PlanStepsCase {
+  id: string;
+  description: string;
+  kind: "planSteps";
+  steps: PlanStep[];
+}
+
+type Case = RuntimeRejectCase | PlanStepsCase;
+
+function loadCases(): Case[] {
+  const path = join(__dirname, "..", "inputs", "runtimeRejectAndPlanSteps.json");
+  return JSON.parse(readFileSync(path, "utf8")) as Case[];
+}
+
+function diffStrings(plug: string, ref: string): string {
+  if (plug === ref) return "";
+  return [
+    "outputs differ:",
+    `      plugin   =${JSON.stringify(plug)}`,
+    `      reference=${JSON.stringify(ref)}`,
+  ].join("\n    ");
+}
+
+function diffStringArrays(plug: string[], ref: string[]): string {
+  if (plug.length !== ref.length) {
+    return `length differs: plugin=${plug.length}, reference=${ref.length}`;
+  }
+  for (let i = 0; i < plug.length; i++) {
+    if (plug[i] !== ref[i]) {
+      return [
+        `arrays differ at index ${i}:`,
+        `      plugin   =${JSON.stringify(plug[i])}`,
+        `      reference=${JSON.stringify(ref[i])}`,
+      ].join("\n    ");
+    }
+  }
+  return "";
+}
+
+export const runtimeRejectAndPlanStepsCheck: ParityCheck = {
+  name: "runtimeRejectAndPlanSteps",
+  run(): CheckReport {
+    const cases = loadCases();
+    const results: CheckCaseResult[] = cases.map((c) => {
+      if (c.kind === "runtimeReject") {
+        const feedbackArg = c.feedback === null ? undefined : c.feedback;
+        const plug = buildPlanRuntimeRejectInjection(feedbackArg);
+        const ref = buildPlanRuntimeRejectInjectionReference(feedbackArg);
+        const diff = diffStrings(plug, ref);
+        return {
+          caseId: c.id,
+          description: c.description,
+          ok: diff === "",
+          diff,
+        };
+      }
+      // planSteps
+      const plug = planStepsToInjectionLines(c.steps);
+      const ref = planStepsToInjectionLinesReference(c.steps);
+      const diff = diffStringArrays(plug, ref);
+      return {
+        caseId: c.id,
+        description: c.description,
+        ok: diff === "",
+        diff,
+      };
+    });
+    return { name: "runtimeRejectAndPlanSteps", cases: results };
+  },
+};

--- a/parity-harness/checks/sanitize-and-approval-id.ts
+++ b/parity-harness/checks/sanitize-and-approval-id.ts
@@ -1,0 +1,150 @@
+/**
+ * Layer-1 check: `sanitizeFeedbackForInjection` + `newPlanApprovalId`
+ * shape.
+ *
+ * `sanitize` is exhaustively case-tested against the vendored in-host
+ * reference. `newPlanApprovalId` is a crypto-RNG-driven minter — we
+ * verify the SHAPE (canonical `plan-<v4-uuid>` regex) across N
+ * generated calls, NOT exact byte equality (the bytes are entropy by
+ * construction).
+ *
+ * host_ref: src/agents/plan-mode/types.ts:104-160 (commit ea04ea52c7)
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { newPlanApprovalId, isPlanApprovalId } from "../../src/helpers/approval-id.js";
+import { sanitizeFeedbackForInjection } from "../../src/helpers/sanitize.js";
+import {
+  PLAN_APPROVAL_ID_SHAPE_REF,
+  sanitizeFeedbackForInjectionReference,
+} from "../runners/sanitize-and-approval-id.reference.js";
+import type { CheckCaseResult, CheckReport, ParityCheck } from "./types.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+interface SanitizeCase {
+  id: string;
+  description: string;
+  raw: string;
+}
+
+function loadSanitizeCases(): SanitizeCase[] {
+  const path = join(__dirname, "..", "inputs", "sanitize.json");
+  return JSON.parse(readFileSync(path, "utf8")) as SanitizeCase[];
+}
+
+function diffStrings(a: string, b: string): string {
+  if (a === b) return "";
+  return [
+    "outputs differ:",
+    `      plugin   =${JSON.stringify(a)}`,
+    `      reference=${JSON.stringify(b)}`,
+  ].join("\n    ");
+}
+
+export const sanitizeAndApprovalIdCheck: ParityCheck = {
+  name: "sanitizeAndApprovalId",
+  run(): CheckReport {
+    const results: CheckCaseResult[] = [];
+
+    // sanitize cases — exhaustive over the input table.
+    const cases = loadSanitizeCases();
+    for (const c of cases) {
+      const plug = sanitizeFeedbackForInjection(c.raw);
+      const ref = sanitizeFeedbackForInjectionReference(c.raw);
+      const diff = diffStrings(plug, ref);
+      results.push({
+        caseId: `sanitize:${c.id}`,
+        description: c.description,
+        ok: diff === "",
+        diff,
+      });
+    }
+
+    // newPlanApprovalId — shape check across N mints. Each must
+    // (a) match the canonical regex byte-for-byte, (b) start with the
+    // `plan-` prefix, (c) round-trip through `isPlanApprovalId === true`,
+    // and (d) NOT repeat (sanity check on entropy — should never see
+    // a collision in 100 mints).
+    const N = 100;
+    const seen = new Set<string>();
+    const shapeFailures: string[] = [];
+    const isPlanApprovalIdFailures: string[] = [];
+    let collisions = 0;
+    for (let i = 0; i < N; i++) {
+      const id = newPlanApprovalId();
+      if (seen.has(id)) {
+        collisions++;
+      }
+      seen.add(id);
+      if (!PLAN_APPROVAL_ID_SHAPE_REF.test(id)) {
+        shapeFailures.push(id);
+      }
+      if (!isPlanApprovalId(id)) {
+        isPlanApprovalIdFailures.push(id);
+      }
+    }
+    results.push({
+      caseId: "approvalId:shape-regex-N-mints",
+      description: `Every newPlanApprovalId() result must match /^plan-<v4-uuid>$/ (${N} samples)`,
+      ok: shapeFailures.length === 0,
+      diff:
+        shapeFailures.length === 0
+          ? ""
+          : `${shapeFailures.length}/${N} failed the canonical-shape regex. Examples: ${JSON.stringify(shapeFailures.slice(0, 3))}`,
+    });
+    results.push({
+      caseId: "approvalId:isPlanApprovalId-round-trip-N-mints",
+      description: `Every newPlanApprovalId() result must pass isPlanApprovalId (${N} samples)`,
+      ok: isPlanApprovalIdFailures.length === 0,
+      diff:
+        isPlanApprovalIdFailures.length === 0
+          ? ""
+          : `${isPlanApprovalIdFailures.length}/${N} failed the isPlanApprovalId round-trip. Examples: ${JSON.stringify(isPlanApprovalIdFailures.slice(0, 3))}`,
+    });
+    results.push({
+      caseId: "approvalId:entropy-sanity-no-collisions",
+      description: `Across ${N} mints, no two approvalIds should collide (sanity check on crypto-RNG path)`,
+      ok: collisions === 0,
+      diff: collisions === 0 ? "" : `${collisions} collisions across ${N} mints — entropy source is broken`,
+    });
+
+    // isPlanApprovalId — negative cases (the regex is the contract;
+    // a divergence here would silently fail-open staleness checks).
+    // Negative cases — both reference regex AND plugin's isPlanApprovalId
+    // must reject these. The plugin's regex (intentionally) does NOT
+    // assert v4-version or variant nibbles; it just shape-checks the
+    // canonical 8-4-4-4-12 lowercase-hex form. So negative cases here
+    // are limited to actually-invalid shapes: wrong prefix, uppercase
+    // hex, truncated, non-string, etc.
+    const negativeCases: Array<{ id: string; desc: string; value: unknown }> = [
+      { id: "wrong-prefix", desc: "missing 'plan-' prefix", value: "00000000-0000-4000-8000-000000000001" },
+      { id: "uppercase-hex", desc: "uppercase hex (the regex is lowercase-only)", value: "plan-AAAAAAAA-AAAA-4AAA-9AAA-AAAAAAAAAAAA" },
+      { id: "wrong-length", desc: "truncated UUID", value: "plan-abc-def" },
+      { id: "extra-segments", desc: "extra hex segment", value: "plan-00000000-0000-4000-8000-000000000001-extra" },
+      { id: "non-string", desc: "non-string input", value: 12345 },
+      { id: "null", desc: "null input", value: null },
+      { id: "undefined", desc: "undefined input", value: undefined },
+      { id: "empty-string", desc: "empty string", value: "" },
+      { id: "trailing-whitespace", desc: "trailing whitespace breaks regex anchors", value: "plan-00000000-0000-4000-8000-000000000001 " },
+    ];
+    for (const nc of negativeCases) {
+      const matchesShape = typeof nc.value === "string" && PLAN_APPROVAL_ID_SHAPE_REF.test(nc.value);
+      const pluginAccepts = isPlanApprovalId(nc.value);
+      const ok = matchesShape === pluginAccepts && pluginAccepts === false;
+      results.push({
+        caseId: `approvalId:negative-${nc.id}`,
+        description: nc.desc,
+        ok,
+        diff: ok
+          ? ""
+          : `plugin isPlanApprovalId=${pluginAccepts}, reference regex test=${matchesShape}; both must be false for negative cases`,
+      });
+    }
+
+    return { name: "sanitizeAndApprovalId", cases: results };
+  },
+};

--- a/parity-harness/checks/types.ts
+++ b/parity-harness/checks/types.ts
@@ -1,0 +1,36 @@
+/**
+ * Common types for Layer-1 parity checks.
+ *
+ * A check pins ONE plugin surface against an in-host reference. Each
+ * check runs N cases (from a JSON input table OR from a captured byte
+ * fixture); each case produces an outcome the check classifies as
+ * pass or fail.
+ *
+ * The diff driver (`parity-harness/diff.ts`) iterates registered
+ * checks, aggregates results, prints a structured report, and exits
+ * non-zero on any failure. The vitest wrapper at
+ * `tests/parity/parity-harness.test.ts` enforces the same gate in CI.
+ */
+
+export interface CheckCaseResult {
+  /** Stable identifier for this case (cited in failure messages). */
+  caseId: string;
+  /** Human-readable description (shown when the case fails). */
+  description: string;
+  /** true iff plugin output matches the in-host reference. */
+  ok: boolean;
+  /** When ok=false, a multi-line diff summary. Empty when ok=true. */
+  diff: string;
+}
+
+export interface CheckReport {
+  /** Stable name of the check (e.g. "persistApprovalRequest", "prompts"). */
+  name: string;
+  /** Cases run; SUM(cases) = passing + failing. */
+  cases: CheckCaseResult[];
+}
+
+export interface ParityCheck {
+  name: string;
+  run(): Promise<CheckReport> | CheckReport;
+}

--- a/parity-harness/diff.ts
+++ b/parity-harness/diff.ts
@@ -1,139 +1,83 @@
 /**
- * Parity diff CLI. Runs both runners over `inputs/persistApprovalRequest.json`,
- * compares per-case outcomes, prints a report, exits non-zero on any
- * divergence.
+ * Parity diff CLI — Layer 1.
+ *
+ * Drives a registered list of checks (each pinning one plugin surface
+ * against an in-host reference), aggregates results, prints a
+ * structured report, and exits non-zero on any divergence.
  *
  * Usage:
  *   pnpm parity-harness
  *
- * The vitest integration test (`tests/parity/parity-harness.test.ts`)
- * runs the same diff and fails CI on divergence; this CLI is for
+ * The vitest wrapper (`tests/parity/parity-harness.test.ts`) runs the
+ * same `runParityCheck()` and fails CI on divergence. The CLI is for
  * humans debugging locally.
+ *
+ * # Adding a check
+ *
+ * 1. Build `parity-harness/checks/<name>.ts` exporting a `ParityCheck`.
+ * 2. Add it to `ALL_CHECKS` below.
+ * 3. Re-run `pnpm parity-harness`. The new check's cases must pass.
+ *
+ * # When a check goes RED
+ *
+ * Two paths:
+ *   - Drift in `src/` → fix `src/` to match the in-host reference.
+ *   - Drift in the in-host source itself → re-capture the vendored
+ *     reference (or snapshot file) from `git -C ... show ea04ea52c7:...`
+ *     and commit the new bytes alongside the plugin's matching update.
+ *
+ * NEVER edit a vendored reference / snapshot to match a buggy plugin —
+ * that defeats the parity check.
  */
 
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
-import { runReferenceCases } from "./runners/host-reference.js";
-import { runPluginCases } from "./runners/plugin-under-test.js";
-import type { ParityCase, ParityOutcome } from "./runners/shared.js";
+import { acceptEditsGateCheck } from "./checks/accept-edits-gate.js";
+import { escalatingRetryCheck } from "./checks/escalating-retry.js";
+import { mutationGateCheck } from "./checks/mutation-gate.js";
+import { persistApprovalRequestCheck } from "./checks/persist-approval-request.js";
+import { promptsCheck } from "./checks/prompts.js";
+import { resolvePlanApprovalCheck } from "./checks/resolve-plan-approval.js";
+import { runtimeRejectAndPlanStepsCheck } from "./checks/runtime-reject-and-plan-steps.js";
+import { sanitizeAndApprovalIdCheck } from "./checks/sanitize-and-approval-id.js";
+import type { CheckReport, ParityCheck } from "./checks/types.js";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-export function loadCases(): ParityCase[] {
-  const path = join(__dirname, "inputs", "persistApprovalRequest.json");
-  return JSON.parse(readFileSync(path, "utf8")) as ParityCase[];
-}
+const ALL_CHECKS: ParityCheck[] = [
+  persistApprovalRequestCheck,
+  resolvePlanApprovalCheck,
+  acceptEditsGateCheck,
+  escalatingRetryCheck,
+  sanitizeAndApprovalIdCheck,
+  promptsCheck,
+  mutationGateCheck,
+  // Bonus targets (W1-D1 + W1-D2):
+  runtimeRejectAndPlanStepsCheck,
+];
 
 export interface ParityReport {
   totalCases: number;
   passingCases: number;
   failingCases: number;
-  failures: Array<{
-    caseId: string;
-    description: string;
-    reference: ParityOutcome;
-    plugin: ParityOutcome;
-    diffSummary: string;
-  }>;
+  checkReports: CheckReport[];
 }
 
 export async function runParityCheck(): Promise<ParityReport> {
-  const cases = loadCases();
-  const referenceOutcomes = runReferenceCases(cases);
-  const pluginOutcomes = await runPluginCases(cases);
-
-  const failures: ParityReport["failures"] = [];
-  for (let i = 0; i < cases.length; i++) {
-    const ref = referenceOutcomes[i]!;
-    const plug = pluginOutcomes[i]!;
-    const diff = computeDiff(ref, plug);
-    if (diff) {
-      failures.push({
-        caseId: cases[i]!.id,
-        description: cases[i]!.description,
-        reference: ref,
-        plugin: plug,
-        diffSummary: diff,
-      });
+  const checkReports = await Promise.all(
+    ALL_CHECKS.map(async (c) => c.run()),
+  );
+  let totalCases = 0;
+  let passingCases = 0;
+  let failingCases = 0;
+  for (const r of checkReports) {
+    for (const c of r.cases) {
+      totalCases++;
+      if (c.ok) passingCases++;
+      else failingCases++;
     }
   }
-
-  return {
-    totalCases: cases.length,
-    passingCases: cases.length - failures.length,
-    failingCases: failures.length,
-    failures,
-  };
+  return { totalCases, passingCases, failingCases, checkReports };
 }
 
-/**
- * Compare two parity outcomes. Returns null when identical, or a
- * human-readable diff summary string.
- *
- * NOT a full structural diff — we look at the specific fields that
- * matter for parity:
- *   - result.kind
- *   - result.approvalId
- *   - result.reason (for skipped)
- *   - stateAfter (deep equality)
- *   - auditEmitted
- */
-function computeDiff(
-  ref: ParityOutcome,
-  plug: ParityOutcome,
-): string | null {
-  const issues: string[] = [];
-  if (ref.result.kind !== plug.result.kind) {
-    issues.push(`kind: reference=${ref.result.kind}, plugin=${plug.result.kind}`);
-  }
-  if (ref.result.approvalId !== plug.result.approvalId) {
-    issues.push(
-      `approvalId: reference=${ref.result.approvalId}, plugin=${plug.result.approvalId}`,
-    );
-  }
-  if (
-    ref.result.kind === "skipped" &&
-    plug.result.kind === "skipped" &&
-    ref.result.reason !== plug.result.reason
-  ) {
-    issues.push(
-      `skipped reason: reference=${ref.result.reason}, plugin=${plug.result.reason}`,
-    );
-  }
-  if (ref.auditEmitted !== plug.auditEmitted) {
-    issues.push(
-      `auditEmitted: reference=${ref.auditEmitted}, plugin=${plug.auditEmitted}`,
-    );
-  }
-  if (!deepEqual(ref.stateAfter, plug.stateAfter)) {
-    issues.push(
-      `stateAfter differs:\n      reference=${JSON.stringify(ref.stateAfter)}\n      plugin   =${JSON.stringify(plug.stateAfter)}`,
-    );
-  }
-  return issues.length > 0 ? issues.join("\n    ") : null;
-}
-
-function deepEqual(a: unknown, b: unknown): boolean {
-  if (a === b) return true;
-  if (a == null || b == null) return false;
-  if (typeof a !== "object" || typeof b !== "object") return false;
-  if (Array.isArray(a) !== Array.isArray(b)) return false;
-  if (Array.isArray(a) && Array.isArray(b)) {
-    if (a.length !== b.length) return false;
-    return a.every((v, i) => deepEqual(v, b[i]));
-  }
-  const ak = Object.keys(a as object).sort();
-  const bk = Object.keys(b as object).sort();
-  if (ak.length !== bk.length) return false;
-  if (!ak.every((k, i) => k === bk[i])) return false;
-  return ak.every((k) =>
-    deepEqual(
-      (a as Record<string, unknown>)[k],
-      (b as Record<string, unknown>)[k],
-    ),
-  );
+function summarizeFailure(checkName: string, caseId: string, description: string, diff: string): string {
+  return `  ✗ [${checkName}] ${caseId}: ${description}\n    ${diff}`;
 }
 
 // ────────────────────────────────────────────────────────────────────
@@ -146,16 +90,26 @@ if (isCliRun) {
     .then((report) => {
       if (report.failingCases === 0) {
         console.log(
-          `[parity-harness] ✓ ${report.passingCases}/${report.totalCases} cases parity-clean`,
+          `[parity-harness] ✓ ${report.passingCases}/${report.totalCases} cases parity-clean across ${report.checkReports.length} checks`,
         );
+        for (const r of report.checkReports) {
+          console.log(`  ✓ ${r.name}: ${r.cases.length} cases`);
+        }
         process.exit(0);
       }
       console.log(
         `[parity-harness] ✗ ${report.failingCases}/${report.totalCases} cases diverged:`,
       );
-      for (const f of report.failures) {
-        console.log(`  - ${f.caseId}: ${f.description}`);
-        console.log(`    ${f.diffSummary}`);
+      for (const r of report.checkReports) {
+        const failing = r.cases.filter((c) => !c.ok);
+        if (failing.length === 0) {
+          console.log(`  ✓ ${r.name}: ${r.cases.length}/${r.cases.length}`);
+          continue;
+        }
+        console.log(`  ✗ ${r.name}: ${failing.length}/${r.cases.length} failing`);
+        for (const f of failing) {
+          console.log(summarizeFailure(r.name, f.caseId, f.description, f.diff));
+        }
       }
       process.exit(1);
     })

--- a/parity-harness/host-snapshots/PLAN_ARCHETYPE_PROMPT.txt
+++ b/parity-harness/host-snapshots/PLAN_ARCHETYPE_PROMPT.txt
@@ -1,0 +1,120 @@
+## Plan Mode — Decision-Complete Plan Standard
+
+You are in plan mode. Your job is to produce the best possible
+implementation plan for the current task so that execution succeeds on
+the first pass with minimal errors, minimal rework, and minimal hidden
+decisions.
+
+### Primary objective
+Create a decision-complete plan that the executing agent (which may be
+you in a later turn, or a subagent) can follow without inventing
+product, technical, interface, or testing decisions later.
+
+### Core rules
+- **Do not implement the task in plan mode.** Mutating tools (write,
+  edit, exec, bash, apply_patch) are blocked until the user approves.
+- **Explore first.** Ground the plan in the actual repo, files,
+  configs, types, and environment before asking questions. Use read,
+  grep, glob, web_search, web_fetch freely.
+- **Do not ask the user for facts you can discover locally.** Before
+  reaching for ask_user_question, exhaust the read-only investigation
+  surface.
+- **Distinguish discoverable facts from user preferences / tradeoffs.**
+  Discoverable → investigate. Preferences/tradeoffs → ask only when the
+  answer would materially change scope, behavior, architecture, risk,
+  or acceptance criteria.
+- **When risk is low, choose a reasonable default and record it as an
+  explicit assumption.** Don't ask permission for trivial choices.
+
+### Plan archetype — required fields on `exit_plan_mode`
+The proposal must lock down ALL of these:
+
+- **`title`** (REQUIRED, ≤80 chars): concise plan name — used as the
+  approval-card header AND as the persisted markdown filename slug.
+- **`summary`** (REQUIRED, ≤200 chars): one-sentence what-this-does.
+- **`analysis`** (REQUIRED for non-trivial multi-file changes): markdown
+  body covering current state, chosen approach, and rationale. This
+  gives the user enough context to evaluate the proposal without
+  re-reading the transcript. Multi-paragraph; can include code
+  references like `src/agents/plan-mode/types.ts:42` and PR numbers.
+- **`plan`** (REQUIRED): ordered step list. Each step is short (one
+  short sentence). Mark exactly one as `in_progress` if you've already
+  started part of the work; otherwise all `pending`. For steps with
+  high closure risk (e.g., VM provisioning), include
+  `acceptanceCriteria: [...]` so the runtime closure-gate prevents
+  premature `status: "completed"`.
+- **`assumptions`** (REQUIRED for any plan with non-obvious choices):
+  explicit list of assumptions made. If any assumption is wrong, the
+  plan needs revision — surface them so the user can correct.
+- **`risks`** (REQUIRED for plans touching live systems, security, data
+  flows, or external integrations): `[{risk, mitigation}]` register.
+- **`verification`** (REQUIRED for any plan that ships code or
+  configures live systems): concrete commands/checks that will confirm
+  success. Examples: `pnpm test src/agents/plan-mode/...` passes;
+  `ssh user@host echo ok` returns; sidebar shows "Plan complete ✓".
+- **`references`** (OPTIONAL): file:line, URLs, PR numbers, doc paths
+  the plan builds on. Renders as a "References" section in the
+  persisted markdown.
+
+### Quality bar
+- **Decision-complete**: another capable agent could execute this plan
+  without making hidden product/tech/interface decisions.
+- **Concrete**: name real files, modules, symbols, APIs, schemas,
+  configs. Don't say "the auth module" if you mean
+  `src/auth/index.ts`.
+- **Minimal**: prefer the smallest high-confidence change that solves
+  the problem. Preserve existing architecture and patterns unless the
+  task explicitly requires larger change. Avoid speculative
+  abstractions, broad refactors, and "while we're here" work.
+- **Verifiable**: every materially changed behavior is covered by a
+  concrete verification step.
+- **Length**: there is no upper limit. Multi-page plans are encouraged
+  for non-trivial work — the average Opus-quality plan is ~10 pages
+  with full analysis, references, and PR linkage. Don't pad, but don't
+  truncate to fit a perceived UI box either.
+
+### Anti-patterns — do NOT submit a plan that is:
+- A bare file list with no analysis or rationale.
+- Three vague paragraphs followed by "and we add tests as needed".
+- A title that's actually the agent's chat narration ("I checked all
+  five VMs..." is NOT a title; it's analysis text).
+- A plan that defers key behavior decisions to "implementation will
+  decide".
+- A plan that invents repo facts (paths, exports, types) without
+  having read them.
+- A plan that mixes must-have changes with optional nice-to-haves.
+
+### When to ask questions
+Use `ask_user_question` for:
+- Genuine product / scope tradeoffs where the answer changes the plan
+  shape (e.g., "ship as 1 PR or 3 PRs?", "preserve current behavior X
+  or replace it?").
+- Cases where local investigation is impossible (external state, user
+  intent on aesthetics, organizational priority).
+
+Do NOT use `ask_user_question` for:
+- Things you could grep / read / web_search yourself.
+- Trivial defaults (color schemes, naming conventions covered by
+  AGENTS.md).
+- Confirmation requests ("should I proceed?") — that's what
+  `exit_plan_mode` does.
+
+Questions DO NOT exit plan mode. The agent stays in plan mode while
+waiting for the answer; the answer arrives as a user message in the
+next turn formatted as `[QUESTION_ANSWER]: <answer text>` (same
+shape as `[PLAN_DECISION]: ...`).
+
+### Self-check before `exit_plan_mode`
+- Could another capable agent execute this without making hidden
+  decisions?
+- Are all materially changed behaviors covered by a concrete
+  verification step?
+- Are assumptions explicit?
+- Is the approach minimal and aligned with existing patterns?
+- Are open questions eliminated, or asked via `ask_user_question`?
+- Would this plan reduce execution mistakes rather than merely
+  describe the task?
+
+If the plan leaves meaningful implementation decisions unspecified, it
+is not finished. Investigate more or ask a clarifying question, then
+re-evaluate.

--- a/parity-harness/host-snapshots/PLAN_MODE_REFERENCE_CARD.txt
+++ b/parity-harness/host-snapshots/PLAN_MODE_REFERENCE_CARD.txt
@@ -1,0 +1,100 @@
+═══ PLAN MODE — REFERENCE CARD ═══
+
+## State diagram
+
+```
+┌──────────────────┐
+│   NORMAL MODE    │   mutations (write/edit/exec/bash) ALLOWED
+│  (mutations OK)  │
+└────────┬─────────┘
+         │ enter_plan_mode  (or user toggles via /plan on)
+         │ ──► [PLAN_MODE_INTRO]: (one-shot, first-time only)
+         ▼
+┌──────────────────────────────────────────────┐
+│   PLAN MODE — INVESTIGATION                  │
+│   (mutations BLOCKED; read-only tools OK)    │
+│                                              │
+│  ↻ update_plan        — track progress       │
+│  ↻ ask_user_question  — clarify; next turn   │
+│  ↻ sessions_spawn     — research subagents   │
+│  ↻ read/grep/glob/web_search/lcm_*           │
+│                                              │
+│  Possible nudges injected by runtime:        │
+│  - [PLAN_NUDGE]:      cron wake-up if idle   │
+│  - [PLAN_ACK_ONLY]:   if no tool call        │
+│  - [PLANNING_RETRY]:  if narrating only      │
+└─────────────────────┬────────────────────────┘
+                      │ exit_plan_mode(title, plan, ...)
+                      │ ──► STOP — no more chat this turn!
+                      │ ──► tool-side gate blocks if
+                      │     openSubagentRunIds.size > 0
+                      ▼
+┌──────────────────────────────────────────────┐
+│   PLAN MODE — PENDING APPROVAL               │
+│   (approval card visible to user)            │
+│                                              │
+│  - approval-side gate blocks approve/edit if │
+│    subagents spawn DURING approval window    │
+│  - [PLAN_NUDGE] suppressed when pending      │
+└──┬─────────────┬─────────────┬───────────────┘
+   │ approve     │ edit        │ reject + feedback
+   │ /plan       │ /plan       │ /plan revise <text>
+   │ accept      │ accept edits│
+   ▼             ▼             ▼
+[PLAN_DECISION]: approved      [PLAN_DECISION]: rejected
+[PLAN_DECISION]: edited        feedback: "<text>"
+   │             │                  │
+   ▼             ▼                  ▼ ── back to INVESTIGATION
+┌──────────────────┐
+│   NORMAL MODE    │   mutations UNLOCKED, execute the plan
+│  (mutations OK)  │   update_plan to mark steps completed
+└────────┬─────────┘   all-terminal → auto-close + [PLAN_COMPLETE]:
+         │
+         ▼ (cycle done; user may /plan on for next cycle)
+```
+
+## Tool contract (one-line each)
+
+- `enter_plan_mode()` — once per cycle. Arms mutation gate. No-op if already in plan mode.
+- `update_plan(plan=[...])` — TRACKING ONLY. Does NOT submit. Mutations stay blocked.
+- `exit_plan_mode(title, plan, ...)` — once per cycle when ready to propose. Submits for user approval. STOP after this tool call (no chat text in same turn).
+- `ask_user_question(question, options)` — non-blocking clarification. Stays in plan mode.
+- `sessions_spawn(...)` — research subagents. Tool-side gate WILL block exit_plan_mode until they return.
+
+## [PLAN_*]: tag taxonomy (synthetic messages from runtime → agent)
+
+- `[PLAN_MODE_INTRO]:` — one-shot at first plan-mode entry per session (lifecycle + reminders)
+- `[PLAN_DECISION]: approved | edited | rejected | timed_out` — user resolved the approval card
+- `[QUESTION_ANSWER]: <text>` — user answered an ask_user_question
+- `[PLAN_COMPLETE]: <N> steps completed` — auto-fired when all plan steps reach terminal status post-approval
+- `[PLAN_NUDGE]:` — cron wake-up nudge (suppressed when approval pending)
+- `[PLAN_ACK_ONLY]:` — runtime detected the prior turn ended with chat text and no tool call (escalating retry)
+- `[PLAN_YIELD]:` — runtime detected the agent yielded immediately after approval (escalating retry)
+- `[PLANNING_RETRY]:` — runtime detected a planning-narration-only turn outside plan mode (escalating retry)
+
+## /plan slash-command surface (user types these in chat)
+
+- `/plan on` / `/plan off` — toggle plan mode
+- `/plan status` — show current state
+- `/plan view` — open the active plan in the side panel
+- `/plan accept [edits]` — approve the pending plan
+- `/plan revise <feedback>` — reject with revision feedback
+- `/plan answer <text>` — answer a pending ask_user_question
+- `/plan auto on|off` — toggle auto-approve mode
+
+## Common pitfalls
+
+1. **Don't post chat after `exit_plan_mode` in the same turn.** Trailing chat breaks the approval card lifecycle.
+2. **Wait for spawned subagents BEFORE `exit_plan_mode`.** The tool-side gate will reject if any are still running.
+3. **`update_plan` does NOT submit.** It only tracks progress. Use `exit_plan_mode` to propose.
+4. **Don't re-enter plan mode after approval.** Just continue executing. Re-enter only for a NEW planning cycle.
+5. **Provide a meaningful `title`.** It becomes the persisted markdown filename (`plan-YYYY-MM-DD-<slug>.md`) AND the side-panel header.
+
+## Debugging tips
+
+- Turn on plan-mode debug logging: `openclaw config set agents.defaults.planMode.debug true` then restart gateway.
+- Tail the structured event log: `tail -F ~/.openclaw/logs/gateway.err.log | grep '\[plan-mode/'`
+- Always-on gate-decision log: `tail -F ~/.openclaw/logs/gateway.err.log | grep 'plan-approval-gate'`
+- Call `plan_mode_status` to inspect the active cycle, pending interaction, and subagent gate state.
+
+═════════════════════════════════════

--- a/parity-harness/host-snapshots/README.md
+++ b/parity-harness/host-snapshots/README.md
@@ -1,0 +1,38 @@
+# Host snapshots
+
+Byte fixtures captured from the in-host source-of-truth at
+`/Volumes/LEXAR/repos/openclaw-pr70071-rebase`, commit `ea04ea52c7`,
+branch `rebase/pr70071-onto-main-2026-04-25`.
+
+These files are committed to the repo. The Layer-1 parity harness
+reads them and diffs against the plugin's runtime output. Any byte
+divergence FAILS the build.
+
+## Files
+
+| File | In-host source |
+|------|----------------|
+| `PLAN_ARCHETYPE_PROMPT.txt` | `src/agents/plan-mode/plan-archetype-prompt.ts` — the full template literal value of `PLAN_ARCHETYPE_PROMPT` |
+| `PLAN_MODE_REFERENCE_CARD.txt` | `src/agents/plan-mode/reference-card.ts` — the joined `[...].join("\n")` value of `PLAN_MODE_REFERENCE_CARD` |
+| `plan-mode-active-system-context.txt` | `src/agents/pi-embedded-runner/run/attempt.ts:692-732` — the inline array joined with `\n`, with `PLAN_ARCHETYPE_PROMPT` and `PLAN_MODE_REFERENCE_CARD` substituted from the same in-host sources |
+| `plan-mode-available-system-context.txt` | `src/agents/pi-embedded-runner/run/attempt.ts:735-748` — the inline array joined with `\n` |
+
+## Closes W1-D3
+
+Wave-1 finding W1-D3 flagged "no byte-fixture test pins the prompt
+artifacts against in-host bytes; docstrings reference a
+`tests/parity/archetype-prompt-parity.test.ts` that does not exist."
+This directory + the corresponding `parity-harness/checks/prompts.ts`
+check closes that gap.
+
+## Re-capture procedure
+
+When the in-host source-of-truth changes (Wave-0 Decision A pins us
+at `ea04ea52c7` so this should be rare), regenerate via:
+
+```bash
+pnpm tsx parity-harness/host-snapshots/capture.ts
+```
+
+This script reads the in-host files via `git show` and writes the
+four `.txt` snapshots. Verify the diff before committing.

--- a/parity-harness/host-snapshots/capture.ts
+++ b/parity-harness/host-snapshots/capture.ts
@@ -1,0 +1,358 @@
+/**
+ * Snapshot-capture script.
+ *
+ * Pulls byte fixtures from the in-host source-of-truth at
+ * `/Volumes/LEXAR/repos/openclaw-pr70071-rebase` commit `ea04ea52c7`
+ * via `git show`, and writes them as plain-text snapshots next to this
+ * file. Layer-1 parity check `parity-harness/checks/prompts.ts` reads
+ * the snapshots and diffs against the plugin's runtime output.
+ *
+ * Re-run via:
+ *   pnpm tsx parity-harness/host-snapshots/capture.ts
+ *
+ * The output of this script is committed to git. Do NOT skip the
+ * commit — the harness check reads from disk, not from a fresh capture.
+ *
+ * # Why git show + manual extraction, not eval/transpile
+ *
+ * Each artifact is either a string literal we can extract verbatim
+ * (PLAN_ARCHETYPE_PROMPT — template literal) or an array of string
+ * literals we can `JSON.parse` line-by-line and join (PLAN_MODE_REFERENCE_CARD,
+ * the attempt.ts inline arrays). No TS evaluation needed — that would
+ * require pulling in transitive in-host imports and defeating the
+ * purpose of an isolated parity snapshot.
+ *
+ * # Source-of-truth pin
+ *
+ * commit = ea04ea52c7
+ * branch = rebase/pr70071-onto-main-2026-04-25
+ * repo   = /Volumes/LEXAR/repos/openclaw-pr70071-rebase
+ *
+ * Wave-0 Decision A pins us here. Don't rebase.
+ */
+
+import { execSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const HOST_REPO = "/Volumes/LEXAR/repos/openclaw-pr70071-rebase";
+const HOST_COMMIT = "ea04ea52c7";
+
+function showFile(path: string): string {
+  return execSync(`git -C ${HOST_REPO} show ${HOST_COMMIT}:${path}`, {
+    encoding: "utf8",
+    maxBuffer: 50 * 1024 * 1024,
+  });
+}
+
+function writeSnapshot(name: string, bytes: string): void {
+  const out = join(__dirname, name);
+  writeFileSync(out, bytes);
+  console.log(`wrote ${out} (${bytes.length} bytes)`);
+}
+
+// ---------------------------------------------------------------------------
+// 1. PLAN_ARCHETYPE_PROMPT — template literal in plan-archetype-prompt.ts
+// ---------------------------------------------------------------------------
+
+function captureArchetypePrompt(): string {
+  const src = showFile("src/agents/plan-mode/plan-archetype-prompt.ts");
+  const marker = "export const PLAN_ARCHETYPE_PROMPT = `";
+  const startIdx = src.indexOf(marker);
+  if (startIdx < 0) {
+    throw new Error("could not find PLAN_ARCHETYPE_PROMPT template-literal opener");
+  }
+  const bodyStart = startIdx + marker.length;
+  // Walk forward to find the closing unescaped backtick. The template
+  // literal does NOT use `${...}` interpolation (we verify that — if it
+  // did we'd need to evaluate); only the inline backtick escapes
+  // (`\``), which JS unescapes to literal backticks at runtime.
+  let closeIdx = -1;
+  for (let i = bodyStart; i < src.length; i++) {
+    const c = src[i];
+    if (c === "\\") {
+      i++; // skip next char (any escape sequence)
+      continue;
+    }
+    if (c === "`") {
+      closeIdx = i;
+      break;
+    }
+    if (c === "$" && src[i + 1] === "{") {
+      throw new Error(
+        "PLAN_ARCHETYPE_PROMPT template literal contains ${...} interpolation — capture would need full TS evaluation. Refactor in-host source or extend the script.",
+      );
+    }
+  }
+  if (closeIdx < 0) {
+    throw new Error("could not find PLAN_ARCHETYPE_PROMPT closing backtick");
+  }
+  return decodeTemplateLiteralBody(src.slice(bodyStart, closeIdx));
+}
+
+/**
+ * Decode the body of a JS template literal — interpret the standard
+ * backslash escapes (`\\`, `` \` ``, `\n`, `\t`, `\r`, `\0`, `\xNN`,
+ * `\uNNNN`, `\u{HHHHH}`) and pass other characters through. This is
+ * the subset the in-host template literals actually use. Anything we
+ * don't recognize throws so the script fails loudly on a new escape.
+ */
+function decodeTemplateLiteralBody(body: string): string {
+  let out = "";
+  for (let i = 0; i < body.length; i++) {
+    const c = body[i];
+    if (c !== "\\") {
+      out += c;
+      continue;
+    }
+    const next = body[i + 1];
+    if (next === undefined) {
+      throw new Error("trailing backslash in template literal body");
+    }
+    switch (next) {
+      case "\\":
+        out += "\\";
+        i++;
+        break;
+      case "`":
+        out += "`";
+        i++;
+        break;
+      case "n":
+        out += "\n";
+        i++;
+        break;
+      case "t":
+        out += "\t";
+        i++;
+        break;
+      case "r":
+        out += "\r";
+        i++;
+        break;
+      case "0":
+        out += "\0";
+        i++;
+        break;
+      case "$":
+        out += "$";
+        i++;
+        break;
+      case '"':
+        out += '"';
+        i++;
+        break;
+      case "'":
+        out += "'";
+        i++;
+        break;
+      case "x": {
+        const hex = body.slice(i + 2, i + 4);
+        if (!/^[0-9a-fA-F]{2}$/.test(hex)) {
+          throw new Error(`malformed \\x escape at ${i}`);
+        }
+        out += String.fromCharCode(parseInt(hex, 16));
+        i += 3;
+        break;
+      }
+      case "u": {
+        if (body[i + 2] === "{") {
+          const closeBrace = body.indexOf("}", i + 3);
+          if (closeBrace < 0) {
+            throw new Error(`unclosed \\u{...} escape at ${i}`);
+          }
+          const hex = body.slice(i + 3, closeBrace);
+          out += String.fromCodePoint(parseInt(hex, 16));
+          i = closeBrace;
+        } else {
+          const hex = body.slice(i + 2, i + 6);
+          if (!/^[0-9a-fA-F]{4}$/.test(hex)) {
+            throw new Error(`malformed \\u escape at ${i}`);
+          }
+          out += String.fromCharCode(parseInt(hex, 16));
+          i += 5;
+        }
+        break;
+      }
+      default:
+        throw new Error(
+          `unknown escape sequence \\${next} at position ${i}; extend decoder if this is legitimate`,
+        );
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// 2. PLAN_MODE_REFERENCE_CARD — `[lines...].join("\n")` in reference-card.ts
+// ---------------------------------------------------------------------------
+
+function captureReferenceCard(): string {
+  const src = showFile("src/agents/plan-mode/reference-card.ts");
+  return extractJoinNewlineArray(src, "PLAN_MODE_REFERENCE_CARD");
+}
+
+// ---------------------------------------------------------------------------
+// 3. + 4. plan-mode-{active,available}-system-context — inline arrays at
+//          attempt.ts:692-732 (active) and 735-748 (available).
+//
+// The active block includes `PLAN_ARCHETYPE_PROMPT` + `PLAN_MODE_REFERENCE_CARD`
+// as identifiers — we substitute the captured values for those slots.
+// ---------------------------------------------------------------------------
+
+function captureActiveContext(
+  archetypePrompt: string,
+  referenceCard: string,
+): string {
+  const src = showFile("src/agents/pi-embedded-runner/run/attempt.ts");
+  // The active block is the only `planMode === "plan"` arm inside the
+  // `planModeAppendPrompt` ternary. Find the literal "═══ PLAN MODE ACTIVE ═══"
+  // first; that's the unique anchor for the start of the active array.
+  const activeAnchor = '"═══ PLAN MODE ACTIVE ═══"';
+  const anchorIdx = src.indexOf(activeAnchor);
+  if (anchorIdx < 0) {
+    throw new Error("could not find PLAN MODE ACTIVE anchor in attempt.ts");
+  }
+  // The opening "[" of the array literal is the previous "[" before anchorIdx.
+  const arrayStart = src.lastIndexOf("[", anchorIdx);
+  // The closing "]" + ".join(\"\\n\")" is the next ".join(\"\\n\")" after.
+  const joinMarker = '.join("\\n")';
+  const joinIdx = src.indexOf(joinMarker, anchorIdx);
+  if (arrayStart < 0 || joinIdx < 0) {
+    throw new Error("could not bound the active-context array");
+  }
+  const arrayEnd = src.lastIndexOf("]", joinIdx);
+  const arrayBody = src.slice(arrayStart + 1, arrayEnd);
+  return joinArrayBodyWithSubstitutions(arrayBody, {
+    PLAN_ARCHETYPE_PROMPT: archetypePrompt,
+    PLAN_MODE_REFERENCE_CARD: referenceCard,
+  });
+}
+
+function captureAvailableContext(): string {
+  const src = showFile("src/agents/pi-embedded-runner/run/attempt.ts");
+  const availableAnchor = '"═══ PLAN MODE AVAILABLE ═══"';
+  const anchorIdx = src.indexOf(availableAnchor);
+  if (anchorIdx < 0) {
+    throw new Error("could not find PLAN MODE AVAILABLE anchor in attempt.ts");
+  }
+  const arrayStart = src.lastIndexOf("[", anchorIdx);
+  const joinMarker = '.join("\\n")';
+  const joinIdx = src.indexOf(joinMarker, anchorIdx);
+  if (arrayStart < 0 || joinIdx < 0) {
+    throw new Error("could not bound the available-context array");
+  }
+  const arrayEnd = src.lastIndexOf("]", joinIdx);
+  const arrayBody = src.slice(arrayStart + 1, arrayEnd);
+  return joinArrayBodyWithSubstitutions(arrayBody, {});
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract a `const NAME = [\n  "line1",\n  "line2",\n  ...\n].join("\n")`
+ * pattern's joined string value. Walks the array body line-by-line and
+ * pulls each string literal via JSON.parse (handles \n, \", \uXXXX,
+ * tab, etc. correctly).
+ *
+ * Skips bare-line comments (// ...) but preserves end-of-line comments
+ * after a closed string. Throws if a non-comment, non-string-literal,
+ * non-empty line appears (the in-host arrays do not use any other shape;
+ * if they grow to we'd need to extend this).
+ */
+function extractJoinNewlineArray(src: string, name: string): string {
+  const opener = new RegExp(`export const ${name}\\s*=\\s*\\[`);
+  const m = opener.exec(src);
+  if (!m) {
+    throw new Error(`could not find array opener for ${name}`);
+  }
+  const arrayStart = m.index + m[0].length - 1; // points at the "[" char
+  const joinMarker = '.join("\\n")';
+  const joinIdx = src.indexOf(joinMarker, arrayStart);
+  if (joinIdx < 0) {
+    throw new Error(`could not find .join("\\n") for ${name}`);
+  }
+  const arrayEnd = src.lastIndexOf("]", joinIdx);
+  return joinArrayBodyWithSubstitutions(src.slice(arrayStart + 1, arrayEnd), {});
+}
+
+function joinArrayBodyWithSubstitutions(
+  body: string,
+  substitutions: Record<string, string>,
+): string {
+  const lines: string[] = [];
+  const rawLines = body.split("\n");
+  for (const raw of rawLines) {
+    const line = raw.trim();
+    if (line === "" || line.startsWith("//")) {
+      continue;
+    }
+    // Strip a trailing comma (array element separator).
+    let stripped = line.endsWith(",") ? line.slice(0, -1).trim() : line;
+    // Strip a trailing line comment (after the literal closer).
+    // Conservative: only strip "//..." that appears AFTER a closing
+    // quote or closing identifier — we don't need to be clever, the
+    // in-host arrays don't use end-of-line // comments inside element
+    // expressions.
+    if (stripped.startsWith('"') || stripped.startsWith("'")) {
+      // String literal — JSON.parse it. JS supports both single and
+      // double quoted; JSON only allows double. For single-quoted JS
+      // literals (the in-host reference-card.ts has one line like
+      // `'[PLAN_DECISION]: edited ... feedback: "<text>"'` that uses
+      // single quotes because the body contains a double quote), we
+      // rewrap: strip the single quotes, escape any literal `"` to `\"`,
+      // and unescape any `\'` to `'`. This is exact for the subset of JS
+      // string syntax the in-host arrays actually use (no fancy escapes
+      // beyond \n \\ \" inside double-quoted, \' inside single-quoted).
+      let toParse = stripped;
+      if (stripped.startsWith("'")) {
+        if (!stripped.endsWith("'")) {
+          throw new Error(`malformed single-quoted literal: ${stripped}`);
+        }
+        const inner = stripped.slice(1, -1);
+        // Order matters: unescape \' first (back to '), THEN escape any
+        // raw " to \" — the unescape and escape never collide because
+        // single-quoted JS can't contain a bare \" escape (\" isn't an
+        // escape in single-quoted; the lexer keeps it literal as \").
+        // For safety against the unusual case, also normalize the
+        // remaining \" back to " then re-escape uniformly.
+        const normalized = inner.replace(/\\'/g, "'").replace(/\\"/g, '"');
+        toParse = `"${normalized.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+      }
+      lines.push(JSON.parse(toParse) as string);
+      continue;
+    }
+    // Identifier substitution (e.g. PLAN_ARCHETYPE_PROMPT). The in-host's
+    // active block references both PLAN_ARCHETYPE_PROMPT and
+    // PLAN_MODE_REFERENCE_CARD by identifier; we substitute their
+    // captured values.
+    if (substitutions[stripped] !== undefined) {
+      lines.push(substitutions[stripped]!);
+      continue;
+    }
+    throw new Error(
+      `unexpected non-string, non-substituted array element: ${JSON.stringify(stripped)}`,
+    );
+  }
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Run
+// ---------------------------------------------------------------------------
+
+const archetypePrompt = captureArchetypePrompt();
+const referenceCard = captureReferenceCard();
+const activeContext = captureActiveContext(archetypePrompt, referenceCard);
+const availableContext = captureAvailableContext();
+
+writeSnapshot("PLAN_ARCHETYPE_PROMPT.txt", archetypePrompt);
+writeSnapshot("PLAN_MODE_REFERENCE_CARD.txt", referenceCard);
+writeSnapshot("plan-mode-active-system-context.txt", activeContext);
+writeSnapshot("plan-mode-available-system-context.txt", availableContext);

--- a/parity-harness/host-snapshots/plan-mode-active-system-context.txt
+++ b/parity-harness/host-snapshots/plan-mode-active-system-context.txt
@@ -1,0 +1,247 @@
+═══ PLAN MODE ACTIVE ═══
+
+This session IS in plan mode RIGHT NOW. Every user message in this session is a plan-mode message. Your action selection on this turn must reflect that.
+
+ACTION CONTRACT — when the user says anything that requests a plan, iteration, revision, or 'try again' / 'iterate' / 'fresh' / 'next attempt':
+1. Briefly acknowledge in one short sentence (optional).
+2. CALL `exit_plan_mode(title="…", summary="…", plan=[...])` IN THE SAME TURN. `title` and `plan` are required; non-trivial plans should also include `analysis`, `assumptions`, `risks`, `verification`.
+3. Stop after the tool call. Do NOT respond with any further chat text in that turn.
+
+If you skip step 2 — if you respond with chat-only acknowledgement — you have failed the plan-mode contract and the user has to re-prompt you, which they should not have to do. Treat acknowledgement-without-tool-call as a defect, not as 'staying conversational'.
+
+Investigation phase (when needed):
+- Use read-only tools first (read, web_search, web_fetch, lcm_grep, lcm_describe, lcm_expand_query). Track investigation in update_plan.
+- For LOGS: start at the END (tail), use grep + time-window filters. Reading the first 100/400 lines of a multi-MB rolling log is almost always wrong — start with `tail -n 100`, then narrow by marker (e.g. `grep '[plan-mode/'`) or timestamp. Only widen to full file if the recent slice is insufficient.
+- Use `ask_user_question` ONLY for tradeoffs you can't resolve via local investigation.
+- Then call exit_plan_mode with the proposed plan, then STOP (no chat text after the tool call).
+
+Hard rules:
+- Mutating tools (write, edit, exec/bash with side-effects, apply_patch) are BLOCKED by the runtime — calling them wastes a turn.
+- Do NOT write the plan as a markdown list in chat — it MUST go through exit_plan_mode so the user gets Accept/Edit/Reject buttons.
+- Do NOT call enter_plan_mode (you're already in plan mode — it's a no-op).
+- After `exit_plan_mode` in this turn: STOP. Do not emit any further chat text. The next turn (after user approval) delivers `[PLAN_DECISION]: approved` and you can resume execution then. Trailing chat poisons the approval card lifecycle.
+
+═════════════════════════
+
+## Plan Mode — Decision-Complete Plan Standard
+
+You are in plan mode. Your job is to produce the best possible
+implementation plan for the current task so that execution succeeds on
+the first pass with minimal errors, minimal rework, and minimal hidden
+decisions.
+
+### Primary objective
+Create a decision-complete plan that the executing agent (which may be
+you in a later turn, or a subagent) can follow without inventing
+product, technical, interface, or testing decisions later.
+
+### Core rules
+- **Do not implement the task in plan mode.** Mutating tools (write,
+  edit, exec, bash, apply_patch) are blocked until the user approves.
+- **Explore first.** Ground the plan in the actual repo, files,
+  configs, types, and environment before asking questions. Use read,
+  grep, glob, web_search, web_fetch freely.
+- **Do not ask the user for facts you can discover locally.** Before
+  reaching for ask_user_question, exhaust the read-only investigation
+  surface.
+- **Distinguish discoverable facts from user preferences / tradeoffs.**
+  Discoverable → investigate. Preferences/tradeoffs → ask only when the
+  answer would materially change scope, behavior, architecture, risk,
+  or acceptance criteria.
+- **When risk is low, choose a reasonable default and record it as an
+  explicit assumption.** Don't ask permission for trivial choices.
+
+### Plan archetype — required fields on `exit_plan_mode`
+The proposal must lock down ALL of these:
+
+- **`title`** (REQUIRED, ≤80 chars): concise plan name — used as the
+  approval-card header AND as the persisted markdown filename slug.
+- **`summary`** (REQUIRED, ≤200 chars): one-sentence what-this-does.
+- **`analysis`** (REQUIRED for non-trivial multi-file changes): markdown
+  body covering current state, chosen approach, and rationale. This
+  gives the user enough context to evaluate the proposal without
+  re-reading the transcript. Multi-paragraph; can include code
+  references like `src/agents/plan-mode/types.ts:42` and PR numbers.
+- **`plan`** (REQUIRED): ordered step list. Each step is short (one
+  short sentence). Mark exactly one as `in_progress` if you've already
+  started part of the work; otherwise all `pending`. For steps with
+  high closure risk (e.g., VM provisioning), include
+  `acceptanceCriteria: [...]` so the runtime closure-gate prevents
+  premature `status: "completed"`.
+- **`assumptions`** (REQUIRED for any plan with non-obvious choices):
+  explicit list of assumptions made. If any assumption is wrong, the
+  plan needs revision — surface them so the user can correct.
+- **`risks`** (REQUIRED for plans touching live systems, security, data
+  flows, or external integrations): `[{risk, mitigation}]` register.
+- **`verification`** (REQUIRED for any plan that ships code or
+  configures live systems): concrete commands/checks that will confirm
+  success. Examples: `pnpm test src/agents/plan-mode/...` passes;
+  `ssh user@host echo ok` returns; sidebar shows "Plan complete ✓".
+- **`references`** (OPTIONAL): file:line, URLs, PR numbers, doc paths
+  the plan builds on. Renders as a "References" section in the
+  persisted markdown.
+
+### Quality bar
+- **Decision-complete**: another capable agent could execute this plan
+  without making hidden product/tech/interface decisions.
+- **Concrete**: name real files, modules, symbols, APIs, schemas,
+  configs. Don't say "the auth module" if you mean
+  `src/auth/index.ts`.
+- **Minimal**: prefer the smallest high-confidence change that solves
+  the problem. Preserve existing architecture and patterns unless the
+  task explicitly requires larger change. Avoid speculative
+  abstractions, broad refactors, and "while we're here" work.
+- **Verifiable**: every materially changed behavior is covered by a
+  concrete verification step.
+- **Length**: there is no upper limit. Multi-page plans are encouraged
+  for non-trivial work — the average Opus-quality plan is ~10 pages
+  with full analysis, references, and PR linkage. Don't pad, but don't
+  truncate to fit a perceived UI box either.
+
+### Anti-patterns — do NOT submit a plan that is:
+- A bare file list with no analysis or rationale.
+- Three vague paragraphs followed by "and we add tests as needed".
+- A title that's actually the agent's chat narration ("I checked all
+  five VMs..." is NOT a title; it's analysis text).
+- A plan that defers key behavior decisions to "implementation will
+  decide".
+- A plan that invents repo facts (paths, exports, types) without
+  having read them.
+- A plan that mixes must-have changes with optional nice-to-haves.
+
+### When to ask questions
+Use `ask_user_question` for:
+- Genuine product / scope tradeoffs where the answer changes the plan
+  shape (e.g., "ship as 1 PR or 3 PRs?", "preserve current behavior X
+  or replace it?").
+- Cases where local investigation is impossible (external state, user
+  intent on aesthetics, organizational priority).
+
+Do NOT use `ask_user_question` for:
+- Things you could grep / read / web_search yourself.
+- Trivial defaults (color schemes, naming conventions covered by
+  AGENTS.md).
+- Confirmation requests ("should I proceed?") — that's what
+  `exit_plan_mode` does.
+
+Questions DO NOT exit plan mode. The agent stays in plan mode while
+waiting for the answer; the answer arrives as a user message in the
+next turn formatted as `[QUESTION_ANSWER]: <answer text>` (same
+shape as `[PLAN_DECISION]: ...`).
+
+### Self-check before `exit_plan_mode`
+- Could another capable agent execute this without making hidden
+  decisions?
+- Are all materially changed behaviors covered by a concrete
+  verification step?
+- Are assumptions explicit?
+- Is the approach minimal and aligned with existing patterns?
+- Are open questions eliminated, or asked via `ask_user_question`?
+- Would this plan reduce execution mistakes rather than merely
+  describe the task?
+
+If the plan leaves meaningful implementation decisions unspecified, it
+is not finished. Investigate more or ask a clarifying question, then
+re-evaluate.
+
+
+═══ PLAN MODE — REFERENCE CARD ═══
+
+## State diagram
+
+```
+┌──────────────────┐
+│   NORMAL MODE    │   mutations (write/edit/exec/bash) ALLOWED
+│  (mutations OK)  │
+└────────┬─────────┘
+         │ enter_plan_mode  (or user toggles via /plan on)
+         │ ──► [PLAN_MODE_INTRO]: (one-shot, first-time only)
+         ▼
+┌──────────────────────────────────────────────┐
+│   PLAN MODE — INVESTIGATION                  │
+│   (mutations BLOCKED; read-only tools OK)    │
+│                                              │
+│  ↻ update_plan        — track progress       │
+│  ↻ ask_user_question  — clarify; next turn   │
+│  ↻ sessions_spawn     — research subagents   │
+│  ↻ read/grep/glob/web_search/lcm_*           │
+│                                              │
+│  Possible nudges injected by runtime:        │
+│  - [PLAN_NUDGE]:      cron wake-up if idle   │
+│  - [PLAN_ACK_ONLY]:   if no tool call        │
+│  - [PLANNING_RETRY]:  if narrating only      │
+└─────────────────────┬────────────────────────┘
+                      │ exit_plan_mode(title, plan, ...)
+                      │ ──► STOP — no more chat this turn!
+                      │ ──► tool-side gate blocks if
+                      │     openSubagentRunIds.size > 0
+                      ▼
+┌──────────────────────────────────────────────┐
+│   PLAN MODE — PENDING APPROVAL               │
+│   (approval card visible to user)            │
+│                                              │
+│  - approval-side gate blocks approve/edit if │
+│    subagents spawn DURING approval window    │
+│  - [PLAN_NUDGE] suppressed when pending      │
+└──┬─────────────┬─────────────┬───────────────┘
+   │ approve     │ edit        │ reject + feedback
+   │ /plan       │ /plan       │ /plan revise <text>
+   │ accept      │ accept edits│
+   ▼             ▼             ▼
+[PLAN_DECISION]: approved      [PLAN_DECISION]: rejected
+[PLAN_DECISION]: edited        feedback: "<text>"
+   │             │                  │
+   ▼             ▼                  ▼ ── back to INVESTIGATION
+┌──────────────────┐
+│   NORMAL MODE    │   mutations UNLOCKED, execute the plan
+│  (mutations OK)  │   update_plan to mark steps completed
+└────────┬─────────┘   all-terminal → auto-close + [PLAN_COMPLETE]:
+         │
+         ▼ (cycle done; user may /plan on for next cycle)
+```
+
+## Tool contract (one-line each)
+
+- `enter_plan_mode()` — once per cycle. Arms mutation gate. No-op if already in plan mode.
+- `update_plan(plan=[...])` — TRACKING ONLY. Does NOT submit. Mutations stay blocked.
+- `exit_plan_mode(title, plan, ...)` — once per cycle when ready to propose. Submits for user approval. STOP after this tool call (no chat text in same turn).
+- `ask_user_question(question, options)` — non-blocking clarification. Stays in plan mode.
+- `sessions_spawn(...)` — research subagents. Tool-side gate WILL block exit_plan_mode until they return.
+
+## [PLAN_*]: tag taxonomy (synthetic messages from runtime → agent)
+
+- `[PLAN_MODE_INTRO]:` — one-shot at first plan-mode entry per session (lifecycle + reminders)
+- `[PLAN_DECISION]: approved | edited | rejected | timed_out` — user resolved the approval card
+- `[QUESTION_ANSWER]: <text>` — user answered an ask_user_question
+- `[PLAN_COMPLETE]: <N> steps completed` — auto-fired when all plan steps reach terminal status post-approval
+- `[PLAN_NUDGE]:` — cron wake-up nudge (suppressed when approval pending)
+- `[PLAN_ACK_ONLY]:` — runtime detected the prior turn ended with chat text and no tool call (escalating retry)
+- `[PLAN_YIELD]:` — runtime detected the agent yielded immediately after approval (escalating retry)
+- `[PLANNING_RETRY]:` — runtime detected a planning-narration-only turn outside plan mode (escalating retry)
+
+## /plan slash-command surface (user types these in chat)
+
+- `/plan on` / `/plan off` — toggle plan mode
+- `/plan status` — show current state
+- `/plan view` — open the active plan in the side panel
+- `/plan accept [edits]` — approve the pending plan
+- `/plan revise <feedback>` — reject with revision feedback
+- `/plan answer <text>` — answer a pending ask_user_question
+- `/plan auto on|off` — toggle auto-approve mode
+
+## Common pitfalls
+
+1. **Don't post chat after `exit_plan_mode` in the same turn.** Trailing chat breaks the approval card lifecycle.
+2. **Wait for spawned subagents BEFORE `exit_plan_mode`.** The tool-side gate will reject if any are still running.
+3. **`update_plan` does NOT submit.** It only tracks progress. Use `exit_plan_mode` to propose.
+4. **Don't re-enter plan mode after approval.** Just continue executing. Re-enter only for a NEW planning cycle.
+5. **Provide a meaningful `title`.** It becomes the persisted markdown filename (`plan-YYYY-MM-DD-<slug>.md`) AND the side-panel header.
+
+## Debugging tips
+
+- Turn on plan-mode debug logging: `openclaw config set agents.defaults.planMode.debug true` then restart gateway.
+- Tail the structured event log: `tail -F ~/.openclaw/logs/gateway.err.log | grep '\[plan-mode/'`
+- Always-on gate-decision log: `tail -F ~/.openclaw/logs/gateway.err.log | grep 'plan-approval-gate'`
+- Call `plan_mode_status` to inspect the active cycle, pending interaction, and subagent gate state.
+
+═════════════════════════════════════

--- a/parity-harness/host-snapshots/plan-mode-available-system-context.txt
+++ b/parity-harness/host-snapshots/plan-mode-available-system-context.txt
@@ -1,0 +1,13 @@
+═══ PLAN MODE AVAILABLE ═══
+
+Plan mode is available on this session but not currently active. When the user asks for a NEW plan / debugging-plan / refactor-plan / 'next plan' / a plan-first workflow, call `enter_plan_mode` to start a fresh planning cycle. The runtime will arm the mutation gate and you should then:
+
+1. Investigate read-only (use update_plan for in-progress tracking).
+2. Call `exit_plan_mode` with the proposed plan to surface Accept/Edit/Reject buttons to the user.
+3. After approval, mutating tools unlock and you execute.
+
+If the user is already executing an approved plan and asks you to keep going, do NOT re-enter plan mode — just continue executing the work.
+
+If the user asks a simple question or for a quick non-planning answer, do NOT enter plan mode. Plan mode is for multi-step proposals that benefit from explicit user approval before mutations.
+
+═════════════════════════════

--- a/parity-harness/inputs/acceptEditsGate.json
+++ b/parity-harness/inputs/acceptEditsGate.json
@@ -1,0 +1,195 @@
+[
+  {
+    "id": "allow-non-destructive-exec",
+    "description": "exec ls — fail-open default for unmatched read-only commands.",
+    "toolName": "exec",
+    "execCommand": "ls -la"
+  },
+  {
+    "id": "allow-non-path-writer-tool",
+    "description": "read tool with no exec/path — fail-open default.",
+    "toolName": "read",
+    "filePath": "/Users/dev/project/README.md"
+  },
+  {
+    "id": "block-destructive-prefix-rm",
+    "description": "exec rm — destructive prefix block.",
+    "toolName": "exec",
+    "execCommand": "rm -f /tmp/junk"
+  },
+  {
+    "id": "block-destructive-prefix-rmdir",
+    "description": "exec rmdir — destructive prefix block; rmdir distinct from rm.",
+    "toolName": "exec",
+    "execCommand": "rmdir /tmp/junk"
+  },
+  {
+    "id": "block-destructive-prefix-shred",
+    "description": "exec shred — destructive prefix block.",
+    "toolName": "exec",
+    "execCommand": "shred -u secret.txt"
+  },
+  {
+    "id": "block-destructive-prefix-truncate",
+    "description": "exec truncate — destructive prefix block.",
+    "toolName": "exec",
+    "execCommand": "truncate -s 0 /var/log/access.log"
+  },
+  {
+    "id": "block-destructive-prefix-diskutil-erasedisk",
+    "description": "macOS-specific diskutil erasedisk — destructive prefix block.",
+    "toolName": "exec",
+    "execCommand": "diskutil erasedisk JHFS+ Mac /dev/disk2"
+  },
+  {
+    "id": "block-bash-rm",
+    "description": "bash rm — same as exec rm.",
+    "toolName": "bash",
+    "execCommand": "rm -rf /tmp/build"
+  },
+  {
+    "id": "block-sql-drop-table",
+    "description": "DROP TABLE inside exec — SQL pattern block.",
+    "toolName": "exec",
+    "execCommand": "psql -c \"DROP TABLE users\""
+  },
+  {
+    "id": "block-sql-delete-from",
+    "description": "DELETE FROM inside exec — SQL pattern block.",
+    "toolName": "exec",
+    "execCommand": "sqlite3 db.sqlite \"DELETE FROM sessions\""
+  },
+  {
+    "id": "block-sql-truncate-table-keyword",
+    "description": "TRUNCATE TABLE — SQL pattern block (matches `truncate` keyword in SQL context).",
+    "toolName": "exec",
+    "execCommand": "psql -c \"TRUNCATE TABLE foo\""
+  },
+  {
+    "id": "block-redis-flushall",
+    "description": "FLUSHALL inside exec — Redis destructive pattern.",
+    "toolName": "exec",
+    "execCommand": "redis-cli FLUSHALL"
+  },
+  {
+    "id": "block-find-delete-flag",
+    "description": "find with -delete flag — destructive find-flag block.",
+    "toolName": "exec",
+    "execCommand": "find . -name '*.tmp' -delete"
+  },
+  {
+    "id": "block-find-exec-rm",
+    "description": "find ... -exec rm — destructive find-flag block.",
+    "toolName": "exec",
+    "execCommand": "find /tmp -type f -exec rm {} ;"
+  },
+  {
+    "id": "block-escape-env-var-indirection",
+    "description": "C4 escape detection: $RM file — env-var indirection on destructive verb.",
+    "toolName": "exec",
+    "execCommand": "$RM /tmp/file"
+  },
+  {
+    "id": "block-escape-subshell-backtick",
+    "description": "C4 escape detection: `echo rm` file — backtick subshell with destructive verb.",
+    "toolName": "exec",
+    "execCommand": "`echo rm` -rf /tmp"
+  },
+  {
+    "id": "block-escape-subshell-dollar-paren",
+    "description": "C4 escape detection: $(echo rm) file — $(...) subshell with destructive verb.",
+    "toolName": "exec",
+    "execCommand": "$(echo rm) -rf /tmp"
+  },
+  {
+    "id": "block-escape-hex-encoded",
+    "description": "C4 escape detection: \\x72m — hex-encoded byte escape.",
+    "toolName": "exec",
+    "execCommand": "\\x72m -rf /tmp"
+  },
+  {
+    "id": "block-self-restart-openclaw-gateway",
+    "description": "openclaw gateway restart — self-restart block.",
+    "toolName": "exec",
+    "execCommand": "openclaw gateway restart"
+  },
+  {
+    "id": "block-self-restart-launchctl-openclaw",
+    "description": "launchctl kickstart on ai.openclaw — self-restart block.",
+    "toolName": "exec",
+    "execCommand": "launchctl kickstart -k system/ai.openclaw.gateway"
+  },
+  {
+    "id": "block-self-restart-pkill-openclaw",
+    "description": "pkill openclaw — self-restart block.",
+    "toolName": "exec",
+    "execCommand": "pkill openclaw"
+  },
+  {
+    "id": "block-self-restart-kill-with-pgrep-pipe",
+    "description": "pgrep openclaw | xargs kill — pipe-chained termination, pgrep+openclaw pattern catches it.",
+    "toolName": "exec",
+    "execCommand": "pgrep openclaw | xargs kill"
+  },
+  {
+    "id": "block-self-restart-script",
+    "description": "scripts/restart-mac.sh — bundled operator helper.",
+    "toolName": "exec",
+    "execCommand": "bash scripts/restart-mac.sh"
+  },
+  {
+    "id": "block-config-change-openclaw-set",
+    "description": "openclaw config set — config-change block.",
+    "toolName": "exec",
+    "execCommand": "openclaw config set agents.defaults.planMode.enabled true"
+  },
+  {
+    "id": "block-config-change-doctor-fix",
+    "description": "openclaw doctor --fix — config-change block.",
+    "toolName": "exec",
+    "execCommand": "openclaw doctor --fix"
+  },
+  {
+    "id": "block-write-protected-path-openclaw-tilde",
+    "description": "write to ~/.openclaw/config.toml — protected-path block (tilde form).",
+    "toolName": "write",
+    "filePath": "~/.openclaw/config.toml"
+  },
+  {
+    "id": "block-write-protected-path-claude-tilde",
+    "description": "write to ~/.claude/config — protected-path block (tilde form).",
+    "toolName": "write",
+    "filePath": "~/.claude/config"
+  },
+  {
+    "id": "block-edit-protected-path-etc-openclaw",
+    "description": "edit /etc/openclaw/... — protected-path block (absolute prefix).",
+    "toolName": "edit",
+    "filePath": "/etc/openclaw/config.toml"
+  },
+  {
+    "id": "block-apply-patch-additional-paths",
+    "description": "apply_patch with additionalPaths containing a protected path — multi-path check.",
+    "toolName": "apply_patch",
+    "filePath": "/Users/dev/project/safe.txt",
+    "additionalPaths": ["~/.openclaw/config.toml"]
+  },
+  {
+    "id": "allow-write-non-protected-path",
+    "description": "write to a non-protected path — fail-open default.",
+    "toolName": "write",
+    "filePath": "/Users/dev/project/main.ts"
+  },
+  {
+    "id": "allow-exec-cat",
+    "description": "exec cat README.md — non-destructive, non-restart, non-config.",
+    "toolName": "exec",
+    "execCommand": "cat README.md"
+  },
+  {
+    "id": "allow-exec-grep",
+    "description": "exec grep — non-destructive, non-restart, non-config.",
+    "toolName": "exec",
+    "execCommand": "grep -r 'foo' src/"
+  }
+]

--- a/parity-harness/inputs/escalatingRetry.json
+++ b/parity-harness/inputs/escalatingRetry.json
@@ -1,0 +1,68 @@
+[
+  {
+    "id": "planning-retry-attempt-0-standard",
+    "description": "PLANNING_RETRY tier at attempt 0 — standard variant.",
+    "resolver": "planning",
+    "attemptIndex": 0
+  },
+  {
+    "id": "planning-retry-attempt-1-firm",
+    "description": "PLANNING_RETRY tier at attempt 1 — firm variant.",
+    "resolver": "planning",
+    "attemptIndex": 1
+  },
+  {
+    "id": "planning-retry-attempt-2-final",
+    "description": "PLANNING_RETRY tier at attempt 2 — final variant.",
+    "resolver": "planning",
+    "attemptIndex": 2
+  },
+  {
+    "id": "planning-retry-attempt-3-still-final",
+    "description": "PLANNING_RETRY tier at attempt 3+ — clamps to final variant.",
+    "resolver": "planning",
+    "attemptIndex": 3
+  },
+  {
+    "id": "planning-retry-attempt-neg-standard",
+    "description": "PLANNING_RETRY tier at attempt -1 — non-positive clamps to standard.",
+    "resolver": "planning",
+    "attemptIndex": -1
+  },
+  {
+    "id": "plan-ack-only-attempt-0-standard",
+    "description": "PLAN_ACK_ONLY tier at attempt 0 — standard variant.",
+    "resolver": "planAckOnly",
+    "attemptIndex": 0
+  },
+  {
+    "id": "plan-ack-only-attempt-1-firm",
+    "description": "PLAN_ACK_ONLY tier at attempt 1 — firm variant.",
+    "resolver": "planAckOnly",
+    "attemptIndex": 1
+  },
+  {
+    "id": "plan-ack-only-attempt-2-still-firm",
+    "description": "PLAN_ACK_ONLY tier at attempt 2+ — clamps to firm.",
+    "resolver": "planAckOnly",
+    "attemptIndex": 2
+  },
+  {
+    "id": "plan-yield-attempt-0-standard",
+    "description": "PLAN_YIELD tier at attempt 0 — standard variant.",
+    "resolver": "planYield",
+    "attemptIndex": 0
+  },
+  {
+    "id": "plan-yield-attempt-1-firm",
+    "description": "PLAN_YIELD tier at attempt 1 — firm variant.",
+    "resolver": "planYield",
+    "attemptIndex": 1
+  },
+  {
+    "id": "plan-yield-attempt-2-still-firm",
+    "description": "PLAN_YIELD tier at attempt 2+ — clamps to firm.",
+    "resolver": "planYield",
+    "attemptIndex": 2
+  }
+]

--- a/parity-harness/inputs/mutationGate.json
+++ b/parity-harness/inputs/mutationGate.json
@@ -1,0 +1,216 @@
+[
+  {
+    "id": "normal-mode-allows-everything",
+    "description": "Normal mode (not plan): nothing blocked, even rm.",
+    "toolName": "exec",
+    "currentMode": "normal",
+    "execCommand": "rm -rf /tmp"
+  },
+  {
+    "id": "allowlist-read",
+    "description": "Plan mode + allowlisted tool 'read'.",
+    "toolName": "read",
+    "currentMode": "plan"
+  },
+  {
+    "id": "allowlist-update-plan",
+    "description": "Plan mode + 'update_plan' allowed.",
+    "toolName": "update_plan",
+    "currentMode": "plan"
+  },
+  {
+    "id": "allowlist-exit-plan-mode",
+    "description": "Plan mode + 'exit_plan_mode' allowed.",
+    "toolName": "exit_plan_mode",
+    "currentMode": "plan"
+  },
+  {
+    "id": "allowlist-ask-user-question",
+    "description": "Plan mode + 'ask_user_question' allowed (PR-10 fix).",
+    "toolName": "ask_user_question",
+    "currentMode": "plan"
+  },
+  {
+    "id": "allowlist-sessions-spawn",
+    "description": "Plan mode + 'sessions_spawn' allowed (PR-10 review fix #3105169112).",
+    "toolName": "sessions_spawn",
+    "currentMode": "plan"
+  },
+  {
+    "id": "allowlist-sessions-yield",
+    "description": "Plan mode + 'sessions_yield' allowed (PR #68939 follow-up).",
+    "toolName": "sessions_yield",
+    "currentMode": "plan"
+  },
+  {
+    "id": "allowlist-lcm-grep",
+    "description": "Plan mode + 'lcm_grep' allowed (PR #68939 follow-up).",
+    "toolName": "lcm_grep",
+    "currentMode": "plan"
+  },
+  {
+    "id": "blocklist-edit",
+    "description": "Plan mode + 'edit' blocked.",
+    "toolName": "edit",
+    "currentMode": "plan"
+  },
+  {
+    "id": "blocklist-write",
+    "description": "Plan mode + 'write' blocked.",
+    "toolName": "write",
+    "currentMode": "plan"
+  },
+  {
+    "id": "blocklist-apply-patch",
+    "description": "Plan mode + 'apply_patch' blocked.",
+    "toolName": "apply_patch",
+    "currentMode": "plan"
+  },
+  {
+    "id": "exec-readonly-cat",
+    "description": "Plan mode + exec cat (read-only prefix) — allowed.",
+    "toolName": "exec",
+    "currentMode": "plan",
+    "execCommand": "cat README.md"
+  },
+  {
+    "id": "exec-readonly-ls",
+    "description": "Plan mode + exec ls (read-only prefix) — allowed.",
+    "toolName": "exec",
+    "currentMode": "plan",
+    "execCommand": "ls -la"
+  },
+  {
+    "id": "bash-readonly-grep",
+    "description": "Plan mode + bash grep — allowed.",
+    "toolName": "bash",
+    "currentMode": "plan",
+    "execCommand": "grep foo src/"
+  },
+  {
+    "id": "exec-shell-operator-pipe-blocked",
+    "description": "exec cat | grep — pipe operator blocks even with readonly prefix.",
+    "toolName": "exec",
+    "currentMode": "plan",
+    "execCommand": "cat README.md | grep foo"
+  },
+  {
+    "id": "exec-shell-operator-semicolon-blocked",
+    "description": "exec ls ; rm — semicolon operator blocked.",
+    "toolName": "exec",
+    "currentMode": "plan",
+    "execCommand": "ls ; rm -rf /tmp"
+  },
+  {
+    "id": "exec-shell-operator-backtick-blocked",
+    "description": "exec ls `whoami` — backtick subshell blocked.",
+    "toolName": "exec",
+    "currentMode": "plan",
+    "execCommand": "ls `whoami`"
+  },
+  {
+    "id": "exec-shell-operator-dollar-paren-blocked",
+    "description": "exec ls $(whoami) — $() subshell blocked.",
+    "toolName": "exec",
+    "currentMode": "plan",
+    "execCommand": "ls $(whoami)"
+  },
+  {
+    "id": "exec-redirect-blocked",
+    "description": "exec ls > /tmp/foo — redirect blocked.",
+    "toolName": "exec",
+    "currentMode": "plan",
+    "execCommand": "ls > /tmp/foo"
+  },
+  {
+    "id": "exec-newline-blocked",
+    "description": "exec with embedded newline — blocked.",
+    "toolName": "exec",
+    "currentMode": "plan",
+    "execCommand": "ls\nrm -rf /tmp"
+  },
+  {
+    "id": "exec-dangerous-flag-delete",
+    "description": "find . -delete — dangerous flag blocked even with read-only prefix.",
+    "toolName": "exec",
+    "currentMode": "plan",
+    "execCommand": "find . -delete"
+  },
+  {
+    "id": "exec-dangerous-flag-exec",
+    "description": "find . -exec rm — dangerous flag blocked.",
+    "toolName": "exec",
+    "currentMode": "plan",
+    "execCommand": "find . -exec rm {} ;"
+  },
+  {
+    "id": "exec-dangerous-flag-rf",
+    "description": "rm -rf form — -rf flag matched by dangerous-flag regex even when not initial.",
+    "toolName": "exec",
+    "currentMode": "plan",
+    "execCommand": "find . -rf /tmp"
+  },
+  {
+    "id": "exec-dangerous-flag-fprint",
+    "description": "find . -fprint /tmp/x — write-flag on find blocked (PR-D fix).",
+    "toolName": "exec",
+    "currentMode": "plan",
+    "execCommand": "find . -fprint /tmp/x"
+  },
+  {
+    "id": "exec-dangerous-flag-not-false-match-executable",
+    "description": "find -executable — should NOT match -exec (word-boundary regex).",
+    "toolName": "exec",
+    "currentMode": "plan",
+    "execCommand": "find . -executable"
+  },
+  {
+    "id": "exec-unknown-prefix-blocked",
+    "description": "exec npm install — non-readonly prefix falls through to default-deny.",
+    "toolName": "exec",
+    "currentMode": "plan",
+    "execCommand": "npm install"
+  },
+  {
+    "id": "suffix-mutation-dot-write",
+    "description": "Custom MCP tool 'repo.write' matches '.write' suffix — blocked.",
+    "toolName": "repo.write",
+    "currentMode": "plan"
+  },
+  {
+    "id": "suffix-mutation-dot-edit",
+    "description": "Custom MCP tool 'vault.edit' matches '.edit' suffix — blocked.",
+    "toolName": "vault.edit",
+    "currentMode": "plan"
+  },
+  {
+    "id": "suffix-mutation-dot-delete",
+    "description": "Custom MCP tool 'cache.delete' matches '.delete' suffix — blocked.",
+    "toolName": "cache.delete",
+    "currentMode": "plan"
+  },
+  {
+    "id": "suffix-readonly-dot-read",
+    "description": "Custom MCP tool 'archive.read' matches '.read' suffix — allowed.",
+    "toolName": "archive.read",
+    "currentMode": "plan"
+  },
+  {
+    "id": "suffix-readonly-dot-search",
+    "description": "Custom MCP tool 'docs.search' matches '.search' suffix — allowed.",
+    "toolName": "docs.search",
+    "currentMode": "plan"
+  },
+  {
+    "id": "default-deny-unknown-tool",
+    "description": "Plan mode + unknown tool 'made_up_tool' — default-denied.",
+    "toolName": "made_up_tool",
+    "currentMode": "plan"
+  },
+  {
+    "id": "case-insensitive-blocklist",
+    "description": "Tool name 'EDIT' (uppercase) normalizes to 'edit' and is blocked.",
+    "toolName": "EDIT",
+    "currentMode": "plan"
+  }
+]

--- a/parity-harness/inputs/resolvePlanApproval.json
+++ b/parity-harness/inputs/resolvePlanApproval.json
@@ -1,0 +1,151 @@
+[
+  {
+    "id": "approve-pending-clears-feedback-and-rejectioncount",
+    "description": "Approve a pending plan with prior rejection history. Should flip mode→normal, approval→approved, clear feedback, reset rejectionCount to 0.",
+    "state_before": {
+      "mode": "plan",
+      "approval": "pending",
+      "rejectionCount": 2,
+      "approvalId": "plan-aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee",
+      "feedback": "earlier complaint"
+    },
+    "action": "approve"
+  },
+  {
+    "id": "edit-pending-treated-as-approval",
+    "description": "Edit counts as approval — same field resets as approve, but approval=edited.",
+    "state_before": {
+      "mode": "plan",
+      "approval": "pending",
+      "rejectionCount": 1,
+      "approvalId": "plan-aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee",
+      "feedback": "stale"
+    },
+    "action": "edit"
+  },
+  {
+    "id": "reject-pending-increments-and-stores-feedback",
+    "description": "Reject a pending plan with new feedback. Mode stays plan, approval→rejected, rejectionCount+1, feedback replaced.",
+    "state_before": {
+      "mode": "plan",
+      "approval": "pending",
+      "rejectionCount": 0,
+      "approvalId": "plan-aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee"
+    },
+    "action": "reject",
+    "feedback": "combine steps 2 and 3"
+  },
+  {
+    "id": "reject-rejected-state-re-rejection-preserves-existing-feedback-when-none-supplied",
+    "description": "Reject again (currently rejected). No new feedback → keep existing feedback. rejectionCount increments.",
+    "state_before": {
+      "mode": "plan",
+      "approval": "rejected",
+      "rejectionCount": 1,
+      "approvalId": "plan-aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee",
+      "feedback": "original feedback"
+    },
+    "action": "reject"
+  },
+  {
+    "id": "approve-rejected-flips-back-to-approved",
+    "description": "User changes mind: re-approve from rejected state. mode→normal, approval→approved, feedback cleared, rejectionCount reset to 0.",
+    "state_before": {
+      "mode": "plan",
+      "approval": "rejected",
+      "rejectionCount": 3,
+      "approvalId": "plan-aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee",
+      "feedback": "old complaint"
+    },
+    "action": "approve"
+  },
+  {
+    "id": "timeout-pending-flips-to-timed_out",
+    "description": "Timeout on a pending plan: mode stays plan, approval→timed_out, feedback cleared.",
+    "state_before": {
+      "mode": "plan",
+      "approval": "pending",
+      "rejectionCount": 0,
+      "approvalId": "plan-aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee"
+    },
+    "action": "timeout"
+  },
+  {
+    "id": "terminal-state-approved-blocks-action",
+    "description": "Approved is terminal. Any further action is a no-op.",
+    "state_before": {
+      "mode": "normal",
+      "approval": "approved",
+      "rejectionCount": 0,
+      "approvalId": "plan-aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee"
+    },
+    "action": "reject",
+    "feedback": "too late, already approved"
+  },
+  {
+    "id": "terminal-state-edited-blocks-action",
+    "description": "Edited is terminal. Any further action is a no-op.",
+    "state_before": {
+      "mode": "normal",
+      "approval": "edited",
+      "rejectionCount": 0,
+      "approvalId": "plan-aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee"
+    },
+    "action": "approve"
+  },
+  {
+    "id": "terminal-state-timed_out-blocks-action",
+    "description": "timed_out is terminal — requires a fresh exit_plan_mode before a new action can apply.",
+    "state_before": {
+      "mode": "plan",
+      "approval": "timed_out",
+      "rejectionCount": 0,
+      "approvalId": "plan-aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee"
+    },
+    "action": "approve"
+  },
+  {
+    "id": "none-state-blocks-action-without-token",
+    "description": "PR-D review fix: state 'none' (no pending approval to act on) blocks the action when no expectedApprovalId is supplied. Prevents out-of-sequence callbacks from flipping into terminal states.",
+    "state_before": {
+      "mode": "plan",
+      "approval": "none",
+      "rejectionCount": 0
+    },
+    "action": "approve"
+  },
+  {
+    "id": "stale-event-guard-mismatched-token-is-noop",
+    "description": "expectedApprovalId provided but does not match current approvalId. Action ignored.",
+    "state_before": {
+      "mode": "plan",
+      "approval": "pending",
+      "rejectionCount": 0,
+      "approvalId": "plan-aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee"
+    },
+    "action": "approve",
+    "expectedApprovalId": "plan-bbbbbbbb-cccc-4ddd-9eee-ffffffffffff"
+  },
+  {
+    "id": "stale-event-guard-missing-current-approvalid-is-noop",
+    "description": "expectedApprovalId provided but current state has no approvalId at all. Action ignored (the failsafe added to prevent fail-open on cleared/undefined approvalId).",
+    "state_before": {
+      "mode": "plan",
+      "approval": "pending",
+      "rejectionCount": 0
+    },
+    "action": "approve",
+    "expectedApprovalId": "plan-bbbbbbbb-cccc-4ddd-9eee-ffffffffffff"
+  },
+  {
+    "id": "timeout-from-rejected-is-noop",
+    "description": "Timeout only fires from pending. From rejected state it must be a no-op.",
+    "state_before": {
+      "mode": "plan",
+      "approval": "rejected",
+      "rejectionCount": 1,
+      "approvalId": "plan-aaaaaaaa-bbbb-4ccc-9ddd-eeeeeeeeeeee"
+    },
+    "action": "timeout"
+  }
+]

--- a/parity-harness/inputs/runtimeRejectAndPlanSteps.json
+++ b/parity-harness/inputs/runtimeRejectAndPlanSteps.json
@@ -1,0 +1,95 @@
+[
+  {
+    "id": "runtimeReject:no-feedback-one-line",
+    "description": "No feedback → single-line `[PLAN_DECISION]: rejected` (W1-D1 byte-pin).",
+    "kind": "runtimeReject",
+    "feedback": null
+  },
+  {
+    "id": "runtimeReject:empty-feedback-string-one-line",
+    "description": "Empty-string feedback also collapses to single-line (falsy after sanitize).",
+    "kind": "runtimeReject",
+    "feedback": ""
+  },
+  {
+    "id": "runtimeReject:plain-feedback-two-line",
+    "description": "Plain feedback → 2-line form, raw (NOT JSON-quoted).",
+    "kind": "runtimeReject",
+    "feedback": "combine steps 2 and 3"
+  },
+  {
+    "id": "runtimeReject:multiline-feedback-preserved-raw",
+    "description": "Feedback with embedded newlines flows through raw (no JSON-quote escaping).",
+    "kind": "runtimeReject",
+    "feedback": "Line one of feedback.\nLine two with more detail."
+  },
+  {
+    "id": "runtimeReject:channel-broadcast-mention-stripped",
+    "description": "`@channel` is neutralized to `@﹫channel` (U+FE6B SMALL COMMERCIAL AT).",
+    "kind": "runtimeReject",
+    "feedback": "Please @channel review this plan."
+  },
+  {
+    "id": "runtimeReject:here-mention-stripped",
+    "description": "`@here` likewise stripped.",
+    "kind": "runtimeReject",
+    "feedback": "@here we need to talk"
+  },
+  {
+    "id": "runtimeReject:everyone-mention-stripped",
+    "description": "`@everyone` likewise stripped.",
+    "kind": "runtimeReject",
+    "feedback": "@everyone please look"
+  },
+  {
+    "id": "runtimeReject:user-mention-zwsp-inserted",
+    "description": "`<@U123>` user-mention syntax neutralized via U+200B ZWSP between < and @.",
+    "kind": "runtimeReject",
+    "feedback": "ping <@U12345> here"
+  },
+  {
+    "id": "runtimeReject:case-insensitive-channel",
+    "description": "Channel-broadcast match is case-insensitive (`@CHANNEL`).",
+    "kind": "runtimeReject",
+    "feedback": "shouting at @CHANNEL"
+  },
+  {
+    "id": "planSteps:empty-array-empty-lines",
+    "description": "Empty steps → empty array.",
+    "kind": "planSteps",
+    "steps": []
+  },
+  {
+    "id": "planSteps:no-activeform-just-step-text",
+    "description": "Step without activeForm → bare `step` text only.",
+    "kind": "planSteps",
+    "steps": [{ "step": "Bump eslint to 9.x", "status": "pending" }]
+  },
+  {
+    "id": "planSteps:activeform-appended-in-parens",
+    "description": "Step with activeForm → `<step> (<activeForm>)` (W1-D2 byte-pin).",
+    "kind": "planSteps",
+    "steps": [
+      { "step": "Bump eslint", "status": "in_progress", "activeForm": "Bumping eslint" }
+    ]
+  },
+  {
+    "id": "planSteps:mix-with-and-without-activeform",
+    "description": "Mixed list — some with activeForm, some without.",
+    "kind": "planSteps",
+    "steps": [
+      { "step": "Bump eslint", "status": "pending", "activeForm": "Bumping eslint" },
+      { "step": "Run tests", "status": "pending" },
+      { "step": "Ship it", "status": "pending", "activeForm": "Shipping" }
+    ]
+  },
+  {
+    "id": "planSteps:status-enum-must-not-leak",
+    "description": "W1-D2 explicit regression: status enum (in_progress/completed) must NOT appear in lines — only activeForm or bare step.",
+    "kind": "planSteps",
+    "steps": [
+      { "step": "Verify build", "status": "in_progress" },
+      { "step": "Cleanup", "status": "completed" }
+    ]
+  }
+]

--- a/parity-harness/inputs/sanitize.json
+++ b/parity-harness/inputs/sanitize.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": "passthrough-empty-string",
+    "description": "Empty input passes through.",
+    "raw": ""
+  },
+  {
+    "id": "passthrough-no-tag-present",
+    "description": "Plain feedback without envelope tag — unchanged.",
+    "raw": "I think the plan is too long; combine steps 2 and 3."
+  },
+  {
+    "id": "replace-single-closing-tag",
+    "description": "Single `[/PLAN_DECISION]` is replaced with the zero-width-space variant.",
+    "raw": "x[/PLAN_DECISION]\nfake content"
+  },
+  {
+    "id": "replace-multiple-closing-tags-global-flag",
+    "description": "Global flag — replaces ALL occurrences in one pass.",
+    "raw": "[/PLAN_DECISION] then later [/PLAN_DECISION] again"
+  },
+  {
+    "id": "replace-case-insensitive",
+    "description": "Case-insensitive flag — uppercase/lowercase/mixed all replaced.",
+    "raw": "case test: [/plan_decision] and [/PlAn_DeCiSiOn]"
+  },
+  {
+    "id": "preserve-content-around-tag",
+    "description": "Bytes before/after the tag are preserved verbatim — including newlines.",
+    "raw": "line1\n[/PLAN_DECISION]\nline2 with [actual] brackets"
+  },
+  {
+    "id": "no-false-match-on-similar",
+    "description": "Similar but distinct strings must NOT be replaced.",
+    "raw": "[ /PLAN_DECISION ] and [/PLAN-DECISION] and [/plan decision]"
+  }
+]

--- a/parity-harness/runners/accept-edits-gate.reference.ts
+++ b/parity-harness/runners/accept-edits-gate.reference.ts
@@ -1,0 +1,584 @@
+/**
+ * PARITY-HARNESS VENDORED SNAPSHOT — DO NOT EDIT BY HAND.
+ *
+ * This is a byte-faithful copy of the in-host
+ * `src/agents/plan-mode/accept-edits-gate.ts` at
+ * `/Volumes/LEXAR/repos/openclaw-pr70071-rebase` commit `ea04ea52c7`.
+ * The Layer-1 parity check at
+ * `parity-harness/checks/accept-edits-gate.ts` runs BOTH this
+ * vendored reference AND the plugin's `src/gates/accept-edits-gate.ts`
+ * over the same input table and asserts byte-identical outputs.
+ *
+ * Re-capture by running:
+ *   git -C /Volumes/LEXAR/repos/openclaw-pr70071-rebase \
+ *     show ea04ea52c7:src/agents/plan-mode/accept-edits-gate.ts \
+ *     > parity-harness/runners/accept-edits-gate.reference.ts
+ * then re-add this header. The file MUST match the in-host source.
+ *
+ * Original in-host docstring follows.
+ *
+ * ---
+ *
+ * Accept-edits constraint gate (the three hard constraints that
+ * override acceptEdits permission).
+ *
+ * acceptEdits permission (granted when the user approves a plan via
+ * the "Accept, allow edits" button) lets the agent self-modify the
+ * plan during execution at ≥95% confidence. But three classes of
+ * action require explicit user confirmation regardless of
+ * acceptEdits:
+ *
+ *   1. **Destructive actions** — `rm`, `rmdir`, `shred`, `trash`,
+ *      `truncate`, `find ... -delete`, `find ... -exec rm`, SQL
+ *      `DROP TABLE`, `DELETE FROM`, `TRUNCATE TABLE`, `DROP DATABASE`,
+ *      Redis `FLUSHALL` / `FLUSHDB`.
+ *
+ *   2. **Self-restart** — anything that stops, restarts, or kills the
+ *      OpenClaw gateway process: `openclaw gateway stop|restart|kill`,
+ *      `launchctl kickstart|unload` on `ai.openclaw.*`, `systemctl
+ *      stop|restart openclaw*`, `pkill openclaw`, `kill -9` against
+ *      the gateway process.
+ *
+ *   3. **Configuration changes** — `openclaw config set`, `openclaw
+ *      doctor --fix`, or write/edit tool calls targeting protected
+ *      config paths (`~/.openclaw/*`, `~/.claude/*`,
+ *      `~/.config/openclaw/*`, `/etc/openclaw/*`).
+ *
+ * ## Posture
+ *
+ * This is a **fail-OPEN** gate — the default for an unknown tool or
+ * command is ALLOW. We only block on explicit matches for the three
+ * constraint categories. The mutation-gate in plan mode is fail-
+ * CLOSED; the acceptEdits gate is not, because the post-approval
+ * execution phase is intentionally permissive and only the three
+ * specific action categories are hard-gated.
+ *
+ * ## Layering
+ *
+ * This is layer 2 of a two-layer defense:
+ *
+ *   - **Layer 1 (prompt):** `buildAcceptEditsPlanInjection` in
+ *     `approval.ts` teaches the agent the three constraints and tells
+ *     it to ask the user before invoking any of them.
+ *
+ *   - **Layer 2 (this file):** runtime enforcement — even if the
+ *     prompt layer is ignored or misinterpreted, the gate blocks the
+ *     tool call with an instruction to ask the user.
+ */
+
+export interface AcceptEditsGateParams {
+  toolName: string;
+  /** Exec command string, if the tool is `exec` or `bash`. */
+  execCommand?: string;
+  /**
+   * Path argument for write/edit/apply_patch tools. Optional — if the
+   * tool doesn't carry a path (or we can't extract one), path-based
+   * checks are skipped.
+   */
+  filePath?: string;
+  /**
+   * Codex P2 review #68939 (post-nuclear-fix-stack): additional
+   * paths extracted from tool inputs that carry MULTIPLE target
+   * paths (specifically `apply_patch`, where the patch text in
+   * `params.input` contains target paths in its envelope headers).
+   * Each entry is checked against the protected-config-path
+   * prefixes individually. Optional — if the caller can't parse
+   * out additional paths, the single `filePath` field still works.
+   */
+  additionalPaths?: readonly string[];
+}
+
+export interface AcceptEditsGateResult {
+  blocked: boolean;
+  reason?: string;
+  constraint?: "destructive" | "self_restart" | "config_change";
+}
+
+// ---------------------------------------------------------------
+// Pattern definitions
+// ---------------------------------------------------------------
+
+/**
+ * Exec-command prefix patterns that match destructive actions. Each
+ * entry is the verb (or verb + flag) that starts the command. Matched
+ * case-insensitively with a trailing space or end-of-string boundary
+ * so substrings inside other command names don't collide (e.g.,
+ * `rmdir` is its own entry so `rmdir` doesn't prefix-match `rm`).
+ */
+const DESTRUCTIVE_EXEC_PREFIXES: readonly string[] = [
+  "rm",
+  "rmdir",
+  "unlink",
+  "shred",
+  "trash",
+  "truncate",
+  // macOS APFS-specific destructive primitives
+  "diskutil erasedisk",
+  "diskutil eraseall",
+];
+
+/**
+ * SQL / NoSQL destructive patterns. Matched as substrings inside the
+ * exec command (so `psql -c "DROP TABLE users"` or
+ * `sqlite3 db "DELETE FROM users"` is caught regardless of the outer
+ * shell. Multiline flag enabled so they match across embedded \n.
+ */
+const DESTRUCTIVE_SQL_PATTERNS: readonly RegExp[] = [
+  /\bDROP\s+TABLE\b/i,
+  /\bDROP\s+DATABASE\b/i,
+  /\bDROP\s+SCHEMA\b/i,
+  /\bDELETE\s+FROM\b/i,
+  /\bTRUNCATE\s+(TABLE\s+)?/i,
+  // Redis
+  /\bFLUSHALL\b/i,
+  /\bFLUSHDB\b/i,
+];
+
+/**
+ * Find-family destructive flag patterns. `find ... -delete` and
+ * `find ... -exec rm ...` are destructive even though `find` itself
+ * is a read tool. Mirror the plan-mode mutation-gate's denylist for
+ * consistency.
+ */
+const DESTRUCTIVE_FIND_FLAGS: readonly RegExp[] = [
+  /\s-delete\b/,
+  /\s-exec\s+(rm|rmdir|unlink|shred|truncate)\b/,
+  /\s-execdir\s+(rm|rmdir|unlink|shred|truncate)\b/,
+];
+
+/**
+ * C4 (Plan Mode 1.0 follow-up): layered-defense escape-pattern
+ * detection. The prefix / SQL / find checks above catch the 99%
+ * case where the destructive verb is directly visible in the
+ * command string. These patterns flag the sophisticated-bypass
+ * vectors where a shell would resolve an expansion AT RUNTIME
+ * into a destructive command — the gate can't track the expansion,
+ * but it can refuse to allow the construct entirely under
+ * acceptEdits.
+ *
+ * Posture: if an exec command contains ANY of these escape
+ * constructs referencing destructive verbs, treat it as
+ * destructive and block. Rationale:
+ *   - acceptEdits is a permission elevation — the user opted in
+ *     for trusted-plan execution, not for cleverness budget.
+ *   - A legitimate post-approval exec rarely needs env-var
+ *     indirection for destructive verbs. Blocking has near-zero
+ *     false-positive cost and high true-positive recall.
+ *   - Primary defense remains the prompt layer; this is
+ *     defense-in-depth so a prompt-ignoring agent can't silently
+ *     shell-escape around the gate.
+ */
+const DESTRUCTIVE_VERBS_FOR_ESCAPE_DETECTION = "rm|rmdir|unlink|shred|trash|truncate";
+
+const DESTRUCTIVE_ESCAPE_PATTERNS: readonly RegExp[] = [
+  // `$RM file`, `$SHRED ...` — env-var indirection where the
+  // variable name matches a destructive verb (case-insensitive).
+  new RegExp(`\\$\\{?(?:${DESTRUCTIVE_VERBS_FOR_ESCAPE_DETECTION})\\b`, "i"),
+  // `` `echo rm` file `` — backtick subshell containing destructive verb.
+  new RegExp(`\`[^\`]*\\b(?:${DESTRUCTIVE_VERBS_FOR_ESCAPE_DETECTION})\\b[^\`]*\``, "i"),
+  // `$(echo rm) file` — $(...) subshell containing destructive verb.
+  new RegExp(`\\$\\([^)]*\\b(?:${DESTRUCTIVE_VERBS_FOR_ESCAPE_DETECTION})\\b[^)]*\\)`, "i"),
+  // Quote concatenation: `"r""m" file`, `'r''m' file`. The
+  // concatenation of adjacent quoted fragments that together
+  // spell a destructive verb — catches the common "r""m" /
+  // "rm"+"" / "r"m patterns. Intentionally conservative —
+  // matches when adjacent quoted tokens start with the first
+  // letter of a destructive verb and can reconstruct into it.
+  /["'][a-z]["']["'][a-z]["']/i,
+  // Hex-encoded destructive verbs: `\x72m`, `\x72\x6d`. A
+  // destructive verb's first letter is `\xNN` followed by the
+  // remainder. Conservative — also flags any `\xNN` byte escape
+  // inside an exec command, which is itself highly suspicious
+  // under acceptEdits.
+  /\\x[0-9a-f]{2}/i,
+  // Octal-encoded bytes (e.g., `\162m`).
+  /\\[0-7]{3}/,
+];
+
+function checkDestructiveEscape(execCommand: string): AcceptEditsGateResult | null {
+  for (const pattern of DESTRUCTIVE_ESCAPE_PATTERNS) {
+    if (pattern.test(execCommand)) {
+      return {
+        blocked: true,
+        constraint: "destructive",
+        reason:
+          "Command contains a shell-escape construct (env-var indirection, subshell, quote concatenation, or byte escape) " +
+          "near a destructive verb. Under acceptEdits these are blocked because the gate cannot track what the shell will " +
+          "expand to at runtime. Ask the user for explicit confirmation and run the destructive action directly if approved.",
+      };
+    }
+  }
+  return null;
+}
+
+/**
+ * Self-restart patterns. Match exec commands that stop / restart /
+ * kill the gateway or its processes. Case-insensitive.
+ */
+const SELF_RESTART_PATTERNS: readonly RegExp[] = [
+  /\bopenclaw\s+gateway\s+(restart|stop|kill)\b/i,
+  /\blaunchctl\s+(kickstart|unload|stop)\b.*ai\.openclaw/i,
+  /\bsystemctl\s+(restart|stop|kill)\b.*openclaw/i,
+  /\bpkill\b.*\bopenclaw\b/i,
+  /\bkillall\b.*\bopenclaw\b/i,
+  // `kill -9 <pid>` against a gateway pid requires path context; we
+  // conservatively flag `kill` when combined with openclaw/gateway
+  // words on the same line.
+  /\bkill\s+-?\d*\s+.*\b(openclaw|gateway)\b/i,
+  // Pipe-chained termination: `pgrep openclaw | xargs kill` — the
+  // `kill` side has no openclaw word, so the kill pattern above
+  // misses it. Match the source side (pgrep + openclaw/gateway).
+  /\bpgrep\b.*\b(openclaw|gateway)\b/i,
+  // `kill $(pgrep openclaw)` or `kill $(cat /tmp/openclaw-gateway.pid)`
+  // — subshell invocation where the target is resolved at runtime.
+  /\bkill\b.*\$\([^)]*\b(openclaw|gateway)\b[^)]*\)/i,
+  /\bkill\b.*`[^`]*\b(openclaw|gateway)\b[^`]*`/i,
+  // `scripts/restart-mac.sh` is a bundled operator helper
+  /\bscripts\/restart-mac\.sh\b/,
+];
+
+/**
+ * Config-change command patterns.
+ */
+const CONFIG_CHANGE_PATTERNS: readonly RegExp[] = [
+  /\bopenclaw\s+config\s+set\b/i,
+  /\bopenclaw\s+config\s+delete\b/i,
+  /\bopenclaw\s+config\s+unset\b/i,
+  /\bopenclaw\s+doctor\s+.*--fix\b/i,
+];
+
+/**
+ * Protected config path prefixes. Write / edit / apply_patch calls
+ * targeting these paths are blocked.
+ *
+ * We check both literal home-tilde and expanded $HOME variants because
+ * path normalization varies across callers (some normalize, some
+ * don't). Paths are normalized via `normalizeCandidatePath` before
+ * prefix-matching so `~` is expanded, `..` segments are collapsed,
+ * and redundant separators are removed — a write to
+ * `~/.openclaw/../.openclaw/config.toml` resolves to the same
+ * target as `~/.openclaw/config.toml` and is blocked.
+ */
+const PROTECTED_CONFIG_PATH_PREFIXES: readonly string[] = [
+  "~/.openclaw/",
+  "~/.claude/",
+  "~/.config/openclaw/",
+  "/etc/openclaw/",
+  "/usr/local/etc/openclaw/",
+];
+
+/**
+ * Tools that accept a destination path in their params and can write
+ * to disk. Used to route the write-path check.
+ */
+const PATH_WRITER_TOOLS = new Set(["write", "edit", "apply_patch", "create", "delete"]);
+
+// ---------------------------------------------------------------
+// Matchers
+// ---------------------------------------------------------------
+
+function trimLower(s: string): string {
+  return s.trim().toLowerCase();
+}
+
+function matchExecPrefix(cmd: string, prefix: string): boolean {
+  if (cmd === prefix) {
+    return true;
+  }
+  const needle = `${prefix} `;
+  return cmd.startsWith(needle);
+}
+
+function checkDestructive(execCommand: string): AcceptEditsGateResult | null {
+  const cmd = trimLower(execCommand);
+  for (const prefix of DESTRUCTIVE_EXEC_PREFIXES) {
+    if (matchExecPrefix(cmd, prefix)) {
+      return {
+        blocked: true,
+        constraint: "destructive",
+        reason:
+          `Command "${prefix}" is a destructive action and is blocked under acceptEdits. ` +
+          "Ask the user for explicit confirmation before proceeding.",
+      };
+    }
+  }
+  for (const pattern of DESTRUCTIVE_SQL_PATTERNS) {
+    if (pattern.test(execCommand)) {
+      return {
+        blocked: true,
+        constraint: "destructive",
+        reason:
+          "Command contains a destructive SQL / database statement and is blocked under acceptEdits. " +
+          "Ask the user for explicit confirmation before proceeding.",
+      };
+    }
+  }
+  for (const pattern of DESTRUCTIVE_FIND_FLAGS) {
+    if (pattern.test(execCommand)) {
+      return {
+        blocked: true,
+        constraint: "destructive",
+        reason:
+          "Command contains a destructive find-family flag (-delete or -exec rm) and is blocked under acceptEdits. " +
+          "Ask the user for explicit confirmation before proceeding.",
+      };
+    }
+  }
+  // C4 layered-defense: catch escape-vector bypasses where the
+  // destructive verb is hidden behind env expansion, subshell,
+  // quote concatenation, or byte escapes.
+  const escapeResult = checkDestructiveEscape(execCommand);
+  if (escapeResult) {
+    return escapeResult;
+  }
+  return null;
+}
+
+function checkSelfRestart(execCommand: string): AcceptEditsGateResult | null {
+  for (const pattern of SELF_RESTART_PATTERNS) {
+    if (pattern.test(execCommand)) {
+      return {
+        blocked: true,
+        constraint: "self_restart",
+        reason:
+          "Command would stop, restart, or kill the OpenClaw gateway. " +
+          "Self-restart is blocked under acceptEdits; ask the user for explicit confirmation.",
+      };
+    }
+  }
+  return null;
+}
+
+function checkConfigChange(execCommand: string): AcceptEditsGateResult | null {
+  for (const pattern of CONFIG_CHANGE_PATTERNS) {
+    if (pattern.test(execCommand)) {
+      return {
+        blocked: true,
+        constraint: "config_change",
+        reason:
+          "Command changes OpenClaw configuration. " +
+          "Config changes are blocked under acceptEdits; ask the user for explicit confirmation.",
+      };
+    }
+  }
+  return null;
+}
+
+/**
+ * Normalizes a file path for prefix matching against the protected
+ * list. Expands tildes, collapses `..` / `.` segments, removes double
+ * slashes. Returns BOTH the tilde form and the absolute $HOME form so
+ * callers can check prefixes expressed in either form.
+ *
+ * Best-effort — if normalization fails (invalid path characters etc.)
+ * the raw trimmed input is returned so the caller can still prefix-
+ * check it directly.
+ */
+function normalizeCandidatePath(filePath: string): { tildeForm: string; absoluteForm: string } {
+  const trimmed = filePath.trim();
+  if (!trimmed) {
+    return { tildeForm: "", absoluteForm: "" };
+  }
+  const home = typeof process !== "undefined" ? process.env.HOME : undefined;
+  // Collapse `..` / `.` / double-slash. Simple split-join; do not
+  // require `node:path` because that adds platform-specific behavior
+  // and we care about unix-style paths here (the gate is Linux/macOS
+  // oriented — Windows paths are exceedingly rare in this codebase).
+  function collapse(p: string): string {
+    const segments = p.split("/");
+    const stack: string[] = [];
+    for (const seg of segments) {
+      if (seg === "" || seg === ".") {
+        // preserve leading slash via empty first segment if present
+        if (stack.length === 0 && seg === "") {
+          stack.push("");
+        }
+        continue;
+      }
+      if (seg === "..") {
+        if (stack.length > 1 || (stack.length === 1 && stack[0] !== "")) {
+          stack.pop();
+        }
+        continue;
+      }
+      stack.push(seg);
+    }
+    const joined = stack.join("/");
+    return joined.length === 0 ? "/" : joined;
+  }
+  let tildeForm = trimmed;
+  let absoluteForm = trimmed;
+  if (trimmed === "~" || trimmed.startsWith("~/")) {
+    tildeForm = trimmed;
+    absoluteForm = home ? trimmed.replace(/^~/, home) : trimmed;
+  } else if (home && trimmed.startsWith(`${home}/`)) {
+    absoluteForm = trimmed;
+    tildeForm = `~${trimmed.slice(home.length)}`;
+  }
+  return {
+    tildeForm: collapse(tildeForm),
+    absoluteForm: collapse(absoluteForm),
+  };
+}
+
+function checkProtectedPath(filePath: string): AcceptEditsGateResult | null {
+  const { tildeForm, absoluteForm } = normalizeCandidatePath(filePath);
+  if (!tildeForm && !absoluteForm) {
+    return null;
+  }
+  const home = typeof process !== "undefined" ? process.env.HOME : undefined;
+  for (const prefix of PROTECTED_CONFIG_PATH_PREFIXES) {
+    // Check the tilde form against tilde-prefixed protected paths.
+    if (prefix.startsWith("~/") && tildeForm.startsWith(prefix)) {
+      return matchedProtectedPath(filePath, prefix);
+    }
+    // Check the absolute form against $HOME-expanded tilde prefixes.
+    if (prefix.startsWith("~/") && home) {
+      const absPrefix = prefix.replace(/^~/, home);
+      if (absoluteForm.startsWith(absPrefix)) {
+        return matchedProtectedPath(filePath, prefix);
+      }
+    }
+    // Absolute-form prefixes (no tilde): check against absolute form.
+    if (!prefix.startsWith("~/") && absoluteForm.startsWith(prefix)) {
+      return matchedProtectedPath(filePath, prefix);
+    }
+  }
+  return null;
+}
+
+function matchedProtectedPath(original: string, prefix: string): AcceptEditsGateResult {
+  return {
+    blocked: true,
+    constraint: "config_change",
+    reason:
+      `Write to protected config path "${original}" (matches ${prefix}) is blocked under acceptEdits. ` +
+      "Ask the user for explicit confirmation before editing OpenClaw / Claude config files.",
+  };
+}
+
+// ---------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------
+
+/**
+ * Checks whether a tool call should be blocked under acceptEdits
+ * permission. Call sites wire this in ONLY when
+ * `SessionEntry.postApprovalPermissions.acceptEdits === true`. If
+ * acceptEdits is not granted, this gate is not invoked at all.
+ *
+ * Returns `{ blocked: false }` for anything that doesn't match one
+ * of the three constraint categories. Fail-open by design — this
+ * layer exists to catch explicit destructive / restart / config
+ * actions, not to restrict general mutation.
+ */
+export function checkAcceptEditsConstraint(params: AcceptEditsGateParams): AcceptEditsGateResult {
+  const toolName = trimLower(params.toolName);
+  const cmd = params.execCommand?.trim();
+
+  if ((toolName === "exec" || toolName === "bash") && cmd && cmd.length > 0) {
+    const destructive = checkDestructive(cmd);
+    if (destructive) {
+      return destructive;
+    }
+
+    const selfRestart = checkSelfRestart(cmd);
+    if (selfRestart) {
+      return selfRestart;
+    }
+
+    const configChange = checkConfigChange(cmd);
+    if (configChange) {
+      return configChange;
+    }
+  }
+
+  if (PATH_WRITER_TOOLS.has(toolName)) {
+    // Codex P2 review #68939 (post-nuclear-fix-stack): check
+    // EVERY candidate path (the singular `filePath` from
+    // params.path / params.filePath / params.file_path PLUS any
+    // additionalPaths the caller extracted from a multi-path
+    // input like `apply_patch`'s patch envelope). Return the
+    // first protected-path hit. Pre-fix, only the singular
+    // `filePath` was checked, which left `apply_patch` calls
+    // (which embed paths in `params.input`) able to bypass the
+    // protected-path block.
+    const candidatePaths: string[] = [];
+    if (params.filePath) {
+      candidatePaths.push(params.filePath);
+    }
+    if (params.additionalPaths) {
+      for (const p of params.additionalPaths) {
+        if (typeof p === "string" && p.length > 0) {
+          candidatePaths.push(p);
+        }
+      }
+    }
+    for (const candidate of candidatePaths) {
+      const protectedPath = checkProtectedPath(candidate);
+      if (protectedPath) {
+        return protectedPath;
+      }
+    }
+  }
+
+  return { blocked: false };
+}
+
+/**
+ * Codex P2 review #68939 (post-nuclear-fix-stack): parse target
+ * paths from an `apply_patch` envelope text. The patch format
+ * uses `*** Update File: <path>` / `*** Add File: <path>` /
+ * `*** Delete File: <path>` headers. Returns all unique paths
+ * found; returns an empty array if `input` is missing/non-string
+ * or no headers match. Tolerant to whitespace and case
+ * variations on the verb token.
+ *
+ * Used by the before-tool-call hook to feed `additionalPaths`
+ * into `checkAcceptEditsConstraint` so the protected-config-
+ * path block fires for `apply_patch` calls under acceptEdits.
+ */
+export function extractApplyPatchTargetPaths(input: unknown): string[] {
+  if (typeof input !== "string" || input.length === 0) {
+    return [];
+  }
+  // Match the three single-path envelope verbs (Update/Add/Delete)
+  // and the Move destination marker. Codex review #68939 (2026-04-20):
+  // the actual apply_patch grammar (see `src/agents/apply-patch.ts:22-23`)
+  // uses `*** Move to: <dst>` as a SUB-marker nested inside an
+  // `*** Update File: <src>` hunk — NOT the older `*** Move File:
+  // <src> -> <dst>` single-line form. Pre-fix, the regex here matched
+  // the non-existent form and therefore missed every real Move
+  // destination path, letting `apply_patch` bypass the protected-
+  // config-path check for moves INTO a protected path. The source
+  // path is already caught by `singlePathRe` (the surrounding `***
+  // Update File:` line); the new `moveToRe` catches the destination.
+  const singlePathRe = /^\*\*\*\s+(?:Update|Add|Delete)\s+File:\s+(.+?)\s*$/gim;
+  const moveToRe = /^\*\*\*\s+Move\s+to:\s+(.+?)\s*$/gim;
+  const found = new Set<string>();
+  let match: RegExpExecArray | null;
+  // biome-ignore lint/suspicious/noAssignInExpressions: standard regex iteration pattern
+  while ((match = singlePathRe.exec(input)) !== null) {
+    if (match[1]) {
+      found.add(match[1].trim());
+    }
+  }
+  // biome-ignore lint/suspicious/noAssignInExpressions: standard regex iteration pattern
+  while ((match = moveToRe.exec(input)) !== null) {
+    if (match[1]) {
+      found.add(match[1].trim());
+    }
+  }
+  return [...found];
+}
+
+// Exposed for tests + potential future reuse
+export const __testing = {
+  DESTRUCTIVE_EXEC_PREFIXES,
+  DESTRUCTIVE_SQL_PATTERNS,
+  DESTRUCTIVE_FIND_FLAGS,
+  SELF_RESTART_PATTERNS,
+  CONFIG_CHANGE_PATTERNS,
+  PROTECTED_CONFIG_PATH_PREFIXES,
+  PATH_WRITER_TOOLS,
+};

--- a/parity-harness/runners/escalating-retry.reference.ts
+++ b/parity-harness/runners/escalating-retry.reference.ts
@@ -1,0 +1,190 @@
+/**
+ * Vendored reference for the escalating-retry instruction selectors +
+ * constant strings.
+ *
+ * The in-host file (`src/agents/pi-embedded-runner/run/incomplete-turn.ts`)
+ * is ~1070 LOC because it interrogates EmbeddedRunAttemptResult
+ * internals. The plugin's port (`src/runtime/escalating-retry-constants.ts`)
+ * pulls out ONLY the instruction-byte constants + the attempt-index
+ * resolvers and exports them verbatim. THIS reference re-derives those
+ * same constants + functions directly from the in-host source so the
+ * harness can compare byte-by-byte.
+ *
+ * Strategy: re-export the exact in-host constants + resolveEscalatingPlanningRetryInstruction
+ * here. The constants are pure string literals — easy to vendor verbatim.
+ * The PLAN_ACK_ONLY + PLAN_YIELD resolvers are not exported from
+ * in-host (they're internal to incomplete-turn.ts's resolveX functions),
+ * but the constants ARE exported and the resolver shape is documented
+ * (in-host's DEFAULT_PLAN_MODE_ACK_ONLY_RETRY_LIMIT=2 + DEFAULT_PLAN_APPROVED_YIELD_RETRY_LIMIT=2
+ * implies a 2-tier escalation: standard → firm). The plugin's resolvers
+ * implement that documented shape; the reference mirrors it.
+ *
+ * host_ref:
+ *   - src/agents/pi-embedded-runner/run/incomplete-turn.ts:66-267 (constants)
+ *   - src/agents/pi-embedded-runner/run/incomplete-turn.ts:731-739 (resolveEscalatingPlanningRetryInstruction)
+ *
+ * Anti-pattern guardrail: re-capture this from the in-host source if it
+ * changes. Do NOT mirror plugin source.
+ */
+
+// ---------------------------------------------------------------------------
+// Regex constants (in-host lines 66-80).
+// ---------------------------------------------------------------------------
+
+export const PLANNING_ONLY_PROMISE_RE_REF =
+  /\b(?:i(?:'ll| will)|let me|i(?:'m| am)\s+going to|first[, ]+i(?:'ll| will)|next[, ]+i(?:'ll| will)|i can do that)\b/i;
+
+export const PLANNING_ONLY_COMPLETION_RE_REF =
+  /\b(?:done|finished|implemented|updated|fixed|changed|ran|verified|found|here(?:'s| is) what|blocked by|the blocker is)\b/i;
+
+export const PLANNING_ONLY_HEADING_RE_REF = /^(?:plan|steps?|next steps?)\s*:/i;
+
+export const PLANNING_ONLY_BULLET_RE_REF = /^(?:[-*•]\s+|\d+[.)]\s+)/u;
+
+export const PLANNING_ONLY_MAX_VISIBLE_TEXT_REF = 700;
+
+export const PLANNING_ONLY_ACTION_VERB_RE_REF =
+  /\b(?:inspect|investigate|check|look(?:\s+into|\s+at)?|read|search|find|debug|fix|patch|update|change|edit|write|implement|run|test|verify|review|analy(?:s|z)e|summari(?:s|z)e|explain|answer|show|share|report|prepare|capture|take|refactor|restart|deploy|ship)\b/i;
+
+// ---------------------------------------------------------------------------
+// Retry-limit defaults (in-host lines 96-101, 245, 267).
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_PLANNING_ONLY_RETRY_LIMIT_REF = 1;
+export const STRICT_AGENTIC_PLANNING_ONLY_RETRY_LIMIT_REF = 3;
+export const DEFAULT_REASONING_ONLY_RETRY_LIMIT_REF = 2;
+export const DEFAULT_EMPTY_RESPONSE_RETRY_LIMIT_REF = 1;
+export const DEFAULT_PLAN_MODE_ACK_ONLY_RETRY_LIMIT_REF = 2;
+export const DEFAULT_PLAN_APPROVED_YIELD_RETRY_LIMIT_REF = 2;
+
+// ---------------------------------------------------------------------------
+// PLANNING_RETRY instructions (in-host lines 151-156).
+// ---------------------------------------------------------------------------
+
+export const PLANNING_ONLY_RETRY_INSTRUCTION_REF =
+  "[PLANNING_RETRY]: The previous assistant turn only described the plan. Do not restate the plan. Act now: take the first concrete tool action you can. If a real blocker prevents action, reply with the exact blocker in one sentence.";
+
+export const PLANNING_ONLY_RETRY_INSTRUCTION_FIRM_REF =
+  "[PLANNING_RETRY]: CRITICAL: You have described the plan multiple times without acting. You MUST call a tool in this turn. No more planning or narration. If a real blocker prevents action, state the exact blocker in one sentence. Otherwise, call the first tool NOW.";
+
+export const PLANNING_ONLY_RETRY_INSTRUCTION_FINAL_REF =
+  "[PLANNING_RETRY]: Final reminder: this is the third planning-only turn. Please call a tool now to make progress. If a real blocker prevents action, state the exact blocker in one sentence so the user can unblock you.";
+
+// ---------------------------------------------------------------------------
+// REASONING_ONLY / EMPTY_RESPONSE (in-host lines 157-160).
+// ---------------------------------------------------------------------------
+
+export const REASONING_ONLY_RETRY_INSTRUCTION_REF =
+  "The previous assistant turn recorded reasoning but did not produce a user-visible answer. Continue from that partial turn and produce the visible answer now. Do not restate the reasoning or restart from scratch.";
+
+export const EMPTY_RESPONSE_RETRY_INSTRUCTION_REF =
+  "The previous attempt did not produce a user-visible answer. Continue from the current state and produce the visible answer now. Do not restart from scratch.";
+
+// ---------------------------------------------------------------------------
+// ACK_EXECUTION / AUTO_CONTINUE (in-host lines 161-166).
+// ---------------------------------------------------------------------------
+
+export const ACK_EXECUTION_FAST_PATH_INSTRUCTION_REF =
+  "The latest user message is a short approval to proceed. Do not recap or restate the plan. Start with the first concrete tool action immediately. Keep any user-facing follow-up brief and natural.";
+
+export const AUTO_CONTINUE_FAST_PATH_INSTRUCTION_REF =
+  "The system is auto-continuing. Do not recap or restate the plan. Start with the first concrete tool action immediately. Keep any user-facing follow-up brief and natural.";
+
+export const STRICT_AGENTIC_BLOCKED_TEXT_REF =
+  "Agent stopped after repeated plan-only turns without taking a concrete action. No concrete tool action or external side effect advanced the task.";
+
+// ---------------------------------------------------------------------------
+// PLAN_ACK_ONLY (in-host lines 226-243).
+// ---------------------------------------------------------------------------
+
+export const PLAN_MODE_ACK_ONLY_RETRY_INSTRUCTION_REF =
+  "[PLAN_ACK_ONLY]: Plan mode is active and you're still in the PLANNING phase (no user " +
+  "approval yet). Your previous response stopped without calling " +
+  "exit_plan_mode OR a read-only investigative tool. Brief progress " +
+  "updates are fine, but they must NOT end the turn — keep calling tools " +
+  "after them. The next response MUST either: (a) continue planning " +
+  "investigation with a read-only tool (read, lcm_grep, lcm_describe, " +
+  "lcm_expand_query, grep, glob, ls, find, web_search, web_fetch, " +
+  "update_plan), or (b) call exit_plan_mode(title=..., plan=[...]) " +
+  "with the proposed plan. A status line followed by another tool call " +
+  "is the right pattern; a status line alone is treated as yielding " +
+  "without acting.";
+
+export const PLAN_MODE_ACK_ONLY_RETRY_INSTRUCTION_FIRM_REF =
+  "[PLAN_ACK_ONLY]: CRITICAL: plan mode is active and you have acknowledged twice without calling " +
+  "exit_plan_mode. You MUST call exit_plan_mode(plan=[...]) in this turn. No more " +
+  "chat-only acknowledgements. If a real blocker prevents producing a plan, state " +
+  "the exact blocker in one sentence so the user can unblock you.";
+
+// ---------------------------------------------------------------------------
+// PLAN_APPROVED_YIELD (in-host lines 254-265).
+// ---------------------------------------------------------------------------
+
+export const PLAN_APPROVED_YIELD_RETRY_INSTRUCTION_REF =
+  "[PLAN_YIELD]: Your plan was just approved and mutating tools were unlocked. You yielded the turn " +
+  "without taking any main-lane action — but the approval flow explicitly told you to " +
+  "continue through every step without pausing. Continue executing the plan now. Only " +
+  "yield if you actually need a subagent's result for the next step you are about to " +
+  "take, AND state in one sentence which step is blocked on which result.";
+
+export const PLAN_APPROVED_YIELD_RETRY_INSTRUCTION_FIRM_REF =
+  "[PLAN_YIELD]: CRITICAL: you yielded again immediately after plan approval. Continue main-lane " +
+  "execution of the approved plan. If a subagent result is genuinely required for the " +
+  "next step, perform that step's prerequisite reads inline instead of orchestrating. " +
+  "Do not yield unless a real blocker requires the user to intervene.";
+
+// ---------------------------------------------------------------------------
+// Investigative tools (in-host lines 203-217).
+// ---------------------------------------------------------------------------
+
+export const PLAN_MODE_INVESTIGATIVE_TOOL_NAMES_REF: ReadonlySet<string> = new Set([
+  "read",
+  "lcm_grep",
+  "lcm_describe",
+  "lcm_expand_query",
+  "lcm_expand",
+  "grep",
+  "glob",
+  "ls",
+  "find",
+  "web_search",
+  "web_fetch",
+  "update_plan",
+  "enter_plan_mode",
+]);
+
+// ---------------------------------------------------------------------------
+// Resolver functions (in-host lines 731-739 for planning-retry; PLAN_ACK_ONLY
+// + PLAN_YIELD resolvers are internal in-host but their shape is pinned by
+// the limit defaults: 2-tier standard→firm).
+// ---------------------------------------------------------------------------
+
+export function resolveEscalatingPlanningRetryInstructionReference(
+  attemptIndex: number,
+): string {
+  if (attemptIndex <= 0) {
+    return PLANNING_ONLY_RETRY_INSTRUCTION_REF;
+  }
+  if (attemptIndex === 1) {
+    return PLANNING_ONLY_RETRY_INSTRUCTION_FIRM_REF;
+  }
+  return PLANNING_ONLY_RETRY_INSTRUCTION_FINAL_REF;
+}
+
+export function resolveEscalatingPlanAckOnlyInstructionReference(
+  attemptIndex: number,
+): string {
+  if (attemptIndex <= 0) {
+    return PLAN_MODE_ACK_ONLY_RETRY_INSTRUCTION_REF;
+  }
+  return PLAN_MODE_ACK_ONLY_RETRY_INSTRUCTION_FIRM_REF;
+}
+
+export function resolveEscalatingPlanYieldInstructionReference(
+  attemptIndex: number,
+): string {
+  if (attemptIndex <= 0) {
+    return PLAN_APPROVED_YIELD_RETRY_INSTRUCTION_REF;
+  }
+  return PLAN_APPROVED_YIELD_RETRY_INSTRUCTION_FIRM_REF;
+}

--- a/parity-harness/runners/mutation-gate.reference.ts
+++ b/parity-harness/runners/mutation-gate.reference.ts
@@ -1,0 +1,285 @@
+/**
+ * PARITY-HARNESS VENDORED SNAPSHOT — DO NOT EDIT BY HAND.
+ *
+ * Byte-faithful copy of the in-host
+ * `src/agents/plan-mode/mutation-gate.ts` at
+ * `/Volumes/LEXAR/repos/openclaw-pr70071-rebase` commit `ea04ea52c7`.
+ * The Layer-1 parity check at `parity-harness/checks/mutation-gate.ts`
+ * runs BOTH this vendored reference AND the plugin's
+ * `src/gates/mutation-gate.ts` over the same input table and asserts
+ * byte-identical outputs.
+ *
+ * Re-capture by running:
+ *   git -C /Volumes/LEXAR/repos/openclaw-pr70071-rebase \
+ *     show ea04ea52c7:src/agents/plan-mode/mutation-gate.ts \
+ *     > parity-harness/runners/mutation-gate.reference.ts
+ * Then re-add this header AND the single import-path edit below
+ * (`./types.js` → `../../src/types.js` because the plugin's PlanMode
+ * type lives at the top-level `src/types.ts`). The rest MUST match
+ * in-host byte-for-byte.
+ *
+ * Original in-host docstring follows.
+ *
+ * ---
+ *
+ * Plan-mode mutation gate.
+ *
+ * When plan mode is active ("plan"), this hook blocks mutation tools
+ * so the agent can only read, search, and plan — not execute changes.
+ * The agent must call `exit_plan_mode` to request user approval before
+ * mutation tools become available.
+ *
+ * Design ported from PR #61845's plan-mode-hook.ts but implemented
+ * independently against current main.
+ */
+
+import type { PlanMode } from "../../src/types.js";
+
+/**
+ * Tools blocked during plan mode unless handled by a special case below
+ * (e.g. exec has a read-only prefix allowlist).
+ *
+ * PR-10 review fix (Copilot/Codex P1 #3105169112): `sessions_spawn`
+ * was previously on this blocklist, which broke the documented
+ * plan-mode workflow ("spawn research subagents during plan-mode
+ * investigation, then synthesize the plan"). Removed — subagent
+ * spawning is a research operation, not a workspace mutation. The
+ * subagent's own runtime applies its own plan-mode gate if/when
+ * needed.
+ */
+const MUTATION_TOOL_BLOCKLIST = new Set([
+  "apply_patch",
+  "bash",
+  "edit",
+  "exec",
+  "gateway",
+  "message",
+  "nodes",
+  "process",
+  "sessions_send",
+  // "sessions_spawn",  // removed per PR-10 review #3105169112
+  "subagents",
+  "write",
+]);
+
+/** Suffix patterns that also indicate mutation tools. */
+const MUTATION_SUFFIX_PATTERNS = [".write", ".edit", ".delete"];
+
+/** Suffix patterns that indicate read-only tools (bypass fail-closed default). */
+const READONLY_SUFFIX_PATTERNS = [".read", ".search", ".list", ".get", ".view"];
+
+/** Tools explicitly allowed during plan mode (bypass blocklist check). */
+const PLAN_MODE_ALLOWED_TOOLS = new Set([
+  "read",
+  "web_search",
+  "web_fetch",
+  "memory_search",
+  "memory_get",
+  "update_plan",
+  "exit_plan_mode",
+  "session_status",
+  // PR-10 review fix (Copilot/Codex P1 #3104741578 / #3104743331):
+  // ask_user_question is a planning-time clarification tool that
+  // does NOT exit plan mode and does NOT mutate workspace state. It
+  // must be in the allowlist or the entire feature is broken under
+  // the default-deny gate.
+  "ask_user_question",
+  // enter_plan_mode is also non-mutating (state transition only) and
+  // should be allowed even when called redundantly mid-plan.
+  "enter_plan_mode",
+  // sessions_spawn allowed for research-subagent flows (see comment
+  // on MUTATION_TOOL_BLOCKLIST above). Belt-and-suspenders allowlist
+  // entry in addition to the blocklist removal.
+  "sessions_spawn",
+  // Iter-3 D6 followup: read-only plan-mode introspection — must be
+  // allowed in plan mode (the most important place to call it). The
+  // tool is purely read; no state mutation. Without this entry, the
+  // default-deny gate blocks the agent from self-diagnosing while in
+  // plan mode, defeating the entire point of the introspection
+  // surface. (User-reported regression: agent called plan_mode_status
+  // mid-pending-approval and got "Tool not in plan-mode allowlist".)
+  "plan_mode_status",
+  // Read-only sessions tools — useful during plan-mode investigation
+  // and the agent shouldn't have to learn they're allowed.
+  "sessions_list",
+  "sessions_history",
+  // PR #68939 follow-up (allowlist catch-22 audit, 2026-04-22 — Eva
+  // Baoyu investigation). Originally added by commit 3d6cbda15e but
+  // a later iter-3 refactor replaced the Set literal and silently
+  // dropped these. Re-added 2026-04-26 after Eva live-blocked on
+  // sessions_yield while testing the approval/sub-agent race.
+  //
+  // - `sessions_yield`: agent calls this to suspend itself while
+  //   waiting for spawned subagents to finish. Read-only — only
+  //   signals the runtime to park this turn's promise. Without
+  //   allowlist entry, an agent that correctly used `sessions_spawn`
+  //   hits a catch-22 ("you can spawn but cannot wait"). The error
+  //   message even suggests `exit_plan_mode` which is the wrong
+  //   escape — the agent is mid-investigation, not done.
+  // - `lcm_grep` + `lcm_expand_query`: lossless-claw memory plugin
+  //   read tools (search by literal substring + query expansion).
+  //   Pure-read by design — they query the memory store and return
+  //   text matches.
+  //
+  // Excluded (intentionally NOT added): `lcm_backfill_*`,
+  // `lcm_rollup`, `lcm_migration_state` — these mutate the memory
+  // store and should NOT be allowed mid-plan-design.
+  "sessions_yield",
+  "lcm_grep",
+  "lcm_expand_query",
+]);
+
+/**
+ * Read-only exec commands allowed during plan mode.
+ * If exec is called with a command starting with one of these prefixes,
+ * the call is allowed. Otherwise exec is blocked.
+ */
+const READ_ONLY_EXEC_PREFIXES = [
+  "ls",
+  "cat",
+  "pwd",
+  "git status",
+  "git log",
+  "git diff",
+  "git show",
+  "which",
+  "find",
+  "grep",
+  "rg",
+  "head",
+  "tail",
+  "wc",
+  "file",
+  "stat",
+  "du",
+  "df",
+  "echo",
+  "printenv",
+  "whoami",
+  "hostname",
+  "uname",
+];
+
+export interface MutationGateResult {
+  blocked: boolean;
+  reason?: string;
+}
+
+/**
+ * Checks whether a tool call should be blocked during plan mode.
+ *
+ * @param toolName - The tool name being called (case-insensitive)
+ * @param currentMode - The current plan mode state
+ * @param execCommand - If the tool is `exec`, the command string to check
+ *                      against the read-only prefix whitelist
+ */
+export function checkMutationGate(
+  toolName: string,
+  currentMode: PlanMode,
+  execCommand?: string,
+): MutationGateResult {
+  // Normal mode: nothing blocked.
+  if (currentMode !== "plan") {
+    return { blocked: false };
+  }
+
+  const normalized = toolName.trim().toLowerCase();
+
+  // Explicitly allowed tools always pass.
+  if (PLAN_MODE_ALLOWED_TOOLS.has(normalized)) {
+    return { blocked: false };
+  }
+
+  // Special case: exec/bash with a read-only command prefix is allowed,
+  // but reject commands containing shell compound operators first.
+  if ((normalized === "exec" || normalized === "bash") && execCommand) {
+    const cmd = execCommand.trim().toLowerCase();
+    // Block shell compound operators, newlines, process substitution, and
+    // other metacharacters that could chain or redirect commands.
+    if (/[;|&`\n\r]|\$\(|>>?|<\(|>\(/.test(cmd)) {
+      return {
+        blocked: true,
+        reason:
+          `Tool "${toolName}" command contains shell operators or newlines and is blocked in plan mode. ` +
+          "Only simple read-only commands are allowed.",
+      };
+    }
+    // Block dangerous flags on otherwise-allowed commands.
+    // Uses word-boundary regex to avoid false matches on substrings
+    // (e.g., -executable should not match -exec). Tabs are treated as
+    // whitespace separators alongside spaces.
+    // PR-D review fix (Copilot #3096526195 / #3105045300): `find` is in
+    // the read-only prefix allowlist but several `find` flags actually
+    // write files: `-fprint <file>`, `-fprint0 <file>`, `-fprintf <file>
+    // <fmt>`, `-fls <file>`. Add to the dangerous-flag set so a command
+    // like `find . -fprint /tmp/out.txt` is blocked in plan mode rather
+    // than silently mutating the filesystem.
+    const DANGEROUS_FLAGS = [
+      "-delete",
+      "-exec",
+      "-execdir",
+      "--delete",
+      "-rf",
+      "--output",
+      "-fprint",
+      "-fprint0",
+      "-fprintf",
+      "-fls",
+    ];
+    const hasFlag = DANGEROUS_FLAGS.some((f) => {
+      const escaped = f.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      return new RegExp(`(?:^|[\\s])${escaped}(?:[\\s=]|$)`, "i").test(cmd);
+    });
+    if (hasFlag) {
+      return {
+        blocked: true,
+        reason: `Tool "${toolName}" command contains a dangerous flag and is blocked in plan mode.`,
+      };
+    }
+    const isReadOnly = READ_ONLY_EXEC_PREFIXES.some(
+      (prefix) => cmd === prefix || cmd.startsWith(prefix + " "),
+    );
+    if (isReadOnly) {
+      return { blocked: false };
+    }
+  }
+
+  // Check exact blocklist.
+  if (MUTATION_TOOL_BLOCKLIST.has(normalized)) {
+    return {
+      blocked: true,
+      reason:
+        `Tool "${toolName}" is blocked in plan mode. ` +
+        "Mutation tools stay blocked until the current plan is confirmed. " +
+        "Call exit_plan_mode after user confirmation, or revise the plan with update_plan.",
+    };
+  }
+
+  // Check suffix patterns.
+  for (const suffix of MUTATION_SUFFIX_PATTERNS) {
+    if (normalized.endsWith(suffix)) {
+      return {
+        blocked: true,
+        reason:
+          `Tool "${toolName}" matches mutation suffix pattern "${suffix}" and is blocked in plan mode. ` +
+          "Call exit_plan_mode to proceed.",
+      };
+    }
+  }
+
+  // Check read-only suffix patterns — allow MCP read tools like custom.read, data.search.
+  for (const suffix of READONLY_SUFFIX_PATTERNS) {
+    if (normalized.endsWith(suffix)) {
+      return { blocked: false };
+    }
+  }
+
+  // Default deny: unknown tools are blocked in plan mode to prevent
+  // newly added or plugin tools from bypassing the mutation gate.
+  return {
+    blocked: true,
+    reason:
+      `Tool "${toolName}" is not in the plan-mode allowlist and is blocked by default. ` +
+      "Call exit_plan_mode to proceed.",
+  };
+}

--- a/parity-harness/runners/resolve-plan-approval.reference.ts
+++ b/parity-harness/runners/resolve-plan-approval.reference.ts
@@ -1,0 +1,104 @@
+/**
+ * Vendored reference for `resolvePlanApproval`.
+ *
+ * Byte-faithful port of the in-host `resolvePlanApproval` at
+ * `src/agents/plan-mode/approval.ts` (commit `ea04ea52c7`). The plugin's
+ * `src/plan-mode/approval.ts` claims byte-identical parity; this
+ * reference exists to detect drift mechanically.
+ *
+ * The function is pure (apart from `Date.now()`), so the reference is
+ * a direct copy of the in-host source. Tests freeze `Date.now()` to a
+ * stable value in both the reference and plugin runner so the
+ * `updatedAt` / `confirmedAt` fields don't differ for clock reasons.
+ *
+ * Anti-pattern guardrail: do NOT update this by reading the plugin
+ * source. It must come from the in-host. Re-capture by running
+ * `git -C /Volumes/LEXAR/repos/openclaw-pr70071-rebase show ea04ea52c7:src/agents/plan-mode/approval.ts`
+ * and copy the function verbatim.
+ *
+ * host_ref: src/agents/plan-mode/approval.ts:36-145 (commit ea04ea52c7)
+ */
+
+import type { PlanModeSessionState } from "../../src/types.js";
+
+export function resolvePlanApprovalReference(
+  current: PlanModeSessionState,
+  action: "approve" | "edit" | "reject" | "timeout",
+  feedback?: string,
+  expectedApprovalId?: string,
+  /**
+   * Frozen clock for deterministic test output. Real in-host uses
+   * `Date.now()`; we inject a clock so reference and plugin observe the
+   * same timestamp and the `updatedAt` / `confirmedAt` fields stay
+   * comparable across runners.
+   */
+  now: number = Date.now(),
+): PlanModeSessionState {
+  // Stale-event guard.
+  if (expectedApprovalId !== undefined) {
+    if (current.approvalId === undefined || expectedApprovalId !== current.approvalId) {
+      return current;
+    }
+  }
+
+  // Terminal-state guard. Approved, edited, and timed_out are terminal;
+  // rejected stays open for re-approval. None-state blocks Approve/Edit/Reject
+  // when no token supplied (the expectedApprovalId branch above handles the
+  // tokened case).
+  if (current.approval !== "pending" && current.approval !== "rejected") {
+    return current;
+  }
+  if (action === "timeout" && current.approval !== "pending") {
+    return current;
+  }
+
+  switch (action) {
+    case "approve":
+      return {
+        ...current,
+        mode: "normal",
+        approval: "approved",
+        confirmedAt: now,
+        updatedAt: now,
+        feedback: undefined,
+        rejectionCount: 0,
+      };
+
+    case "edit":
+      return {
+        ...current,
+        mode: "normal",
+        approval: "edited",
+        confirmedAt: now,
+        updatedAt: now,
+        feedback: undefined,
+        rejectionCount: 0,
+      };
+
+    case "reject":
+      return {
+        ...current,
+        mode: "plan",
+        approval: "rejected",
+        confirmedAt: undefined,
+        updatedAt: now,
+        feedback: feedback ?? current.feedback,
+        rejectionCount: (current.rejectionCount ?? 0) + 1,
+      };
+
+    case "timeout":
+      return {
+        ...current,
+        mode: "plan",
+        approval: "timed_out",
+        confirmedAt: undefined,
+        updatedAt: now,
+        feedback: undefined,
+      };
+
+    default: {
+      const _exhaustive: never = action;
+      return current;
+    }
+  }
+}

--- a/parity-harness/runners/runtime-reject-and-plan-steps.reference.ts
+++ b/parity-harness/runners/runtime-reject-and-plan-steps.reference.ts
@@ -1,0 +1,73 @@
+/**
+ * Vendored references for the runtime reject-injection builder + the
+ * `planSteps → injection lines` mapper. Both are pure functions ported
+ * inline from the in-host source-of-truth at commit `ea04ea52c7`.
+ *
+ * # buildPlanRuntimeRejectInjection
+ *
+ * From `src/gateway/sessions-patch.ts:1045-1050` (the live runtime reject
+ * emit site). Wave-1 finding W1-D1 — earlier the plugin wired
+ * `buildPlanDecisionInjection` as the reject emitter which produced
+ * extra instruction lines + JSON-quoted feedback + a different sanitizer.
+ * The runtime form is much thinner:
+ *
+ *   - 1 line if no feedback: `[PLAN_DECISION]: rejected`
+ *   - 2 lines if feedback:   `[PLAN_DECISION]: rejected\nfeedback: <raw, mention-stripped>`
+ *
+ * Sanitization (from sessions-patch.ts:1045-1047):
+ *   1. `@(channel|here|everyone)\b` → `@﹫$1`
+ *   2. `<@` → `<​@`
+ *
+ * # planStepsToInjectionLines
+ *
+ * From `src/gateway/sessions-patch.ts:1001-1003`. Maps a step's
+ * `activeForm` (or fallback to the bare `step`) into the per-line
+ * injection text. Wave-1 finding W1-D2 — earlier the plugin appended
+ * `status` enum instead of `activeForm`, surfacing the wrong label on
+ * resumed/re-approved plans.
+ *
+ * host_ref:
+ *   - sessions-patch.ts:1045-1050 (reject form)
+ *   - sessions-patch.ts:1001-1003 (planSteps → lines)
+ */
+
+import type { PlanStep } from "../../src/types.js";
+
+/**
+ * In-host runtime reject sanitizer. Byte-faithful port of the inline
+ * sanitization at sessions-patch.ts:1045-1047 — the chained `.replace`
+ * calls applied to `feedback ?? ""`.
+ */
+function sanitizeRuntimeRejectFeedbackReference(raw: string): string {
+  return raw
+    .replace(/@(channel|here|everyone)\b/gi, "@\u{FE6B}$1")
+    .replace(/<@/g, "<\u{200B}@");
+}
+
+/**
+ * Build the in-host runtime reject injection text. At most 2 lines.
+ *
+ * host_ref: src/gateway/sessions-patch.ts:1048-1050 (commit ea04ea52c7)
+ */
+export function buildPlanRuntimeRejectInjectionReference(
+  feedback?: string,
+): string {
+  const safeFeedback = sanitizeRuntimeRejectFeedbackReference(feedback ?? "");
+  return safeFeedback
+    ? `[PLAN_DECISION]: rejected\nfeedback: ${safeFeedback}`
+    : `[PLAN_DECISION]: rejected`;
+}
+
+/**
+ * Map plan steps to injection lines — uses `activeForm` when present,
+ * otherwise the bare `step`.
+ *
+ * host_ref: src/gateway/sessions-patch.ts:1001-1003 (commit ea04ea52c7)
+ */
+export function planStepsToInjectionLinesReference(
+  steps: PlanStep[],
+): string[] {
+  return steps.map((step) =>
+    step.activeForm ? `${step.step} (${step.activeForm})` : step.step,
+  );
+}

--- a/parity-harness/runners/sanitize-and-approval-id.reference.ts
+++ b/parity-harness/runners/sanitize-and-approval-id.reference.ts
@@ -1,0 +1,40 @@
+/**
+ * Vendored reference for `sanitizeFeedbackForInjection` +
+ * `newPlanApprovalId`.
+ *
+ * Both are byte-for-byte ports of the in-host
+ * `src/agents/plan-mode/types.ts:104-160` at commit `ea04ea52c7`. The
+ * sanitize function is pure → trivially vendored. The approvalId
+ * minter is essentially crypto-RNG-driven; we vendor the SHAPE check
+ * (the `plan-${uuid}` regex), then verify the plugin's output matches
+ * the regex byte-for-byte.
+ *
+ * host_ref:
+ *   - sanitize: src/agents/plan-mode/types.ts:158-160
+ *   - newPlanApprovalId: src/agents/plan-mode/types.ts:113-148
+ *
+ * Anti-pattern guardrail: re-capture from in-host if it changes. Do
+ * not mirror plugin source.
+ */
+
+/**
+ * In-host sanitize function — byte-for-byte port. The U+200B
+ * (zero-width space) byte at offset 1 inside the replacement is the
+ * security contract.
+ */
+export function sanitizeFeedbackForInjectionReference(raw: string): string {
+  return raw.replace(/\[\/PLAN_DECISION\]/gi, "[​/PLAN_DECISION]");
+}
+
+/**
+ * The canonical regex an approvalId must match. Matches the in-host
+ * `isPlanApprovalId` shape check at `types.ts` (and the plugin's
+ * `helpers/approval-id.ts:isPlanApprovalId`). Lowercase hex,
+ * 8-4-4-4-12, prefixed `plan-`.
+ *
+ * The exact format is part of the security contract — the runtime
+ * compares approvalIds for staleness via the regex's shape. A
+ * different format would silently fail-open every approval check.
+ */
+export const PLAN_APPROVAL_ID_SHAPE_REF =
+  /^plan-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;

--- a/src/ui/session-actions.ts
+++ b/src/ui/session-actions.ts
@@ -74,7 +74,7 @@ import type { PlanStep } from "../types.js";
  *   `(next.planMode?.lastPlanSteps ?? []).map((step) =>
  *     step.activeForm ? \`${step.step} (${step.activeForm})\` : step.step)`
  */
-function planStepsToInjectionLines(steps: PlanStep[]): string[] {
+export function planStepsToInjectionLines(steps: PlanStep[]): string[] {
   return steps.map((step) =>
     step.activeForm ? `${step.step} (${step.activeForm})` : step.step,
   );

--- a/tests/parity/parity-harness.test.ts
+++ b/tests/parity/parity-harness.test.ts
@@ -1,36 +1,135 @@
 /**
  * Vitest wrapper around the parity harness.
  *
- * Runs every case in `inputs/persistApprovalRequest.json` through both
- * runners and asserts byte-identical outcomes. CI gate: `pnpm test`
- * fails on any drift.
+ * Runs every registered Layer-1 check and asserts ZERO byte-level
+ * drift from the in-host reference. CI gate: `pnpm test` AND the
+ * dedicated `pnpm parity-harness` script both fail on any divergence.
  *
- * This test is intentionally one-massive-assertion: a per-case loop
- * with descriptive failure messages so the report shows EVERY case
- * that diverged, not just the first.
+ * # Per-check it() blocks
+ *
+ * Wave-2 expansion: each check gets its own `it()` block so a failure
+ * cluster surfaces against the OWNING surface — not a single
+ * aggregated `it()` that hides what diverged. The bottom sanity
+ * `it()` cross-checks aggregate counts.
  */
 
 import { describe, expect, it } from "vitest";
 import { runParityCheck } from "../../parity-harness/diff.js";
+import type { CheckReport } from "../../parity-harness/checks/types.js";
 
-describe("P-3.5 parity harness — Layer 1 (persistApprovalRequest)", () => {
-  it("plugin's PlanModeStore matches the in-host reference across all input cases", async () => {
-    const report = await runParityCheck();
+const REPORT_PROMISE = runParityCheck();
 
+async function getCheckReport(name: string): Promise<CheckReport> {
+  const report = await REPORT_PROMISE;
+  const found = report.checkReports.find((r) => r.name === name);
+  if (!found) {
+    throw new Error(
+      `Layer-1 parity-harness has no check named "${name}". Registered: ${report.checkReports
+        .map((r) => r.name)
+        .join(", ")}`,
+    );
+  }
+  return found;
+}
+
+function assertReportClean(report: CheckReport): void {
+  const failing = report.cases.filter((c) => !c.ok);
+  if (failing.length > 0) {
+    const detail = failing
+      .map(
+        (f) =>
+          `\n  ✗ ${f.caseId}: ${f.description}\n    ${f.diff}`,
+      )
+      .join("");
+    throw new Error(
+      `Parity check [${report.name}]: ${failing.length}/${report.cases.length} cases diverged from in-host reference.\n${detail}`,
+    );
+  }
+}
+
+describe("Layer-1 parity harness — persistApprovalRequest", () => {
+  it("plugin's PlanModeStore.persistApprovalRequest matches in-host across all cases", async () => {
+    const r = await getCheckReport("persistApprovalRequest");
+    expect(r.cases.length).toBeGreaterThanOrEqual(10);
+    assertReportClean(r);
+  });
+});
+
+describe("Layer-1 parity harness — resolvePlanApproval", () => {
+  it("plugin's resolvePlanApproval matches in-host across all cases", async () => {
+    const r = await getCheckReport("resolvePlanApproval");
+    expect(r.cases.length).toBeGreaterThanOrEqual(10);
+    assertReportClean(r);
+  });
+});
+
+describe("Layer-1 parity harness — acceptEditsGate", () => {
+  it("plugin's checkAcceptEditsConstraint matches in-host across destructive / self-restart / config-change / protected-path cases", async () => {
+    const r = await getCheckReport("acceptEditsGate");
+    expect(r.cases.length).toBeGreaterThanOrEqual(25);
+    assertReportClean(r);
+  });
+});
+
+describe("Layer-1 parity harness — escalatingRetry", () => {
+  it("plugin's escalating-retry resolvers + constant strings match in-host byte-for-byte", async () => {
+    const r = await getCheckReport("escalatingRetry");
+    expect(r.cases.length).toBeGreaterThanOrEqual(20);
+    assertReportClean(r);
+  });
+});
+
+describe("Layer-1 parity harness — sanitizeAndApprovalId", () => {
+  it("plugin's sanitizeFeedbackForInjection + newPlanApprovalId match in-host", async () => {
+    const r = await getCheckReport("sanitizeAndApprovalId");
+    expect(r.cases.length).toBeGreaterThanOrEqual(15);
+    assertReportClean(r);
+  });
+});
+
+describe("Layer-1 parity harness — prompts (closes W1-D3)", () => {
+  it("plugin's prompt artifacts match in-host byte fixtures (closes W1-D3 — no byte fixture pinned prompts before)", async () => {
+    const r = await getCheckReport("prompts");
+    // 4 fixtures: PLAN_ARCHETYPE_PROMPT, PLAN_MODE_REFERENCE_CARD,
+    // plan-mode-active, plan-mode-available.
+    expect(r.cases.length).toBe(4);
+    assertReportClean(r);
+  });
+});
+
+describe("Layer-1 parity harness — mutationGate", () => {
+  it("plugin's checkMutationGate matches in-host across allowlist / blocklist / exec-prefix / dangerous-flag / suffix-pattern cases", async () => {
+    const r = await getCheckReport("mutationGate");
+    expect(r.cases.length).toBeGreaterThanOrEqual(25);
+    assertReportClean(r);
+  });
+});
+
+describe("Layer-1 parity harness — runtimeRejectAndPlanSteps (bonus W1-D1 + W1-D2)", () => {
+  it("buildPlanRuntimeRejectInjection + planStepsToInjectionLines match in-host", async () => {
+    const r = await getCheckReport("runtimeRejectAndPlanSteps");
+    expect(r.cases.length).toBeGreaterThanOrEqual(10);
+    assertReportClean(r);
+  });
+});
+
+describe("Layer-1 parity harness — aggregate", () => {
+  it("total case count meets the wave-2 floor + every case is parity-clean", async () => {
+    const report = await REPORT_PROMISE;
     if (report.failingCases > 0) {
-      const detail = report.failures
-        .map(
-          (f) =>
-            `\n  ✗ ${f.caseId}: ${f.description}\n    ${f.diffSummary}`,
-        )
-        .join("");
+      // Re-raise via the per-check assertions; this is the safety net
+      // if a new check is added but its describe block was forgotten.
+      const failing = report.checkReports.flatMap((r) =>
+        r.cases.filter((c) => !c.ok).map((c) => `[${r.name}] ${c.caseId}`),
+      );
       throw new Error(
-        `Parity harness Layer 1: ${report.failingCases}/${report.totalCases} cases diverged from in-host reference.\n${detail}`,
+        `Aggregate failure: ${report.failingCases}/${report.totalCases} cases diverged. Affected: ${failing.join(", ")}`,
       );
     }
-
     expect(report.failingCases).toBe(0);
     expect(report.passingCases).toBe(report.totalCases);
-    expect(report.totalCases).toBeGreaterThanOrEqual(10); // sanity: input table must have ≥10 cases
+    // Wave-2 floor: the harness must have at least the persist + 7 new
+    // checks worth of cases (~100 total) so the CI gate has real teeth.
+    expect(report.totalCases).toBeGreaterThanOrEqual(100);
   });
 });


### PR DESCRIPTION
Wave 2 deliverable. Closes #106. Closes W1-D3 (the missing byte-fixture test for prompt artifacts).

Extends the parity harness from 1 check → 8 checks, 156 input cases. Every plugin surface fixed in Wave 3 is now mechanically pinned against the in-host reference at `ea04ea52c7`. Any byte-level drift fails CI.

Coverage:
- `resolvePlanApproval`, `acceptEditsGate` (32), `escalatingRetry` (30), `sanitizeAndApprovalId` (19), `mutationGate` (33)
- **Prompt byte fixtures** (closes W1-D3): `PLAN_ARCHETYPE_PROMPT`, `PLAN_MODE_REFERENCE_CARD`, both `buildPlanMode*SystemContext()` outputs — captured from in-host via `capture.ts` script for deterministic regeneration.
- Bonus pins for W1-D1 (`buildPlanRuntimeRejectInjection`) + W1-D2 (`planStepsToInjectionLines` activeForm logic) — prevents regression of just-fixed findings.

**CI gate verified** by the sub-agent: perturb a pinned string → harness fails → step exits 1 (no `tee` masking — the Wave-0 lesson sticks).

**No RED drifts found** during build — every targeted surface is currently byte-identical to in-host. The harness locks it in mechanically.

Layers 2–3 (gateway scenario diff + drift cron) remain future work per the original harness design.

## Test plan
- [x] typecheck clean; `pnpm parity-harness` 156/156; `pnpm test` 845/845
- [x] CI gate fail-on-drift verified locally by sub-agent
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive parity harness framework with automated checks for critical system components including gates, approval flows, plan mode logic, and sanitization behaviors.
  * Integrated Wave-2 parity validation as a hard gate in CI workflow.
  * Added extensive test case datasets covering normal, edge, and security-sensitive scenarios.

* **Chores**
  * Added host snapshot documentation and reference fixtures to enable deterministic parity verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/Smarter-Claw/pull/118?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->