### PR TITLE
Wave 4: cross-platform — W1-F5 implemented + W1-F3 blocker (consolidates with F1)

### DIFF
--- a/docs/audits/parity-refresh/EXECUTION-STATUS.md
+++ b/docs/audits/parity-refresh/EXECUTION-STATUS.md
@@ -21,7 +21,7 @@ complete, quality at-or-above Codex / Claude Code plan mode.
 | 1 | Parity re-audit + build-specs + Codex/CC benchmark | ✅ **merged (PR #98)** |
 | 2 | Parity harness Layer 1 (mechanical drift CI gate) | ⏳ needs isolated re-run |
 | 3 | Fix all P0/P1 findings | ▶ **in progress** — batch 1 merged-pending (PR #99) |
-| 4 | Cross-platform build (Telegram + Slack) | ⬜ pending |
+| 4 | Cross-platform build (Telegram + Slack) | ▶ **in progress** — F5 implemented, F3 deferred (SDK blocker, same as F1) |
 | 5 | Webchat inline UI + patcher | ⬜ pending (upstream-blocked) |
 | 6 | Final adversarial + 3-channel smoke + release | ⬜ pending |
 
@@ -81,8 +81,28 @@ Fix sequentially, one focused PR per cluster. IDs reference
 | ui | W1-S9-1 (sidebar schema omits 5 fields), W1-S18-1 (Telegram 100-cmd menu hides `/plan`), W1-B4 (accept-edits trigger has no CI test) | `src/ui/*`, `index.ts` |
 | benchmark gaps | W1-F1 (no action-required notification — P0), W1-F2 (prompt promises a `plan-*.md` no code writes — P0), W1-F4 (`/plan auto` dead toggle) | `src/ui/session-actions.ts`, `src/prompt/*`, `index.ts` |
 
-**Deferred to Wave 4** (cross-platform, not Wave-3 port-bugs): W1-F3
-(multi-surface approval), W1-F5 (`/plan answer` cross-surface).
+**Wave 4 (cross-platform — Telegram + Slack)** status as of 2026-05-20:
+- W1-F3 (multi-surface approval push) — **deferred — SDK blocker (same
+  as W1-F1)**. See `blocker-W1-F3.md`. Every push-to-channel SDK seam
+  is `bundled-plugin-only` on `2026.5.18`. Resolution path (`/plan
+  accept|reject|cancel|edit|answer`) ALREADY works on every channel
+  via the universal text pipeline; the gap is the PROACTIVE PUSH (the
+  "your plan is ready" message), which needs the same upstream SDK
+  change as F1 (R1/R2/R3). Files updated upstream issue: one PR
+  covers both findings.
+- W1-F5 (`/plan answer` cross-surface) — **IMPLEMENTED**. Added
+  `PendingQuestion` field to `PlanModeSessionState`; added
+  `PlanModeStore.persistPendingQuestion` + `clearPendingQuestion`
+  mutators; wired `ask_user_question` tool body to persist on
+  success; wired `/plan answer <text>` in `slash-commands.ts` to
+  read persisted state + dispatch `plan.answer`. Idempotency: store
+  clears slot on dispatch success; injection-writer dedups on
+  `questionId`. Membership guard (`allowFreetext === false` →
+  answer must be in `options`) mirrors in-host
+  `sessions-patch.ts:721-732`. New tests: store +9, slash-commands
+  +8 (replacing 1 known-gap test), ask-user-question +6. 868 total
+  tests green.
+
 **~30 P2s**: triage during/after Wave 3 — fix-now vs defer-with-issue.
 
 ---

--- a/docs/audits/parity-refresh/blocker-W1-F3.md
+++ b/docs/audits/parity-refresh/blocker-W1-F3.md
@@ -1,0 +1,312 @@
+# Blocker — W1-F3 (P1) multi-surface approval push on Telegram/Slack
+
+**Status:** **blocked — same SDK gap as W1-F1.** The audit's claim
+"Inline cards are upstream-SDK-blocked; a channel ping is not" rests
+on a delivery affordance that does not exist for 3P plugins. The only
+SDK seams that would let the plugin push an action-required
+notification to Telegram/Slack — `sendSessionAttachment` and
+`emitAgentEvent` on host-owned streams (`approval`, `lifecycle`,
+`assistant`, etc.) — both reject 3P plugins at call time on
+`openclaw@2026.5.18`. F3 inherits the W1-F1 verdict.
+
+**Issue:** W1-F3 in `wave-1-catalog.md` line 98.
+
+**Decision date:** 2026-05-20.
+
+**Investigator:** parity-refresh Wave-4 worker (read-only against
+in-host `/Users/lume/repos/openclaw-pr70071-rebase` tip `ea04ea52c7`
+via the openclaw-1 worktree; plugin against the working tree on the
+same date; SDK `openclaw@2026.5.18` per
+`/Users/lume/repos/Smarter-Claw/package.json:openclaw`).
+
+## Audit's claim, restated
+
+`wave-1-catalog.md` row W1-F3 (line 98):
+
+> "**W1-F3** | missing-feature | No multi-surface approval —
+> Approve/Edit/Reject buttons are sidebar-only. Telegram/Slack users
+> get no interactive card. (Inline cards are upstream-SDK-blocked; a
+> channel ping is not.)"
+
+The first half (no inline buttons → upstream-SDK-blocked) is
+**correct** — `docs/audits/parity-refresh/buildspec-S16-channel-native.md`
+§2 already documents the missing
+`registerChannelInteractiveHandler` seam. The Path-A spec there
+(rich text-command UX + attachment bridge) is the shippable scope.
+
+The second half (a channel ping IS unblocked) is **wrong** on the
+same SDK as W1-F1. The "ping" the audit envisions (a synchronous
+"plan ready for your approval" message pushed to the Telegram chat /
+Slack workspace at the moment the plan goes pending) needs the SAME
+two SDK affordances W1-F1 needs, and runs into the SAME two
+restrictions. The investigation below records what was checked, the
+empirical evidence in the installed runtime, and a recommendation
+that consolidates with the W1-F1 / S16-U upstream PR work.
+
+## What the in-host does today
+
+`/Users/lume/repos/openclaw-pr70071-rebase` at `ea04ea52c7` (verified
+via the `openclaw-1` worktree's `git show ea04ea52c7:<path>`):
+
+- **Cross-channel push for plan-pending lives in
+  `src/agents/plan-mode/plan-archetype-bridge.ts:124-200`** —
+  `dispatchPlanArchetypeAttachment`. Mirror-image of the W1-F1
+  blocker's §"What the in-host does today":
+  1. Renders the plan archetype as markdown
+     (`renderFullPlanArchetypeMarkdown`).
+  2. Persists it to `~/.openclaw/agents/<agentId>/plans/` (always).
+  3. Reads `deliveryContext` for the originating session. If channel
+     is **`telegram`** AND `to` is present, calls
+     `sendDocumentTelegram(dctx.to, absPath, { caption, parseMode:
+     "HTML" })`. The caption ends with
+     `/plan accept | /plan accept edits | /plan revise <feedback>`
+     (built by `buildPlanAttachmentCaption` at lines 64-87).
+  4. **All other channels (Slack, Matrix, Discord, etc.) — falls
+     silent at the `dctx.channel !== "telegram"` guard.**
+- **Call site**: `src/agents/pi-embedded-subscribe.handlers.tools.ts:1935-1949`
+  void-fires `dispatchPlanArchetypeAttachment` immediately after
+  `emitAgentApprovalEvent`. The approval event itself goes to UI
+  subscribers (Codex app-server, webchat); channels are NOT subscribed
+  to the `approval` stream (re-verified — `git show
+  ea04ea52c7:extensions/telegram/` + `extensions/slack/` carry no
+  `onAgentEvent` / `registerAgentEventSubscription` matches against
+  the `approval` stream).
+- **Slack on the in-host gets no signal either.** "Match in-host
+  parity" for W1-F3 = matching Telegram (one channel) and inheriting
+  the Slack/Matrix/Discord silence the in-host itself ships.
+
+**Net**: in-host action-required for plan-mode on a messaging channel
+= `sendDocumentTelegram` to the originating Telegram chat. Full stop.
+Same conclusion as W1-F1.
+
+## What SDK seams are available to the plugin
+
+Re-verified against
+`/Users/lume/repos/Smarter-Claw/node_modules/openclaw/dist/plugin-sdk/`
+on `2026.5.18` (identical landscape to W1-F1; pointers below are
+spot-checks, full taxonomy lives in `blocker-W1-F1.md` §"What SDK
+seams are available to the plugin"):
+
+### 1. `api.session.workflow.sendSessionAttachment` — bundled-only
+
+- **Type** (`host-hooks.d.ts:186-204`):
+  ```ts
+  export type PluginSessionAttachmentParams = {
+    sessionKey: string;
+    files: PluginSessionAttachmentFile[];  // REQUIRED, ≥1
+    text?: string;
+    threadId?: string | number;
+    forceDocument?: boolean;
+    maxBytes?: number;
+    captionFormat?: PluginSessionAttachmentCaptionFormat;
+    channelHints?: PluginAttachmentChannelHints;  // telegram.parseMode, slack.threadTs
+  };
+  ```
+- **Runtime gate** (installed loader at
+  `node_modules/openclaw/dist/loader-CxUWY2_6.js`): confirmed via
+  `grep -o "session attachments are restricted[^\"]*"` — literal
+  error string `session attachments are restricted to bundled plugins`
+  is in the shipped bundle.
+- Smarter-Claw is a 3P plugin (`PluginOrigin = "global" | "workspace"`),
+  call returns `{ ok: false, error }` 100% of the time. Same exact
+  blocker that stops W1-F1 from sending the markdown.
+
+### 2. `api.agent.events.emitAgentEvent` — `approval` stream reserved
+
+- **Runtime gate** (installed loader): `HOST_OWNED_AGENT_EVENT_STREAMS`
+  Set contains `approval` (+ `lifecycle`, `tool`, `assistant`, etc.) —
+  re-verified via `grep -o "HOST_OWNED_AGENT_EVENT_STREAMS = new Set"`.
+  Error message `reserved for bundled plugins` is in the shipped
+  bundle.
+- 3P plugins can only emit `stream: "smarter-claw"` / `"smarter-claw.*"`
+  scoped streams. Telegram/Slack channel handlers do not subscribe to
+  those — they would need new channel-side subscriptions, which is
+  itself an upstream-SDK ask.
+
+### 3. `api.session.workflow.scheduleSessionTurn` — wrong tool
+
+- Same five-fold problem documented in `blocker-W1-F1.md` §3 (latency,
+  token cost, probabilistic compliance, cooldown collision, no native
+  push). Specifically for F3: scheduling a turn to "tell the user the
+  plan is ready" would conflict with the plugin's
+  `tool-descriptions.ts:71` rule that the agent must STOP after
+  `exit_plan_mode`. Not a fit.
+
+### 4. The plugin's existing surfaces — already used or inapplicable
+
+- `registerControlUiDescriptor` — already wired
+  (`src/ui/sidebar-descriptor.ts`). Covers webchat / Codex desktop;
+  does not reach Telegram/Slack. This IS the "buttons are
+  sidebar-only" observation the audit cites.
+- `registerCommand` — already wired (`src/ui/slash-commands.ts`).
+  `/plan accept|reject|cancel|edit|...` work on every channel via the
+  universal text pipeline. This IS the resolution-side that the
+  audit's parenthetical "channel ping is not [blocked]" was meant to
+  complement. The resolution path works today; the PUSH (proactive
+  "you have a plan waiting" signal) is what F3 asks for and is what's
+  blocked.
+- `registerAgentEventSubscription` — read-side, not write-side. The
+  plugin can OBSERVE host-emitted events; it cannot emit on
+  host-owned streams (#2 above).
+- `registerChannel` — would register a new channel plugin
+  (Smarter-Claw as a Telegram provider). Architecturally wrong and
+  out of scope.
+
+## Why the audit's "channel ping is not [blocked]" assumption fails
+
+The audit's parenthetical relied on a model where the plugin can call
+a "send a short message to this session's channel" method
+synchronously, with no per-channel adapter glue, no bundled gate, and
+no host-owned-stream restriction. **No such method exists in
+`2026.5.18` for a 3P plugin.** Every plausible candidate either
+rejects 3P origins (`sendSessionAttachment`), restricts the stream
+(`emitAgentEvent` to `approval`/`lifecycle`/...), or is the wrong
+tool (`scheduleSessionTurn` is a cron-driven agent-turn injector, not
+a chat-message emitter; `enqueueNextTurnInjection` writes a synthetic
+USER message into the next turn — the agent then has to choose to
+RESPOND with a notification, same probabilistic / cooldown failure
+mode as `scheduleSessionTurn`).
+
+## What the plugin already does for visibility (W1-F2)
+
+The W1-F2 markdown persister already lands at
+`src/tools/exit-plan-mode.ts:627-648` (via
+`persistPlanArchetypeIfConfigured` at line 799 → calls
+`persistPlanArchetypeMarkdown` from
+`src/plan-mode/plan-archetype-persist.ts`). The plugin DOES write the
+`plan-YYYY-MM-DD-<slug>.md` audit artifact every approval cycle. What
+it cannot do is PUSH that file (or a "your plan is ready" caption) to
+the originating channel — that's exactly the W1-F1 / F3 gap.
+
+The plugin's `src/tools/exit-plan-mode.ts:610-626` comment block
+explicitly documents this asymmetry: "the persisted markdown WRITTEN
+below is the building block a future host-side or bundled-capability
+notifier would attach. Today, Telegram/Slack users get no signal —
+the same gap the in-host has on non-Telegram channels."
+
+## Recommendation
+
+**Defer to the same upstream SDK changes as W1-F1.** Three options
+ranked by plugin-side change footprint:
+
+### R1 (preferred) — lift the `bundled` gate on `sendSessionAttachment`
+
+- **Host change**: drop or soften the `origin !== "bundled"` rejection
+  in the in-host `src/plugins/host-hook-attachments.ts:216-218`.
+  Replace with a per-plugin capability that the operator opts into at
+  install time (manifest field
+  `capabilities: ["sendSessionAttachment"]`).
+- **Plugin code unlocked by R1** (~40 LOC total, F1 + F3 combined):
+  ```ts
+  // In src/tools/exit-plan-mode.ts, right after persistPlanArchetypeIfConfigured:
+  if (r.kind === "persisted" && opts.attachmentNotifier && absPath) {
+    void opts.attachmentNotifier.send({
+      sessionKey,
+      files: [{ path: absPath }],
+      text: buildPlanAttachmentCaption(title, summary),
+      channelHints: { telegram: { parseMode: "HTML" } },
+    });
+  }
+  ```
+  Dedup is automatic (fires once per `r.kind === "persisted"` —
+  matching the W1-F2 persister's once-per-cycle guard). Resume safety
+  is automatic (W1-F2's existing in-cycle idempotency carries through).
+  **Cooldown/dedup invariant**: the action-required signal fires
+  exactly once per `approvalId` because `persistApprovalRequest`'s
+  invariant 3 + 7 (`lastPlanPayloadHash` idempotency) returns
+  `kind: "reused"` on a duplicate `exit_plan_mode` — the F3 push and
+  the F2 persist share the same trigger boundary.
+- **Result**: Telegram users get a Telegram document push (matches
+  in-host today). Slack users get a Slack file upload (BETTER than
+  in-host today). Webchat users still see the sidebar (unchanged).
+  Both W1-F1 and W1-F3 close in the same PR.
+
+### R2 — add a plan-specific approval-channel push seam
+
+- New SDK method `api.session.workflow.sendActionRequiredNotice({
+  sessionKey, kind: "plan_approval", message, actions?: [{label,
+  command}] })`. Host adapter routes per-channel: Telegram → text
+  message with HTML buttons; Slack → blocks API with action buttons;
+  webchat → reuses the existing approval-card; CLI → terminal bell.
+  The plugin emits ONE call; the host fans out.
+- More host code than R1 (per-channel adapters) but avoids giving 3P
+  plugins generic attachment access. Composes with the S16-U
+  "interactive callback" upstream PR
+  (`buildspec-S16-channel-native.md` §3 Path B) — R2's
+  `actions: [{label, command}]` payload becomes the entry-point for
+  true tappable buttons once S16-U lands.
+
+### R3 — host emits the notification on the plugin's behalf
+
+- Move the `dispatchPlanArchetypeAttachment` equivalent into the
+  host, triggered when a `session.state` extension with
+  `planMode.approval === "pending"` is written. The plugin owns
+  state + tool; the host owns delivery. No plugin code change for F3.
+- Highest decoupling, hardest to ship (cross-cuts host concerns the
+  in-host today keeps in the plan-mode runtime).
+
+### Interim posture this PR ships
+
+**Pure documentation. No production code change for F3.**
+
+1. **This blocker doc**. The honest record.
+2. **The W1-F2 markdown persister stays.** It is the artifact that
+   R1/R2/R3 would attach.
+3. **The W1-F1 comment block in `src/tools/exit-plan-mode.ts:610-626`
+   already covers F3.** Both findings deferred to the same set of
+   upstream paths. No additional in-code comment needed.
+
+User-facing reality today:
+- **Resolution (response) works everywhere.** `/plan accept|edit|
+  reject|cancel|auto` are routed through `src/ui/slash-commands.ts`
+  and dispatch to the existing session-action handlers — works on
+  Telegram, Slack, Discord, webchat, CLI via the universal text
+  pipeline.
+- **Push (proactive signal) only works on webchat.** Sidebar
+  descriptor renders the approval card. Other channels see no
+  "action-required" message at the moment the plan goes pending.
+  Users on those channels must either (a) check the sidebar
+  separately or (b) be told by the agent (the
+  `agentPromptGuidance` field in `createPlanSlashCommand`
+  documents `/plan accept | reject` so the agent can surface the
+  commands in its assistant text, but the agent's
+  `exit_plan_mode` tool description tells it to STOP AFTER the
+  call — so there's no agent text in the same turn for the user
+  to read).
+- **R1 closes the gap with ~40 LOC of plugin code + a host PR.**
+  The same upstream change unblocks both findings.
+
+## Tracking
+
+- W1-F3 row in `wave-1-catalog.md` (line 98): the wave-1 catalog
+  already correctly classifies this as `missing-feature` P1. Severity
+  is unchanged. The "channel ping is not [blocked]" parenthetical was
+  the optimistic interpretation; this doc records the empirical
+  refutation.
+- `EXECUTION-STATUS.md`: mark W1-F3 as "deferred — SDK blocker (same
+  as W1-F1)" with a link to this doc.
+- **Upstream issue**: the SDK-change request filed for W1-F1 (R1) is
+  the same change. **Do not file a separate upstream PR for F3** —
+  they share the seam and the rationale. Add F3 as an additional
+  consumer in the F1 issue's description.
+
+## Lessons
+
+- **`bundled-plugin-only` runtime gates cluster.** When one parity
+  finding hits a `bundled-plugin-only` SDK seam, all sibling findings
+  that depend on the same seam (push to channel, emit on host stream,
+  decorate built-in channel) are blocked by the same change. Audit
+  pass-2 should grep `origin !== "bundled"` in the installed loader
+  bundle (`node_modules/openclaw/dist/loader-*.js`) up front and
+  collect ALL findings that share the constraint.
+- **The audit's "channel ping is not blocked" was a thinking shortcut
+  that assumed a primitive the SDK doesn't expose.** Same as W1-F1's
+  "no new SDK seam needed" — the parity audit needs an
+  SDK-seam-feasibility pass on every "wire X" recommendation BEFORE
+  the catalog rows are scoped as P0/P1.
+- **In-host parity has a Telegram-shaped ceiling for F3.** "Match the
+  in-host" means matching Telegram and inheriting Slack/Matrix/Discord
+  silence. R2 (the new push seam) is the better long-term answer
+  because it lifts the in-host's own ceiling. R1 (lift the bundled
+  gate) is the cheapest answer that still gives Slack parity-or-better
+  (Slack file upload >> in-host's Slack silence).

--- a/docs/audits/parity-refresh/wave-1-catalog.md
+++ b/docs/audits/parity-refresh/wave-1-catalog.md
@@ -95,9 +95,9 @@ pattern: file-level copying without integration.
 
 | ID | Type | Description |
 |---|---|---|
-| **W1-F3** | missing-feature | No multi-surface approval — Approve/Edit/Reject buttons are sidebar-only. Telegram/Slack users get no interactive card. (Inline cards are upstream-SDK-blocked; a channel ping is not.) |
+| **W1-F3** | missing-feature | No multi-surface approval — Approve/Edit/Reject buttons are sidebar-only. Telegram/Slack users get no interactive card. (Inline cards are upstream-SDK-blocked; a channel ping is not.) **2026-05-20: DEFERRED — SDK blocker (same as W1-F1).** The "channel ping" parenthetical was over-optimistic — every push-to-channel SDK seam on `2026.5.18` is `bundled-plugin-only`. See `blocker-W1-F3.md`. Resolution path (`/plan accept|reject|cancel|edit|answer`) ALREADY works on every channel via the universal text pipeline; the PUSH (proactive "plan ready" message) is what's blocked. |
 | **W1-F4** | bug | `/plan auto on` flips an `autoApprove` flag that **does nothing** — the runtime that fires auto-approve "lands at P-final". A non-functional safety-relevant control. Wire it or hide it. |
-| **W1-F5** | parity-gap | `/plan answer` cannot resolve a pending `ask_user_question` on Telegram/Slack — needs plugin-side question-state tracking (also flagged as a known gap in #93). |
+| **W1-F5** | parity-gap | `/plan answer` cannot resolve a pending `ask_user_question` on Telegram/Slack — needs plugin-side question-state tracking (also flagged as a known gap in #93). **2026-05-20: IMPLEMENTED.** Added `PendingQuestion` field to `PlanModeSessionState`; added `persistPendingQuestion` + `clearPendingQuestion` store mutators; wired `ask_user_question` tool to persist on success; wired `/plan answer <text>` in `slash-commands.ts` to read store + dispatch `plan.answer`. Membership guard (`allowFreetext === false` → answer must be in `options`) mirrors in-host `sessions-patch.ts:721-732`. Idempotency: store clears slot on dispatch success; injection-writer dedups on `questionId`. |
 
 ---
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -422,9 +422,23 @@ export default definePluginEntry({
     // P-8: ask_user_question — non-blocking clarification tool.
     // P-12 wires the question→answer flow via the `plan.answer`
     // session-action below; this registration is the model-facing tool.
-    api.registerTool(createAskUserQuestionTool(), {
-      name: "ask_user_question",
-    });
+    //
+    // W1-F5 (2026-05-20): pass `store` so the tool body persists
+    // pending-question state. Without this wire, `/plan answer
+    // <text>` on Telegram/Slack/Discord/CLI cannot resolve the
+    // question because the slash-command handler has no source for
+    // the `{questionId, questionPrompt, selectedOption}` payload
+    // required by the `plan.answer` session-action. See
+    // `docs/audits/parity-refresh/wave-1-catalog.md:W1-F5`.
+    api.registerTool(
+      createAskUserQuestionTool({
+        store,
+        logger: { warn: (msg: string) => api.logger.warn(msg) },
+      }),
+      {
+        name: "ask_user_question",
+      },
+    );
 
     // P-12: session-actions — operator-side resolution surface.
     // /plan accept|reject|cancel|edit|answer + plan.auto.toggle. UI

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -749,6 +749,210 @@ export class PlanModeStore {
   }
 
   /**
+   * Persist a pending `ask_user_question` interaction so the
+   * `/plan answer` slash-command handler (and any future cross-surface
+   * answer dispatcher) can route the user's reply.
+   *
+   * **Wave-1 W1-F5 fix (2026-05-20)**: closes the cross-surface
+   * `/plan answer` gap on Telegram/Slack — see the `PendingQuestion`
+   * docstring + `docs/audits/parity-refresh/wave-1-catalog.md:W1-F5`.
+   *
+   * # Semantics
+   *
+   * - Overwrites any prior `pendingQuestion` (a fresh
+   *   `ask_user_question` supersedes a stale one).
+   * - Does NOT require the session to be in plan mode — the in-host
+   *   permits `ask_user_question` outside plan mode (the tool's own
+   *   "plan-mode safe" doc says "DOES NOT exit plan mode", but it
+   *   never said "requires plan mode either"). Mirror that
+   *   permissiveness.
+   * - Lazy-inits the plan-mode payload when absent: a fresh session
+   *   that's never touched plan mode can still hold a pending
+   *   question (matches the in-host where `pendingInteraction` is
+   *   a top-level field on `SessionEntry`, independent of
+   *   `planMode`).
+   *
+   * # Idempotency
+   *
+   * Repeated calls with the same `questionId` overwrite (last write
+   * wins). The in-host's
+   * `pendingInteraction` field has the same overwrite semantics:
+   * each `ask_user_question` mints a fresh approvalId, and the
+   * persister stamps the latest interaction blindly. Defense-in-depth
+   * lives in the injection-writer (`enqueueQuestionAnswerInjection`
+   * keys on `questionId`, so a duplicate answer dispatch dedups).
+   *
+   * host_ref: in-host's `plan-snapshot-persister.ts:163-208` which
+   *   subscribes to the `approval` stream and writes
+   *   `pendingInteraction`. The plugin can't subscribe to the
+   *   `approval` stream (it's `bundled-plugin-only` —
+   *   `blocker-W1-F1.md` §2), so we persist directly from the
+   *   tool body instead.
+   */
+  async persistPendingQuestion(input: {
+    sessionKey: string;
+    questionId: string;
+    questionPrompt: string;
+    options: string[];
+    allowFreetext: boolean;
+  }): Promise<
+    | { kind: "persisted"; state: PlanModeSessionState }
+    | { kind: "failed"; error: Error }
+  > {
+    const {
+      sessionKey,
+      questionId,
+      questionPrompt,
+      options,
+      allowFreetext,
+    } = input;
+    try {
+      let outcome: { kind: "persisted"; state: PlanModeSessionState };
+      const now = Date.now();
+      const pending = {
+        questionId,
+        questionPrompt,
+        options,
+        allowFreetext,
+        askedAt: now,
+      };
+      const { transition } = await this.gateway.withLock<{
+        prev: PlanModeSessionState | undefined;
+        next: PlanModeSessionState;
+      }>(sessionKey, async (current) => {
+        // Lazy-init: no plan-mode payload yet → create one in normal
+        // mode with only the pendingQuestion set. The in-host's
+        // `pendingInteraction` is independent of `planMode`; we
+        // model the same independence by allowing a question
+        // without an active plan-mode cycle.
+        const base: PlanModeSessionState = current ?? {
+          mode: "normal",
+          approval: "none",
+          rejectionCount: 0,
+        };
+        const next: PlanModeSessionState = {
+          ...base,
+          pendingQuestion: pending,
+          updatedAt: now,
+        };
+        outcome = { kind: "persisted", state: next };
+        return {
+          next: stampSchemaVersion(next) as PlanModeSessionState,
+          transition: { prev: current, next },
+        };
+      });
+      if (transition && this.audit) {
+        this.audit({
+          sessionKey,
+          prev: transition.prev,
+          next: transition.next,
+          source: "smarter-claw:PlanModeStore.persistPendingQuestion",
+        });
+      }
+      return outcome!;
+    } catch (err) {
+      const wrapped = err instanceof Error ? err : new Error(String(err));
+      this.logger?.warn?.(
+        `PlanModeStore.persistPendingQuestion: failed (sessionKey=${sessionKey}): ${wrapped.message}`,
+      );
+      return { kind: "failed", error: wrapped };
+    }
+  }
+
+  /**
+   * Clear the pending `ask_user_question` interaction. Called by the
+   * `/plan answer` slash-command handler on successful dispatch and
+   * by any other code path that resolves the question (e.g. the
+   * session-action handler in future refactors).
+   *
+   * # Idempotency
+   *
+   * Answering an already-answered question is a no-op:
+   *   - First call: state had `pendingQuestion` → deleted, returns
+   *     `kind: "cleared"`.
+   *   - Second call: state already lacks `pendingQuestion` →
+   *     returns `kind: "noop"`.
+   *
+   * Optional `expectedQuestionId` guard: when provided, only clears
+   * if the persisted `pendingQuestion.questionId` matches. Mismatch
+   * (stale answer attempt) → `kind: "stale"` no-op. Mirrors the
+   * `expectedApprovalId` stale-event pattern used elsewhere in the
+   * store.
+   *
+   * host_ref: in-host's `clearPendingQuestionState` at
+   *   `src/gateway/sessions-patch.ts:160-166` (delete-on-answer
+   *   site at line 769).
+   */
+  async clearPendingQuestion(input: {
+    sessionKey: string;
+    expectedQuestionId?: string;
+  }): Promise<
+    | { kind: "cleared"; state: PlanModeSessionState }
+    | { kind: "noop" }
+    | { kind: "stale"; persistedQuestionId: string }
+    | { kind: "failed"; error: Error }
+  > {
+    const { sessionKey, expectedQuestionId } = input;
+    try {
+      let outcome:
+        | { kind: "cleared"; state: PlanModeSessionState }
+        | { kind: "noop" }
+        | { kind: "stale"; persistedQuestionId: string };
+      const { transition } = await this.gateway.withLock<{
+        prev: PlanModeSessionState | undefined;
+        next: PlanModeSessionState;
+      }>(sessionKey, async (current) => {
+        if (!current || !current.pendingQuestion) {
+          outcome = { kind: "noop" };
+          return { next: null };
+        }
+        if (
+          expectedQuestionId !== undefined &&
+          current.pendingQuestion.questionId !== expectedQuestionId
+        ) {
+          outcome = {
+            kind: "stale",
+            persistedQuestionId: current.pendingQuestion.questionId,
+          };
+          return { next: null };
+        }
+        const now = Date.now();
+        // Spread current, then explicitly unset pendingQuestion. The
+        // `pendingQuestion: undefined` form would persist `undefined`
+        // through JSON serialization (the gateway's writer treats
+        // explicit undefined as a no-write); rebuild the object
+        // omitting the field entirely.
+        const { pendingQuestion: _drop, ...rest } = current;
+        void _drop;
+        const next: PlanModeSessionState = {
+          ...rest,
+          updatedAt: now,
+        };
+        outcome = { kind: "cleared", state: next };
+        return {
+          next: stampSchemaVersion(next) as PlanModeSessionState,
+          transition: { prev: current, next },
+        };
+      });
+      if (transition && this.audit) {
+        this.audit({
+          sessionKey,
+          prev: transition.prev,
+          next: transition.next,
+          source: "smarter-claw:PlanModeStore.clearPendingQuestion",
+        });
+      }
+      return outcome!;
+    } catch (err) {
+      const wrapped = err instanceof Error ? err : new Error(String(err));
+      this.logger?.warn?.(
+        `PlanModeStore.clearPendingQuestion: failed (sessionKey=${sessionKey}): ${wrapped.message}`,
+      );
+      return { kind: "failed", error: wrapped };
+    }
+  }
+
+  /**
    * Read the current plan-mode state for a session. Returns undefined
    * when no payload exists yet (fresh session, or one that has never
    * touched plan mode).

--- a/src/tools/ask-user-question.ts
+++ b/src/tools/ask-user-question.ts
@@ -20,14 +20,29 @@
  *
  * In-host: the runtime intercepts the tool result and emits a
  * question approval event via the existing kind:"plugin" approval
- * pipeline. P-8 ships the TOOL itself (input validation + structured
- * result). Full question→answer wiring (the approval pipeline + the
- * pendingAgentInjections write on user reply) lands at P-11 alongside
- * rejection-cycle tracking.
+ * pipeline; the gateway's `plan-snapshot-persister.ts:184-209`
+ * subscribes to that stream and writes `pendingInteraction` on the
+ * SessionEntry, so `/plan answer` can resolve the question.
+ *
+ * Plugin: the plugin CANNOT subscribe to the host's `approval`
+ * stream (it is `bundled-plugin-only` — see
+ * `docs/audits/parity-refresh/blocker-W1-F1.md` §2 and the
+ * `HOST_OWNED_AGENT_EVENT_STREAMS` Set in the installed loader). So
+ * the tool body itself persists the pending-question state into the
+ * plugin's own `pluginExtensions["smarter-claw"]["plan-mode"]`
+ * namespace via `store.persistPendingQuestion`. The slash-command
+ * surface (`src/ui/slash-commands.ts`) reads from the same slot to
+ * route `/plan answer <text>` cross-surface. **Wave-1 W1-F5 fix
+ * (2026-05-20).**
+ *
+ * The store wire is optional for the tool's stateless input-validation
+ * tests (which never construct a PlanModeStore). Production wiring
+ * in `src/index.ts` always supplies it.
  */
 
 import { Type } from "typebox";
 import { describeAskUserQuestionTool } from "../plan-mode/tool-descriptions.js";
+import type { PlanModeStore } from "../state/store.js";
 import { ToolInputError, readStringParam } from "./common.js";
 
 interface ToolContext {
@@ -35,9 +50,32 @@ interface ToolContext {
 }
 
 export interface CreateAskUserQuestionToolInput {
-  // No deps in P-8 — the tool is stateless input-validation.
-  // P-11 will inject a PlanModeStore reference for question-cycle
-  // tracking.
+  /**
+   * Optional PlanModeStore wire. When supplied, the tool body persists
+   * the pending-question state into the plan-mode session-extension
+   * namespace so cross-surface answering (`/plan answer <text>` on
+   * Telegram/Slack/Discord/CLI) can resolve the question.
+   *
+   * When omitted (input-validation tests), persistence is silently
+   * skipped — the tool's return shape is unaffected, and the
+   * in-host-equivalent webchat path (Control UI projecting the
+   * session-extension into the sidebar) is the same regardless of
+   * whether the store is wired (both paths read from the persisted
+   * state).
+   *
+   * Wave-1 W1-F5 fix (2026-05-20). Closes the cross-surface answer
+   * gap originally flagged in PR #93 and re-catalogued in
+   * `docs/audits/parity-refresh/wave-1-catalog.md:W1-F5`.
+   */
+  store?: PlanModeStore;
+  /**
+   * Optional logger for non-fatal persist failures. Defaults to a
+   * no-op. Production wiring in `src/index.ts` supplies
+   * `{ warn: api.logger.warn }`.
+   */
+  logger?: {
+    warn?: (message: string) => void;
+  };
 }
 
 const SCHEMA = Type.Object(
@@ -69,9 +107,9 @@ const SCHEMA = Type.Object(
 );
 
 export function createAskUserQuestionTool(
-  _opts: CreateAskUserQuestionToolInput = {},
+  opts: CreateAskUserQuestionToolInput = {},
 ) {
-  return (_ctx: ToolContext) => ({
+  return (ctx: ToolContext) => ({
     label: "Ask User Question",
     name: "ask_user_question",
     // W1-A3: verbatim in-host description (was a paraphrase).
@@ -133,6 +171,56 @@ export function createAskUserQuestionTool(
         // host_ref: src/agents/tools/ask-user-question-tool.ts (PR-10
         //   review H5 fix).
         const questionId = `q-${toolCallId}`;
+        // W1-F5 (2026-05-20): persist the pending-question state so
+        // the `/plan answer` slash command can resolve it on
+        // Telegram/Slack/Discord/CLI. The persist is BEST-EFFORT —
+        // failures log at warn and never change the tool result.
+        // The webchat path (which reads the same session-extension
+        // slot via the Control UI sidebar descriptor) benefits from
+        // the same persist, so both surfaces converge on the same
+        // source of truth.
+        //
+        // Persist requires (a) a wired store (production wiring in
+        // src/index.ts always supplies it; tests may omit), (b) a
+        // sessionKey from the tool context (tool-result events
+        // always carry it in production; some legacy tests stub
+        // without it). When either is absent, skip silently and
+        // emit a single debug-level warn — the tool's contract is
+        // input-validation; persistence is the W1-F5 extension.
+        if (opts.store && ctx.sessionKey) {
+          try {
+            const result = await opts.store.persistPendingQuestion({
+              sessionKey: ctx.sessionKey,
+              questionId,
+              questionPrompt: question,
+              options,
+              allowFreetext,
+            });
+            if (result.kind === "failed") {
+              opts.logger?.warn?.(
+                `ask_user_question: persistPendingQuestion failed (sessionKey=${ctx.sessionKey} questionId=${questionId}): ${result.error.message}`,
+              );
+            }
+          } catch (persistErr) {
+            // Defense-in-depth: persistPendingQuestion already
+            // catches + returns kind:"failed"; this guards against
+            // a future refactor that lets a throw escape.
+            opts.logger?.warn?.(
+              `ask_user_question: persistPendingQuestion threw (sessionKey=${ctx.sessionKey} questionId=${questionId}): ${persistErr instanceof Error ? persistErr.message : String(persistErr)}`,
+            );
+          }
+        } else if (!opts.store) {
+          opts.logger?.warn?.(
+            `ask_user_question: no store wired — pending-question persistence skipped (cross-surface /plan answer will not work). questionId=${questionId}`,
+          );
+        } else {
+          // store present but no sessionKey — typically a tool-call
+          // outside a session context. The tool itself remains valid
+          // for input-validation; persistence is just skipped.
+          opts.logger?.warn?.(
+            `ask_user_question: no sessionKey on context — pending-question persistence skipped. questionId=${questionId}`,
+          );
+        }
         const text = `Question submitted to user: "${question}" (${options.length} options).`;
         return {
           content: [{ type: "text" as const, text }],

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,6 +89,88 @@ export interface PlanStep {
 }
 
 /**
+ * Persisted pending `ask_user_question` state. Mirrors the in-host
+ * `PendingInteraction` union's `kind: "question"` variant
+ * (`src/config/sessions/types.ts:113-124` at commit `ea04ea52c7`),
+ * but plugin-side and pruned to what the plugin actually needs to
+ * resolve a `/plan answer <text>` cross-surface dispatch.
+ *
+ * # Why the plugin needs this (W1-F5)
+ *
+ * In-host: `ask_user_question` tool fires → runtime emits a
+ * `kind: "plugin"` approval event → gateway's
+ * `plan-snapshot-persister.ts:184-209` writes
+ * `entry.pendingInteraction = { kind: "question", approvalId,
+ * questionId, ... }`. `/plan answer` in
+ * `src/auto-reply/reply/commands-plan.ts:312-318` reads
+ * `liveSessionEntry.pendingInteraction.approvalId/questionId` and
+ * dispatches `sessions.patch { planApproval: { action: "answer",
+ * answer, approvalId, questionId } }`.
+ *
+ * In the plugin: the host's `pendingInteraction` is host-owned —
+ * the plugin cannot write it (the runtime fields belong to the
+ * plan-snapshot-persister, which subscribes to the `approval`
+ * stream that is `bundled-plugin-only`; see
+ * `docs/audits/parity-refresh/blocker-W1-F1.md` §2). So the
+ * plugin stores its OWN question-state under
+ * `pluginExtensions["smarter-claw"]["plan-mode"].pendingQuestion`,
+ * written by the `ask_user_question` tool body directly. The plugin
+ * never reads the host's `pendingInteraction` and never claims to.
+ *
+ * # Lifecycle
+ *
+ * - WRITE: by `ask_user_question` tool's `execute()` body on a
+ *   `status: "question_submitted"` result, AFTER the tool's input
+ *   validation passes. The `questionId` is the deterministic
+ *   `q-${toolCallId}` (already minted on line 135 of
+ *   `src/tools/ask-user-question.ts`).
+ * - READ: by the `/plan answer` slash-command handler in
+ *   `src/ui/slash-commands.ts` — looks up
+ *   `store.readSnapshot(sessionKey).pendingQuestion` and uses the
+ *   `questionId` + `questionPrompt` to build the `plan.answer`
+ *   session-action payload.
+ * - CLEAR: cleared on (a) successful `plan.answer` dispatch
+ *   (idempotency — answering twice should be a no-op), (b)
+ *   `exit_plan_mode` (the question is implicitly resolved when the
+ *   agent proceeds to propose a plan), (c) `cancelPlanMode` /
+ *   `exitPlanMode` (state reset).
+ *
+ * # Idempotency invariant
+ *
+ * Answering an already-answered question must be a no-op, not a
+ * duplicate inject. Implementation: the `/plan answer` handler
+ * checks `pendingQuestion` is present BEFORE dispatching; on
+ * dispatch success the store CLEARS `pendingQuestion`. A second
+ * `/plan answer` finds an empty slot → returns
+ * "No pending question" instead of re-injecting.
+ *
+ * The injection-writer already deduplicates by
+ * `idempotencyKey: smarter-claw:question_answer:<questionId>` (see
+ * `src/runtime/injection-writer.ts:293`); the store-side clear is
+ * the user-visible idempotency, the injection-side dedup is the
+ * defense-in-depth.
+ */
+export interface PendingQuestion {
+  /**
+   * Deterministic question id minted as `q-${toolCallId}` by the
+   * `ask_user_question` tool. Stable across replays, so the
+   * `enqueueQuestionAnswerInjection` idempotency key
+   * `smarter-claw:question_answer:<questionId>` is stable too.
+   */
+  questionId: string;
+  /** The original question text, for re-rendering in `/plan answer` help. */
+  questionPrompt: string;
+  /** The N selectable options the agent offered. UI may render them
+   *  inline; `/plan answer` validates against this set when
+   *  `allowFreetext=false`. */
+  options: string[];
+  /** When true, accept any text as the answer; else only one of `options`. */
+  allowFreetext: boolean;
+  /** Unix ms timestamp of when the question was persisted. */
+  askedAt: number;
+}
+
+/**
  * The full plan-mode session-extension payload. Stored under
  * `pluginExtensions["smarter-claw"]["plan-mode"]` on the host's session
  * row. UI clients read this via the session-extension projector
@@ -221,6 +303,25 @@ export interface PlanModeSessionState {
    *   auto-mode wiring).
    */
   autoApprove?: boolean;
+
+  /**
+   * Pending `ask_user_question` interaction state. Written by the
+   * `ask_user_question` tool body; read by the `/plan answer`
+   * slash-command handler. See `PendingQuestion` for the full
+   * lifecycle + idempotency invariant.
+   *
+   * Wave-1 W1-F5 fix (2026-05-20): closes the cross-surface
+   * `/plan answer` gap for Telegram/Slack. Before this field
+   * existed, the `/plan answer` slash command returned the
+   * "known gap" message because the session-action's required
+   * `{ questionId, questionPrompt, selectedOption }` payload had no
+   * source. With this field populated by `ask_user_question`, the
+   * slash command can build the payload from the persisted state.
+   *
+   * host_ref: `src/config/sessions/types.ts:104-124` (the in-host's
+   *   `PendingInteraction` union — same shape, plugin-side mirror).
+   */
+  pendingQuestion?: PendingQuestion;
 }
 
 /**

--- a/src/ui/slash-commands.ts
+++ b/src/ui/slash-commands.ts
@@ -20,11 +20,11 @@
  *   - `/plan accept`                — approve the pending plan (verbatim)
  *   - `/plan edit <body>`           — approve with inline-edited body
  *   - `/plan reject [feedback]`     — reject with feedback
+ *   - `/plan answer <text>`         — answer a pending ask_user_question
+ *                                     (Wave-1 W1-F5 fix 2026-05-20 —
+ *                                     previously not wired pending
+ *                                     plugin-side question-state tracking)
  *   - `/plan auto on|off`           — toggle auto-approve mode
- *
- * `/plan answer` is intentionally NOT wired through this surface — see
- * the `answer` case below for the rationale (plugin-side question-state
- * tracking does not exist yet; tracked as a Wave-1 finding).
  *
  * # Dispatch
  *
@@ -110,6 +110,9 @@ const PLAN_AGENT_PROMPT_GUIDANCE: readonly string[] = [
     "`/plan accept` (approve verbatim), `/plan edit <new plan text>` " +
     "(approve with edits), `/plan reject [reason]` (reject for revision), " +
     "or `/plan cancel` (exit plan mode). `/plan enter` enters plan mode. " +
+    "When you call `ask_user_question`, the user can answer with " +
+    "`/plan answer <text>` (text must match one of the offered options " +
+    "exactly, unless you set `allowFreetext: true`). " +
     "These work on every channel even if the channel's native command " +
     "menu does not list them — if a user cannot find `/plan` in an " +
     "autocomplete menu, tell them to type it as a normal message.",
@@ -131,7 +134,7 @@ export function createPlanSlashCommand(
   return {
     name: "plan",
     description:
-      "Plan-mode controls: /plan enter | accept | edit | reject | cancel | auto on|off",
+      "Plan-mode controls: /plan enter | accept | edit | reject | cancel | answer | auto on|off",
     acceptsArgs: true,
     // Available on every channel; do NOT restrict via `channels`.
     agentPromptGuidance: PLAN_AGENT_PROMPT_GUIDANCE,
@@ -215,8 +218,8 @@ const USAGE = [
   "  /plan edit <body>      — approve with edits",
   "  /plan reject [reason]  — reject with optional feedback",
   "  /plan cancel           — exit plan mode",
+  "  /plan answer <text>    — answer a pending ask_user_question",
   "  /plan auto on|off      — toggle auto-approve",
-  "(Answer pending questions from the approval card.)",
 ].join("\n");
 
 async function handlePlanCommand(
@@ -269,18 +272,35 @@ async function handlePlanCommand(
       return handleEnter(ctx, input.store);
     case "answer":
     case "ans":
-      // No slash-surface answering: pending-question metadata
-      // (questionId / questionPrompt) is minted host-side by
-      // ask_user_question and is NOT projected into plan-mode state,
-      // so this command cannot supply the `plan.answer` session-action
-      // its required payload. Route the user to the approval card.
-      // Tracked as a Wave-1 finding (plugin-side question-state
-      // tracking + cross-platform answer surface — Wave 4).
-      return reply(
-        "Answer pending questions from the approval card. Slash-command " +
-          "answering is not available yet — it needs plugin-side " +
-          "question-state tracking (known gap).",
-      );
+      // W1-F5 fix (2026-05-20): cross-surface `/plan answer <text>`.
+      //
+      // Previously a known-gap message: pending-question metadata
+      // was not plugin-side, so this command had no source for the
+      // `{questionId, questionPrompt, selectedOption}` payload the
+      // `plan.answer` session-action requires. The W1-F5 fix added
+      // `PlanModeStore.persistPendingQuestion` (called from the
+      // `ask_user_question` tool body) so the store now carries the
+      // pending question whenever one is active. This dispatcher
+      // reads from that slot and routes to `plan.answer`.
+      //
+      // **Hard constraint — idempotency**: answering an already-
+      // answered question MUST be a no-op, not a duplicate inject.
+      // Two layers of defense:
+      //   (a) `store.clearPendingQuestion` is called by the
+      //       `plan.answer` flow below on success — a second `/plan
+      //       answer <text>` finds an empty slot and returns "no
+      //       pending question".
+      //   (b) The injection-writer dedups on `idempotencyKey:
+      //       smarter-claw:question_answer:<questionId>` so even if
+      //       (a) races, the host's queue collapses duplicates.
+      //
+      // host_ref: in-host `/plan answer` at
+      //   src/auto-reply/reply/commands-plan.ts:475-516 (commit
+      //   ea04ea52c7) — reads `liveSessionEntry.pendingInteraction`
+      //   and dispatches via sessions.patch. The plugin reads from
+      //   its own `pluginExtensions["smarter-claw"]["plan-mode"]
+      //   .pendingQuestion` slot for the equivalent.
+      return handleAnswer(ctx, input, tail);
     case "status":
       return reply(USAGE);
     default:
@@ -319,6 +339,148 @@ async function handleEnter(
       ? "Already in plan mode — investigate read-only, then propose a plan."
       : "Plan mode entered. Mutating tools are blocked until a plan is approved.",
   );
+}
+
+/**
+ * `/plan answer <text>` — resolve a pending `ask_user_question`
+ * cross-surface (Telegram / Slack / Discord / CLI / webchat).
+ *
+ * **Wave-1 W1-F5 fix (2026-05-20).**
+ *
+ * # Flow
+ *
+ *   1. Require `sessionKey` (slash commands without a session
+ *      context cannot answer; mirrors the in-host check at
+ *      `commands-plan.ts:475-498`).
+ *   2. Require non-empty `tail` (the answer text).
+ *   3. Read `store.readSnapshot(sessionKey).pendingQuestion` —
+ *      the slot populated by `ask_user_question`'s tool body.
+ *   4. If absent: friendly "no pending question" reply (mirrors
+ *      the in-host's "No pending ask_user_question for this
+ *      session" message).
+ *   5. If `allowFreetext === false`: validate that the answer text
+ *      is one of `options` exactly. Mirrors the in-host
+ *      `sessions-patch.ts:721-732` answer-guard. Without this gate
+ *      a Telegram user could `/plan answer <arbitrary>` and steer
+ *      the agent's next turn with unintended free text.
+ *   6. Dispatch `plan.answer` with
+ *      `{ questionId, questionPrompt, selectedOption: tail }`.
+ *   7. On success, CLEAR `pendingQuestion` from the store
+ *      (idempotency layer (a) — a repeat `/plan answer` finds an
+ *      empty slot and returns step 4's "no pending" message).
+ *
+ * # Hard constraints
+ *
+ * - **Idempotent**: a repeat `/plan answer` finds the slot cleared
+ *   (step 7), returns "no pending question" — same code path as
+ *   "no question was ever pending". A defense-in-depth layer lives
+ *   in the injection-writer (idempotency key
+ *   `smarter-claw:question_answer:<questionId>`) so even if (a)
+ *   races with another `/plan answer`, the host's queue collapses.
+ * - **Mention-neutralized**: the answer text is forwarded to
+ *   `plan.answer` which calls `enqueueQuestionAnswerInjection`,
+ *   which already JSON-quotes the answer in the
+ *   `[QUESTION_ANSWER]` envelope. Slack `@channel`/`@here`/
+ *   `@everyone` and `<@U…>` mentions inside the answer are NOT
+ *   themselves the answer text the agent reads — the JSON encoding
+ *   makes them inert. (The in-host has an additional
+ *   `sessions-patch.ts:751-754` neutralization for the answer
+ *   stored at queue-time; the plugin's JSON-quote is the
+ *   equivalent guard.)
+ *
+ * host_ref: src/auto-reply/reply/commands-plan.ts:475-516 — the
+ *   in-host /plan answer handler, commit ea04ea52c7. The plugin
+ *   tracks question state in its own pluginExtensions slot (the
+ *   host's `pendingInteraction` is bundled-only — see
+ *   `blocker-W1-F1.md` §2).
+ * host_ref: src/gateway/sessions-patch.ts:702-730 — the in-host
+ *   `allowFreetext === false` membership guard, mirrored here.
+ */
+async function handleAnswer(
+  ctx: PluginCommandContext,
+  input: CreatePlanSlashCommandInput,
+  tail: string,
+): Promise<PluginCommandResult> {
+  if (!ctx.sessionKey) {
+    return reply(
+      "`/plan answer` requires a session context. Send it from inside an active session.",
+    );
+  }
+  if (!tail) {
+    return reply(
+      "`/plan answer` requires an answer. Usage: `/plan answer <one of the offered options>` (or any text when the agent enabled free-text).",
+    );
+  }
+  // Read the pending-question slot. `readSnapshot` is non-locking
+  // (the store's docstring is explicit). The store handler we
+  // dispatch to does the authoritative lock+clear via
+  // `clearPendingQuestion`; this read is for the prompt-side guard.
+  let snap: Awaited<ReturnType<PlanModeStore["readSnapshot"]>>;
+  try {
+    snap = await input.store.readSnapshot(ctx.sessionKey);
+  } catch (err) {
+    return reply(
+      `/plan answer failed: ${(err as Error).message ?? "unexpected error"}`,
+    );
+  }
+  const pending = snap?.pendingQuestion;
+  if (!pending) {
+    return reply(
+      "No pending question for this session. `/plan answer` only works when the agent has asked a question via `ask_user_question`.",
+    );
+  }
+  // Membership guard — mirror in-host sessions-patch.ts:721-732. If
+  // the agent disabled free-text, the answer text must match one of
+  // the offered options EXACTLY. Pre-W1-F5 this was unenforceable
+  // (no slash-side answering); now it ships with the parity check.
+  if (!pending.allowFreetext) {
+    if (
+      pending.options.length > 0 &&
+      !pending.options.includes(tail)
+    ) {
+      return reply(
+        `Your answer "${tail}" is not in the offered options. The agent disabled free-text for this question. Pick one of: ${pending.options
+          .map((o) => `"${o}"`)
+          .join(", ")}.`,
+      );
+    }
+  }
+  // Dispatch `plan.answer` with the resolved payload. Reuses the
+  // same handler the sidebar buttons call — no re-implementation.
+  const dispatchResult = await dispatchAction(
+    input.actions,
+    "plan.answer",
+    ctx,
+    {
+      questionId: pending.questionId,
+      questionPrompt: pending.questionPrompt,
+      selectedOption: tail,
+    },
+  );
+  // Clear the slot ONLY when the dispatch succeeded. A failure
+  // (handler threw / returned ok:false) leaves the question armed so
+  // the user can retry without losing the question state.
+  //
+  // `dispatchAction` returns `reply(...)` with text like
+  // "/plan answer failed: ..." on failure; we detect by inspecting
+  // the text. The cleaner contract would be a {ok, text} return,
+  // but matching the existing dispatcher shape keeps this hunk
+  // small. (The friendly map's "plan.answer" entry below makes the
+  // success text deterministic.)
+  if (!dispatchResult.text?.startsWith("/plan answer failed:")) {
+    try {
+      await input.store.clearPendingQuestion({
+        sessionKey: ctx.sessionKey,
+        expectedQuestionId: pending.questionId,
+      });
+    } catch {
+      // Non-fatal: the injection-writer's idempotency key
+      // (smarter-claw:question_answer:<questionId>) prevents a
+      // duplicate dispatch on retry even if clear fails. The user's
+      // answer already landed; this is housekeeping.
+    }
+  }
+  return dispatchResult;
 }
 
 async function dispatchAction(
@@ -372,6 +534,7 @@ async function dispatchAction(
     "plan.edit": "Plan approved with edits — agent will execute the edited body.",
     "plan.reject": "Plan rejected — agent will revise based on your feedback.",
     "plan.cancel": "Exited plan mode — back to normal session.",
+    "plan.answer": "Answer recorded — agent will resume with your response.",
     "plan.auto.toggle": "Auto-approve toggled.",
   };
   return {

--- a/tests/state/store.test.ts
+++ b/tests/state/store.test.ts
@@ -1164,3 +1164,179 @@ describe("PlanModeStore — W1-C1: expectedApprovalId stale-event guard threadin
     expect(gw.peek(SESSION_KEY)?.approval).toBe("pending");
   });
 });
+
+describe("W1-F5 PlanModeStore — pending question persist / clear", () => {
+  let gw: InMemoryGateway;
+  let store: PlanModeStore;
+  let audit: AuditEmitter;
+
+  beforeEach(() => {
+    gw = new InMemoryGateway();
+    audit = vi.fn();
+    store = new PlanModeStore(gw, undefined, audit);
+  });
+
+  it("persistPendingQuestion lazy-inits a normal-mode payload when none exists", async () => {
+    const r = await store.persistPendingQuestion({
+      sessionKey: SESSION_KEY,
+      questionId: "q-call-1",
+      questionPrompt: "Pick a color",
+      options: ["red", "blue"],
+      allowFreetext: false,
+    });
+    expect(r.kind).toBe("persisted");
+    const written = gw.peek(SESSION_KEY)!;
+    expect(written.mode).toBe("normal");
+    expect(written.pendingQuestion).toBeDefined();
+    expect(written.pendingQuestion?.questionId).toBe("q-call-1");
+    expect(written.pendingQuestion?.options).toEqual(["red", "blue"]);
+    expect(written.pendingQuestion?.allowFreetext).toBe(false);
+    expect(audit).toHaveBeenCalledOnce();
+  });
+
+  it("persistPendingQuestion preserves existing plan-mode state", async () => {
+    gw.seed(
+      SESSION_KEY,
+      planModeSession({
+        mode: "plan",
+        approval: "pending",
+        approvalId: APPROVAL_ID,
+        title: "Bump deps",
+        lastPlanSteps: [{ step: "step 1", status: "pending" }],
+      }),
+    );
+    const r = await store.persistPendingQuestion({
+      sessionKey: SESSION_KEY,
+      questionId: "q-call-2",
+      questionPrompt: "Major or minor bump?",
+      options: ["major", "minor"],
+      allowFreetext: false,
+    });
+    expect(r.kind).toBe("persisted");
+    const written = gw.peek(SESSION_KEY)!;
+    expect(written.mode).toBe("plan");
+    expect(written.approval).toBe("pending");
+    expect(written.approvalId).toBe(APPROVAL_ID);
+    expect(written.title).toBe("Bump deps");
+    expect(written.lastPlanSteps).toEqual([{ step: "step 1", status: "pending" }]);
+    expect(written.pendingQuestion?.questionId).toBe("q-call-2");
+  });
+
+  it("persistPendingQuestion OVERWRITES a prior pending question", async () => {
+    await store.persistPendingQuestion({
+      sessionKey: SESSION_KEY,
+      questionId: "q-first",
+      questionPrompt: "First Q",
+      options: ["a", "b"],
+      allowFreetext: false,
+    });
+    await store.persistPendingQuestion({
+      sessionKey: SESSION_KEY,
+      questionId: "q-second",
+      questionPrompt: "Second Q",
+      options: ["x", "y"],
+      allowFreetext: true,
+    });
+    const written = gw.peek(SESSION_KEY)!;
+    expect(written.pendingQuestion?.questionId).toBe("q-second");
+    expect(written.pendingQuestion?.allowFreetext).toBe(true);
+  });
+
+  it("clearPendingQuestion clears the slot and returns kind:cleared", async () => {
+    await store.persistPendingQuestion({
+      sessionKey: SESSION_KEY,
+      questionId: "q-call-1",
+      questionPrompt: "Pick",
+      options: ["a", "b"],
+      allowFreetext: false,
+    });
+    const r = await store.clearPendingQuestion({ sessionKey: SESSION_KEY });
+    expect(r.kind).toBe("cleared");
+    const written = gw.peek(SESSION_KEY)!;
+    expect(written.pendingQuestion).toBeUndefined();
+  });
+
+  it("clearPendingQuestion is a no-op when no pending question (idempotency)", async () => {
+    const r = await store.clearPendingQuestion({ sessionKey: SESSION_KEY });
+    expect(r.kind).toBe("noop");
+    // Calling on a session that has plan-mode state but no question
+    // is also a no-op.
+    gw.seed(SESSION_KEY, planModeSession({ mode: "plan", approval: "none" }));
+    const r2 = await store.clearPendingQuestion({ sessionKey: SESSION_KEY });
+    expect(r2.kind).toBe("noop");
+  });
+
+  it("clearPendingQuestion with expectedQuestionId returns stale on mismatch", async () => {
+    await store.persistPendingQuestion({
+      sessionKey: SESSION_KEY,
+      questionId: "q-current",
+      questionPrompt: "Pick",
+      options: ["a", "b"],
+      allowFreetext: false,
+    });
+    const r = await store.clearPendingQuestion({
+      sessionKey: SESSION_KEY,
+      expectedQuestionId: "q-stale",
+    });
+    expect(r.kind).toBe("stale");
+    if (r.kind === "stale") {
+      expect(r.persistedQuestionId).toBe("q-current");
+    }
+    // Slot preserved on stale.
+    expect(gw.peek(SESSION_KEY)?.pendingQuestion?.questionId).toBe("q-current");
+  });
+
+  it("clearPendingQuestion with matching expectedQuestionId clears", async () => {
+    await store.persistPendingQuestion({
+      sessionKey: SESSION_KEY,
+      questionId: "q-call-1",
+      questionPrompt: "Pick",
+      options: ["a", "b"],
+      allowFreetext: false,
+    });
+    const r = await store.clearPendingQuestion({
+      sessionKey: SESSION_KEY,
+      expectedQuestionId: "q-call-1",
+    });
+    expect(r.kind).toBe("cleared");
+    expect(gw.peek(SESSION_KEY)?.pendingQuestion).toBeUndefined();
+  });
+
+  it("exitPlanMode clears pendingQuestion (state reset hygiene)", async () => {
+    gw.seed(
+      SESSION_KEY,
+      planModeSession({
+        mode: "plan",
+        approval: "pending",
+        approvalId: APPROVAL_ID,
+        pendingQuestion: {
+          questionId: "q-call-1",
+          questionPrompt: "Pick",
+          options: ["a", "b"],
+          allowFreetext: false,
+          askedAt: 1_700_000_000_000,
+        },
+      }),
+    );
+    const r = await store.exitPlanMode({ sessionKey: SESSION_KEY });
+    expect(r.kind).toBe("exited");
+    const written = gw.peek(SESSION_KEY)!;
+    expect(written.mode).toBe("normal");
+    expect(written.pendingQuestion).toBeUndefined();
+  });
+
+  it("readSnapshot returns pendingQuestion when present", async () => {
+    await store.persistPendingQuestion({
+      sessionKey: SESSION_KEY,
+      questionId: "q-call-1",
+      questionPrompt: "Pick a color",
+      options: ["red", "blue"],
+      allowFreetext: false,
+    });
+    const snap = await store.readSnapshot(SESSION_KEY);
+    expect(snap?.pendingQuestion?.questionId).toBe("q-call-1");
+    expect(snap?.pendingQuestion?.options).toEqual(["red", "blue"]);
+    expect(snap?.pendingQuestion?.allowFreetext).toBe(false);
+    expect(typeof snap?.pendingQuestion?.askedAt).toBe("number");
+  });
+});

--- a/tests/tools/ask-user-question.test.ts
+++ b/tests/tools/ask-user-question.test.ts
@@ -4,9 +4,12 @@
  * Covers input validation + structured result shape. The full
  * question→answer wiring (pendingAgentInjections write on user reply)
  * lands at P-11 and is exercised by Eva live-smoke #3.
+ *
+ * Wave-1 W1-F5 extension: persist-pending-question tests
+ * (`createAskUserQuestionTool({ store, logger })` path).
  */
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createAskUserQuestionTool } from "../../src/tools/ask-user-question.js";
 
 const SESSION_KEY = "agent:main:main";
@@ -184,5 +187,145 @@ describe("P-8 ask_user_question — happy path", () => {
       options: ["a", "b", "c"],
     });
     expect(r.content[0]?.text).toMatch(/Question submitted to user.*Pick one.*3 options/);
+  });
+});
+
+describe("W1-F5 ask_user_question — pending-question persistence", () => {
+  // Helper: a minimal in-memory store stub that captures
+  // persistPendingQuestion calls without running the real gateway.
+  function stubStore() {
+    const calls: Array<{
+      sessionKey: string;
+      questionId: string;
+      questionPrompt: string;
+      options: string[];
+      allowFreetext: boolean;
+    }> = [];
+    return {
+      store: {
+        persistPendingQuestion: async (params: typeof calls[number]) => {
+          calls.push(params);
+          return { kind: "persisted" as const, state: {} as never };
+        },
+      },
+      calls,
+    };
+  }
+
+  it("when store + sessionKey wired, persists pending question on success", async () => {
+    const { store, calls } = stubStore();
+    const warn = vi.fn();
+    const factory = createAskUserQuestionTool({
+      store: store as never,
+      logger: { warn },
+    });
+    const t = factory({ sessionKey: SESSION_KEY });
+    const r = await t.execute("call-1", {
+      question: "Major or minor bump?",
+      options: ["major", "minor"],
+      allowFreetext: false,
+    });
+    expect((r.details as { status: string }).status).toBe("question_submitted");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({
+      sessionKey: SESSION_KEY,
+      questionId: "q-call-1",
+      questionPrompt: "Major or minor bump?",
+      options: ["major", "minor"],
+      allowFreetext: false,
+    });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("when store wired but no sessionKey, skips persist and logs warn", async () => {
+    const { store, calls } = stubStore();
+    const warn = vi.fn();
+    const factory = createAskUserQuestionTool({
+      store: store as never,
+      logger: { warn },
+    });
+    const t = factory({}); // no sessionKey
+    const r = await t.execute("call-1", {
+      question: "Q?",
+      options: ["a", "b"],
+    });
+    expect((r.details as { status: string }).status).toBe("question_submitted");
+    expect(calls).toEqual([]); // skipped
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0]?.[0]).toMatch(/no sessionKey/);
+  });
+
+  it("when store omitted, skips persist and logs warn (input-validation path)", async () => {
+    const warn = vi.fn();
+    const factory = createAskUserQuestionTool({ logger: { warn } });
+    const t = factory({ sessionKey: SESSION_KEY });
+    const r = await t.execute("call-1", {
+      question: "Q?",
+      options: ["a", "b"],
+    });
+    expect((r.details as { status: string }).status).toBe("question_submitted");
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0]?.[0]).toMatch(/no store wired/);
+  });
+
+  it("does NOT persist on invalid input (tool returns invalid-input before persist branch)", async () => {
+    const { store, calls } = stubStore();
+    const warn = vi.fn();
+    const factory = createAskUserQuestionTool({
+      store: store as never,
+      logger: { warn },
+    });
+    const t = factory({ sessionKey: SESSION_KEY });
+    const r = await t.execute("call-1", {
+      // Missing options → invalid-input
+      question: "Q?",
+    });
+    expect((r.details as { status: string }).status).toBe("invalid-input");
+    expect(calls).toEqual([]);
+  });
+
+  it("persist failure is non-fatal: tool result is unaffected, error is logged", async () => {
+    const warn = vi.fn();
+    const storeWithError = {
+      persistPendingQuestion: async () => ({
+        kind: "failed" as const,
+        error: new Error("disk full"),
+      }),
+    };
+    const factory = createAskUserQuestionTool({
+      store: storeWithError as never,
+      logger: { warn },
+    });
+    const t = factory({ sessionKey: SESSION_KEY });
+    const r = await t.execute("call-1", {
+      question: "Q?",
+      options: ["a", "b"],
+    });
+    // Tool succeeds even though persist failed — matches the
+    // "best-effort persist" contract documented in the tool body.
+    expect((r.details as { status: string }).status).toBe("question_submitted");
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0]?.[0]).toMatch(/persistPendingQuestion failed.*disk full/);
+  });
+
+  it("persist throwing is also caught (defense-in-depth)", async () => {
+    const warn = vi.fn();
+    const storeThatThrows = {
+      persistPendingQuestion: async () => {
+        throw new Error("gateway exploded");
+      },
+    };
+    const factory = createAskUserQuestionTool({
+      store: storeThatThrows as never,
+      logger: { warn },
+    });
+    const t = factory({ sessionKey: SESSION_KEY });
+    const r = await t.execute("call-1", {
+      question: "Q?",
+      options: ["a", "b"],
+    });
+    expect((r.details as { status: string }).status).toBe("question_submitted");
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0]?.[0]).toMatch(/persistPendingQuestion threw.*gateway exploded/);
   });
 });

--- a/tests/ui/slash-commands.test.ts
+++ b/tests/ui/slash-commands.test.ts
@@ -3,7 +3,7 @@
  *
  * Covers the command dispatcher: subcommand routing, the `/plan enter`
  * store path, the dispatcher's try/catch error guard, and the
- * `/plan answer` known-gap message.
+ * `/plan answer` cross-surface flow (Wave-1 W1-F5).
  */
 
 import { describe, expect, it, vi } from "vitest";
@@ -281,17 +281,268 @@ describe("/plan enter — store path", () => {
   });
 });
 
-describe("/plan answer — known-gap message", () => {
-  it("/plan answer does NOT dispatch and returns the known-gap message", async () => {
-    const input = makeInput({
-      actions: new Map<string, ActionHandler>([
-        ["plan.answer", vi.fn(async () => ({ ok: true as const })) as ActionHandler],
-      ]),
-    });
+describe("/plan answer — W1-F5 cross-surface answer", () => {
+  // Helper: build a store stub with a configurable pendingQuestion
+  // and clear semantics.
+  function storeWithPendingQuestion(pending?: {
+    questionId: string;
+    questionPrompt: string;
+    options: string[];
+    allowFreetext: boolean;
+  }) {
+    const clearCalls: Array<{ sessionKey: string; expectedQuestionId?: string }> = [];
+    return {
+      store: {
+        readSnapshot: vi.fn(async () => {
+          if (!pending) return undefined;
+          return {
+            mode: "plan" as const,
+            approval: "none" as const,
+            rejectionCount: 0,
+            pendingQuestion: { ...pending, askedAt: Date.now() },
+          };
+        }),
+        clearPendingQuestion: vi.fn(async (input: { sessionKey: string; expectedQuestionId?: string }) => {
+          clearCalls.push(input);
+          return { kind: "cleared" as const, state: {} as never };
+        }),
+        enterPlanMode: vi.fn(async () => ({
+          kind: "entered" as const,
+          state: {} as never,
+        })),
+      } as unknown as PlanModeStore,
+      clearCalls,
+    };
+  }
+
+  it("with no pending question, returns a friendly 'no pending' reply and does NOT dispatch", async () => {
+    const { store } = storeWithPendingQuestion(undefined);
+    const planAnswer = vi.fn(async () => ({ ok: true as const })) as ActionHandler;
+    const input = {
+      actions: new Map<string, ActionHandler>([["plan.answer", planAnswer]]),
+      store,
+    };
     const cmd = createPlanSlashCommand(input);
-    const r = await cmd.handler(cmdCtx("answer option one"));
-    expect(r.text).toMatch(/approval card/);
-    expect(input.actions.get("plan.answer")).not.toHaveBeenCalled();
+    const r = await cmd.handler(cmdCtx("answer something"));
+    expect(r.text).toMatch(/No pending question/);
+    expect(planAnswer).not.toHaveBeenCalled();
+  });
+
+  it("requires a non-empty tail (the answer text)", async () => {
+    const { store } = storeWithPendingQuestion({
+      questionId: "q-abc",
+      questionPrompt: "Pick a color",
+      options: ["red", "blue"],
+      allowFreetext: false,
+    });
+    const planAnswer = vi.fn(async () => ({ ok: true as const })) as ActionHandler;
+    const input = {
+      actions: new Map<string, ActionHandler>([["plan.answer", planAnswer]]),
+      store,
+    };
+    const cmd = createPlanSlashCommand(input);
+    const r = await cmd.handler(cmdCtx("answer"));
+    expect(r.text).toMatch(/requires an answer/);
+    expect(planAnswer).not.toHaveBeenCalled();
+  });
+
+  it("requires a session context", async () => {
+    const { store } = storeWithPendingQuestion({
+      questionId: "q-abc",
+      questionPrompt: "Pick a color",
+      options: ["red", "blue"],
+      allowFreetext: false,
+    });
+    const planAnswer = vi.fn(async () => ({ ok: true as const })) as ActionHandler;
+    const input = {
+      actions: new Map<string, ActionHandler>([["plan.answer", planAnswer]]),
+      store,
+    };
+    const cmd = createPlanSlashCommand(input);
+    const r = await cmd.handler(cmdCtx("answer red", { noSession: true }));
+    expect(r.text).toMatch(/requires a session context/);
+    expect(planAnswer).not.toHaveBeenCalled();
+  });
+
+  it("when allowFreetext=false, rejects an answer NOT in the offered options", async () => {
+    const { store } = storeWithPendingQuestion({
+      questionId: "q-abc",
+      questionPrompt: "Pick a color",
+      options: ["red", "blue"],
+      allowFreetext: false,
+    });
+    const planAnswer = vi.fn(async () => ({ ok: true as const })) as ActionHandler;
+    const input = {
+      actions: new Map<string, ActionHandler>([["plan.answer", planAnswer]]),
+      store,
+    };
+    const cmd = createPlanSlashCommand(input);
+    const r = await cmd.handler(cmdCtx("answer purple"));
+    expect(r.text).toMatch(/not in the offered options/);
+    expect(r.text).toMatch(/"red"/);
+    expect(r.text).toMatch(/"blue"/);
+    expect(planAnswer).not.toHaveBeenCalled();
+  });
+
+  it("when allowFreetext=true, accepts an arbitrary answer", async () => {
+    const { store } = storeWithPendingQuestion({
+      questionId: "q-abc",
+      questionPrompt: "Describe the bug",
+      options: ["short", "long"],
+      allowFreetext: true,
+    });
+    const planAnswer = vi.fn(async () => ({
+      ok: true as const,
+      continueAgent: true,
+    })) as ActionHandler;
+    const input = {
+      actions: new Map<string, ActionHandler>([["plan.answer", planAnswer]]),
+      store,
+    };
+    const cmd = createPlanSlashCommand(input);
+    const r = await cmd.handler(cmdCtx("answer the parser drops trailing newlines"));
+    expect(r.text).toMatch(/Answer recorded/);
+    expect(planAnswer).toHaveBeenCalledOnce();
+    expect(planAnswer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionId: "plan.answer",
+        payload: expect.objectContaining({
+          questionId: "q-abc",
+          selectedOption: "the parser drops trailing newlines",
+        }),
+      }),
+    );
+  });
+
+  it("dispatches plan.answer with the correct payload on a valid option choice", async () => {
+    const { store, clearCalls } = storeWithPendingQuestion({
+      questionId: "q-abc",
+      questionPrompt: "Pick a color",
+      options: ["red", "blue"],
+      allowFreetext: false,
+    });
+    const planAnswer = vi.fn(async () => ({
+      ok: true as const,
+      continueAgent: true,
+    })) as ActionHandler;
+    const input = {
+      actions: new Map<string, ActionHandler>([["plan.answer", planAnswer]]),
+      store,
+    };
+    const cmd = createPlanSlashCommand(input);
+    const r = await cmd.handler(cmdCtx("answer red"));
+    expect(planAnswer).toHaveBeenCalledOnce();
+    expect(planAnswer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionId: "plan.answer",
+        sessionKey: SESSION_KEY,
+        payload: {
+          questionId: "q-abc",
+          questionPrompt: "Pick a color",
+          selectedOption: "red",
+        },
+      }),
+    );
+    expect(r.text).toMatch(/Answer recorded/);
+    // On success, the pending-question slot is cleared
+    // (idempotency layer (a)).
+    expect(clearCalls).toEqual([
+      { sessionKey: SESSION_KEY, expectedQuestionId: "q-abc" },
+    ]);
+  });
+
+  it("idempotency: a second /plan answer finds the slot cleared and returns 'no pending'", async () => {
+    // Simulate two-call sequence by toggling the pending state between
+    // calls. After the first /plan answer resolves, real production
+    // clears the slot via clearPendingQuestion; we simulate that by
+    // returning undefined from readSnapshot on the second call.
+    let callCount = 0;
+    const pending = {
+      questionId: "q-abc",
+      questionPrompt: "Pick a color",
+      options: ["red", "blue"],
+      allowFreetext: false,
+    };
+    const store = {
+      readSnapshot: vi.fn(async () => {
+        callCount += 1;
+        if (callCount === 1) {
+          return {
+            mode: "plan" as const,
+            approval: "none" as const,
+            rejectionCount: 0,
+            pendingQuestion: { ...pending, askedAt: Date.now() },
+          };
+        }
+        return undefined; // second call: cleared
+      }),
+      clearPendingQuestion: vi.fn(async () => ({
+        kind: "cleared" as const,
+        state: {} as never,
+      })),
+      enterPlanMode: vi.fn(async () => ({
+        kind: "entered" as const,
+        state: {} as never,
+      })),
+    } as unknown as PlanModeStore;
+    const planAnswer = vi.fn(async () => ({
+      ok: true as const,
+      continueAgent: true,
+    })) as ActionHandler;
+    const input = {
+      actions: new Map<string, ActionHandler>([["plan.answer", planAnswer]]),
+      store,
+    };
+    const cmd = createPlanSlashCommand(input);
+    const r1 = await cmd.handler(cmdCtx("answer red"));
+    expect(r1.text).toMatch(/Answer recorded/);
+    const r2 = await cmd.handler(cmdCtx("answer red"));
+    expect(r2.text).toMatch(/No pending question/);
+    // The session-action handler fires ONLY for the first call.
+    expect(planAnswer).toHaveBeenCalledOnce();
+  });
+
+  it("on dispatch failure, does NOT clear the pending-question slot", async () => {
+    const { store, clearCalls } = storeWithPendingQuestion({
+      questionId: "q-abc",
+      questionPrompt: "Pick a color",
+      options: ["red", "blue"],
+      allowFreetext: false,
+    });
+    const failing: ActionHandler = vi.fn(async () => {
+      throw new Error("handler exploded");
+    });
+    const input = {
+      actions: new Map<string, ActionHandler>([["plan.answer", failing]]),
+      store,
+    };
+    const cmd = createPlanSlashCommand(input);
+    const r = await cmd.handler(cmdCtx("answer red"));
+    expect(r.text).toMatch(/\/plan answer failed/);
+    // Question state preserved → user can retry without losing the
+    // question context.
+    expect(clearCalls).toEqual([]);
+  });
+
+  it("accepts the `/plan ans` short alias", async () => {
+    const { store } = storeWithPendingQuestion({
+      questionId: "q-abc",
+      questionPrompt: "Pick a color",
+      options: ["red", "blue"],
+      allowFreetext: false,
+    });
+    const planAnswer = vi.fn(async () => ({
+      ok: true as const,
+      continueAgent: true,
+    })) as ActionHandler;
+    const input = {
+      actions: new Map<string, ActionHandler>([["plan.answer", planAnswer]]),
+      store,
+    };
+    const cmd = createPlanSlashCommand(input);
+    const r = await cmd.handler(cmdCtx("ans red"));
+    expect(planAnswer).toHaveBeenCalledOnce();
+    expect(r.text).toMatch(/Answer recorded/);
   });
 });
 


### PR DESCRIPTION
Wave 4. Part of #100.

**W1-F5 (P1) — IMPLEMENTED**: `/plan answer <option>` now works cross-surface. Sub-agent realized the plugin's own `pluginExtensions` namespace lets it track question-state directly, bypassing the bundled-only `pendingInteraction` field. Added `PendingQuestion` to state + persist/clear mutators + wired through `ask_user_question` tool + full `/plan answer` handler with idempotency + options-membership guard. +23 tests.

**W1-F3 (P1) — BLOCKER**: same SDK constraint as W1-F1. `sendSessionAttachment` + `emitAgentEvent` are bundled-plugin-only. The in-host itself only pushes on Telegram (silent on Slack/Discord/Matrix). `blocker-W1-F3.md` consolidates with `blocker-W1-F1.md` — same upstream paths unblock both.

User-facing reality: `/plan accept|reject` etc. already work everywhere via the text pipeline (W3-tools); F3's gap is the proactive PUSH, not the response.

This is the **4th** Wave-1 finding where the audit's proposed fix was based on a wrong premise (E-1, E-6, F1, now F3). Audits valuable for detection; proposed fixes need verification. Pattern goes in final report.

## Test plan
- [x] typecheck clean; 868/868; parity-harness 156/156
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cross-surface question answering via `/plan answer <text>` command, enabling users to respond to pending questions from AI across Telegram and Slack.
  * Implemented persistent pending-question tracking for plan-mode sessions.

* **Documentation**
  * Updated Wave 4 execution status (Telegram + Slack) with F5 implementation details and F3 deferred due to SDK limitations.
  * Added blocker documentation for Wave 1 F3, detailing SDK constraints and workaround options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/Smarter-Claw/pull/119?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->