### PR TITLE
Recover OpenClaw 26.5.18 plugin registration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Runtime registration gate
+        run: pnpm runtime-gate
+
       # Run vitest. The reporter-JSON-numTests check guards against
       # silent zero-tests-discovered failures.
       #
@@ -114,8 +117,19 @@ jobs:
           # Manifest sanity — ensure version + minHostVersion are present.
           node -e "
             const m = JSON.parse(require('fs').readFileSync('/tmp/sc-extract/package/dist/openclaw.plugin.json','utf8'));
+            const p = JSON.parse(require('fs').readFileSync('/tmp/sc-extract/package/package.json','utf8'));
             if (!m.id || !m.minHostVersion) {
               throw new Error('manifest missing id or minHostVersion: ' + JSON.stringify(m));
+            }
+            if (p.openclaw?.install?.minHostVersion !== '>=' + m.minHostVersion) {
+              throw new Error('package openclaw.install.minHostVersion must be >=' + m.minHostVersion);
+            }
+            const tools = new Set(m.contracts?.tools || []);
+            for (const tool of ['enter_plan_mode', 'exit_plan_mode', 'ask_user_question']) {
+              if (!tools.has(tool)) throw new Error('manifest contracts.tools missing ' + tool);
+            }
+            if (!(m.contracts?.sessionAttachments || []).includes('active-session')) {
+              throw new Error('manifest contracts.sessionAttachments missing active-session');
             }
             console.log('manifest id=' + m.id + ' minHostVersion=' + m.minHostVersion);
           "

--- a/.github/workflows/drift-cron.yml
+++ b/.github/workflows/drift-cron.yml
@@ -93,7 +93,7 @@ jobs:
           # For now, a placeholder that surfaces "harness not wired
           # yet" without failing the job.
           if [ -f parity-harness/runners/plugin-under-test.ts ]; then
-            node --experimental-strip-types parity-harness/runners/plugin-under-test.ts || true
+            pnpm exec tsx parity-harness/runners/plugin-under-test.ts || true
           else
             pnpm parity-harness || true
           fi
@@ -113,7 +113,7 @@ jobs:
             exit 0
           fi
           set +e
-          node --experimental-strip-types parity-harness/diff.ts > /tmp/diff-output.txt 2>&1
+          pnpm exec tsx parity-harness/diff.ts > /tmp/diff-output.txt 2>&1
           rc=$?
           set -e
           cat /tmp/diff-output.txt

--- a/.github/workflows/drift-cron.yml
+++ b/.github/workflows/drift-cron.yml
@@ -93,7 +93,9 @@ jobs:
           # For now, a placeholder that surfaces "harness not wired
           # yet" without failing the job.
           if [ -f parity-harness/runners/plugin-under-test.ts ]; then
-            pnpm exec tsx parity-harness/runners/plugin-under-test.ts || true
+            node --experimental-strip-types parity-harness/runners/plugin-under-test.ts || true
+          else
+            pnpm parity-harness || true
           fi
           echo "Plugin runner step complete."
 
@@ -111,7 +113,7 @@ jobs:
             exit 0
           fi
           set +e
-          pnpm exec tsx parity-harness/diff.ts > /tmp/diff-output.txt 2>&1
+          node --experimental-strip-types parity-harness/diff.ts > /tmp/diff-output.txt 2>&1
           rc=$?
           set -e
           cat /tmp/diff-output.txt

--- a/README.md
+++ b/README.md
@@ -4,14 +4,17 @@ Plan Mode plugin for [OpenClaw](https://github.com/openclaw/openclaw) — plan-t
 
 ## Status
 
-**`1.0.0-port.17` — OpenClaw 26.5.18 recovery candidate (2026-05-20).**
+**`1.0.0-port.18` — OpenClaw 26.5.19 recovery candidate (2026-05-21).**
 
 The 6-wave parity refresh closed all 2 P0 + 14/17 P1 Wave-1 findings,
 built a 156-case mechanical parity-harness CI gate, and bumped the
-minimum host version to `openclaw@2026.5.18`. Port `.17` adds the
+minimum host version to `openclaw@2026.5.19`. Port `.18` keeps the
+stable-load contracts from `.17`, updates the SDK/test target to the
+current npm `latest`, and tracks OpenClaw's Node 22.19 runtime floor.
+Port `.17` adds the
 stable-load contracts (`contracts.tools`), explicit CLI descriptors,
 the runtime registration gate, and Telegram-native plan/question button
-wiring. On stock `openclaw@2026.5.18`, the typed `/plan` fallback and
+wiring. On stock `openclaw@2026.5.19`, the typed `/plan` fallback and
 persisted Markdown plan path remain authoritative; Markdown attachment
 delivery and native Telegram buttons activate when the host includes the
 trusted `contracts.sessionAttachments: ["active-session"]` SDK seam.
@@ -55,7 +58,7 @@ The mutation gate (`before_tool_call`) works without this flag, but most
 of the plugin requires it. An advisory message fires on every new session
 start when the flag is missing.
 
-Minimum host version: `openclaw >= 2026.5.18` (declared via the canonical
+Minimum host version: `openclaw >= 2026.5.19` (declared via the canonical
 `package.json#openclaw.install.minHostVersion` floor and mirrored in
 `openclaw.plugin.json` for runtime metadata).
 
@@ -64,11 +67,11 @@ Minimum host version: `openclaw >= 2026.5.18` (declared via the canonical
 The plugin's v0.x sidebar UI works out of the box. For the v1.0 **inline UI** (mode-switcher chip, inline plan cards, input-bar suppression on pending approval), Smarter-Claw needs SDK seams that aren't in the upstream openclaw release yet — they're filed as draft PR [openclaw/openclaw#80982](https://github.com/openclaw/openclaw/pull/80982).
 
 > **Status: upstream-blocked.** The patcher targets the `2026.5.10-beta.5`
-> baseline; on the current `minHostVersion` (`2026.5.18`) the content-hashed
+> baseline; on the current `minHostVersion` (`2026.5.19`) the content-hashed
 > bundle filenames the manifest keys on have rotated (`loader-DdN5GTsW.js`
 > → `loader-CxUWY2_6.js`; `protocol-BBwaRnfZ.js` → `protocol-CdYy0xVK.js`
 > + `protocol-B17omF7t.js`), so the patcher's SHA pre-flight refuses to
-> apply (`process.exitCode === 3` / `4`). **Operators on `2026.5.18`
+> apply (`process.exitCode === 3` / `4`). **Operators on `2026.5.19`
 > should skip this section** — sidebar UI + `/plan` slash commands cover
 > the supported UX. See [`docs/audits/parity-refresh/blocker-W1-S17-webchat-ui.md`](./docs/audits/parity-refresh/blocker-W1-S17-webchat-ui.md)
 > for the full investigation and the upstream tracking
@@ -92,7 +95,7 @@ node scripts/install-chat-stream-seam.mjs --host /path/to/your/openclaw
 ```
 
 What the patcher does:
-- Validates the installed openclaw version matches the patcher's manifest (refuses on mismatch — `2026.5.18` exits 3)
+- Validates the installed openclaw version matches the patcher's manifest (refuses on mismatch — current stable hosts exit 3)
 - SHA256-checks the 2 dist files that will be replaced against the manifest's expected baseline (refuses on drift — use `--force` to override at your own risk)
 - Backs up the originals into `node_modules/openclaw/.smarter-claw-backups/`
 - Replaces 2 compiled JS bundle files with seam-built equivalents (~370KB total; ~80 lines of new code inside larger bundles)
@@ -101,7 +104,7 @@ What the patcher does:
 
 The patch is a **temporary tactical unblock for the legacy `2026.5.10-beta.5` baseline**. When upstream openclaw merges PR #80982 into a published release, we'll bump `peerDependencies.openclaw` + drop the patcher.
 
-## What works in 1.0.0-port.17
+## What works in 1.0.0-port.18
 
 | Feature | Status |
 |---|---|
@@ -123,8 +126,8 @@ The patch is a **temporary tactical unblock for the legacy `2026.5.10-beta.5` ba
 | `autoApprove` toggle (state mutator) | ✅ |
 | Approval grant ledger + structured debug log | ✅ |
 | Parity harness (Layer 1, 2, 3-cron) | ✅ |
-| Telegram-native approval/question buttons | ✅ with OpenClaw active-session attachment seam; `/plan` fallback on stock `26.5.18` |
-| Markdown plan artifact persistence + attachment | ✅ persisted on stock `26.5.18`; attached when host seam is available |
+| Telegram-native approval/question buttons | ✅ with OpenClaw active-session attachment seam; `/plan` fallback on stock `26.5.19` |
+| Markdown plan artifact persistence + attachment | ✅ persisted on stock `26.5.19`; attached when host seam is available |
 
 ## Deferred to v1.0 (upstream-blocked)
 
@@ -170,7 +173,7 @@ at the in-host code it mirrors (see `host_ref:` comments in each file).
 | `api.session.controls.registerControlUiDescriptor` | Sidebar widget descriptor |
 | `api.session.workflow.enqueueNextTurnInjection` | `[PLAN_DECISION]:` and `[QUESTION_ANSWER]:` writers |
 | `api.registerInteractiveHandler` | `smarter-claw-plan` Telegram callback namespace for approve/revise/reject/cancel and option answers |
-| `api.session.workflow.sendSessionAttachment` | Best-effort active-session plan/question presentation delivery; falls back when stock `26.5.18` blocks third-party attachments |
+| `api.session.workflow.sendSessionAttachment` | Best-effort active-session plan/question presentation delivery; falls back when stock `26.5.19` blocks third-party attachments |
 | `api.registerCli` | `openclaw plan-clear` rollback drain command |
 
 ## Develop
@@ -189,7 +192,8 @@ pnpm build           # tsc → dist/
 
 | OpenClaw | Smarter Claw |
 |---|---|
-| `2026.5.18` and later | `1.0.0-port.17` (current recovery RC) |
+| `2026.5.19` and later | `1.0.0-port.18` (current recovery RC) |
+| `2026.5.18` and later | `1.0.0-port.17` (stable-load + Telegram bridge consumer RC) |
 | `2026.5.18` and later | `1.0.0-port.16` (parity-refresh RC; no Telegram-native button bridge) |
 | `2026.5.10-beta.5` ... `<2026.5.18` | `1.0.0-port.15` (legacy; chat-stream patcher applies here only) |
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ What the patcher does:
 
 The patch is a **temporary tactical unblock for the legacy `2026.5.10-beta.5` baseline**. When upstream openclaw merges PR #80982 into a published release, we'll bump `peerDependencies.openclaw` + drop the patcher.
 
-## What works in 1.0.0-port.16
+## What works in 1.0.0-port.17
 
 | Feature | Status |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -4,15 +4,18 @@ Plan Mode plugin for [OpenClaw](https://github.com/openclaw/openclaw) — plan-t
 
 ## Status
 
-**`1.0.0-port.16` — parity-refresh release candidate (2026-05-20).**
+**`1.0.0-port.17` — OpenClaw 26.5.18 recovery candidate (2026-05-20).**
 
 The 6-wave parity refresh closed all 2 P0 + 14/17 P1 Wave-1 findings,
 built a 156-case mechanical parity-harness CI gate, and bumped the
-minimum host version to `openclaw@2026.5.18`. The plugin is
-**release-ready** against `openclaw@2026.5.18`+; sidebar UI + slash
-commands work end-to-end. **868 unit tests + 4 Eva-live-smokes pass;
-parity-harness 156+/156+ cases parity-clean across 8+ checks; all
-green on Ubuntu CI**. See [`docs/audits/parity-refresh/FINAL-REPORT.md`](./docs/audits/parity-refresh/FINAL-REPORT.md)
+minimum host version to `openclaw@2026.5.18`. Port `.17` adds the
+stable-load contracts (`contracts.tools`), explicit CLI descriptors,
+the runtime registration gate, and Telegram-native plan/question button
+wiring. On stock `openclaw@2026.5.18`, the typed `/plan` fallback and
+persisted Markdown plan path remain authoritative; Markdown attachment
+delivery and native Telegram buttons activate when the host includes the
+trusted `contracts.sessionAttachments: ["active-session"]` SDK seam.
+See [`docs/audits/parity-refresh/FINAL-REPORT.md`](./docs/audits/parity-refresh/FINAL-REPORT.md)
 for the full ship-readiness account.
 
 `v1.0` public release is gated on the upstream OpenClaw chat-stream renderer
@@ -52,8 +55,9 @@ The mutation gate (`before_tool_call`) works without this flag, but most
 of the plugin requires it. An advisory message fires on every new session
 start when the flag is missing.
 
-Minimum host version: `openclaw >= 2026.5.18` (declared via
-`minHostVersion` in `openclaw.plugin.json`).
+Minimum host version: `openclaw >= 2026.5.18` (declared via the canonical
+`package.json#openclaw.install.minHostVersion` floor and mirrored in
+`openclaw.plugin.json` for runtime metadata).
 
 ## Optional: chat-stream seam patch (for inline UI before upstream merges)
 
@@ -119,6 +123,8 @@ The patch is a **temporary tactical unblock for the legacy `2026.5.10-beta.5` ba
 | `autoApprove` toggle (state mutator) | ✅ |
 | Approval grant ledger + structured debug log | ✅ |
 | Parity harness (Layer 1, 2, 3-cron) | ✅ |
+| Telegram-native approval/question buttons | ✅ with OpenClaw active-session attachment seam; `/plan` fallback on stock `26.5.18` |
+| Markdown plan artifact persistence + attachment | ✅ persisted on stock `26.5.18`; attached when host seam is available |
 
 ## Deferred to v1.0 (upstream-blocked)
 
@@ -163,6 +169,8 @@ at the in-host code it mirrors (see `host_ref:` comments in each file).
 | `api.session.controls.registerSessionAction` (×6) | `plan.accept` / `plan.edit` / `plan.reject` / `plan.cancel` / `plan.answer` / `plan.auto.toggle` |
 | `api.session.controls.registerControlUiDescriptor` | Sidebar widget descriptor |
 | `api.session.workflow.enqueueNextTurnInjection` | `[PLAN_DECISION]:` and `[QUESTION_ANSWER]:` writers |
+| `api.registerInteractiveHandler` | `smarter-claw-plan` Telegram callback namespace for approve/revise/reject/cancel and option answers |
+| `api.session.workflow.sendSessionAttachment` | Best-effort active-session plan/question presentation delivery; falls back when stock `26.5.18` blocks third-party attachments |
 | `api.registerCli` | `openclaw plan-clear` rollback drain command |
 
 ## Develop
@@ -172,7 +180,8 @@ git clone https://github.com/electricsheephq/Smarter-Claw.git
 cd Smarter-Claw
 pnpm install
 pnpm typecheck       # tsc --noEmit
-pnpm test            # vitest run — 551 tests across 26 files
+pnpm test            # vitest run
+pnpm runtime-gate    # built-plugin registration contract smoke
 pnpm build           # tsc → dist/
 ```
 
@@ -180,11 +189,14 @@ pnpm build           # tsc → dist/
 
 | OpenClaw | Smarter Claw |
 |---|---|
-| `2026.5.18` and later | `1.0.0-port.16` (current parity-refresh RC) |
+| `2026.5.18` and later | `1.0.0-port.17` (current recovery RC) |
+| `2026.5.18` and later | `1.0.0-port.16` (parity-refresh RC; no Telegram-native button bridge) |
 | `2026.5.10-beta.5` ... `<2026.5.18` | `1.0.0-port.15` (legacy; chat-stream patcher applies here only) |
 
-`minHostVersion` is enforced via `openclaw.plugin.json`. Earlier host
-versions don't have the required SDK seams.
+Install-time compatibility is enforced via
+`package.json#openclaw.install.minHostVersion`; runtime metadata is mirrored
+in `openclaw.plugin.json`. Earlier host versions don't have the required SDK
+seams.
 
 ## Known limitations
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,24 @@
 # Smarter-Claw Release Notes
 
+## 1.0.0-port.18 — OpenClaw 26.5.19 latest-stable bump (2026-05-21)
+
+This maintenance pass moves the recovery candidate from stable
+`openclaw@2026.5.18` to npm `latest`, `openclaw@2026.5.19`.
+
+### What changed since `1.0.0-port.17`
+
+- Bumped the SDK/test target to `openclaw@2026.5.19`.
+- Bumped `openclaw.plugin.json` `minHostVersion` to `2026.5.19`.
+- Bumped canonical `package.json#openclaw.install.minHostVersion` to
+  `>=2026.5.19` and `peerDependencies.openclaw` to `>=2026.5.19`.
+- Bumped the package candidate to `1.0.0-port.18`.
+- Raised the package Node engine floor to `>=22.19.0`, matching
+  OpenClaw 2026.5.19's published package engine requirement.
+- Kept the same compatibility truth: stock `openclaw@2026.5.19` still
+  rejects third-party active-session attachments, so typed `/plan`
+  commands and persisted Markdown paths remain the stable fallback until
+  the trusted host seam lands.
+
 ## 1.0.0-port.17 — OpenClaw 26.5.18 recovery candidate (2026-05-20)
 
 This recovery pass makes the plugin honest and testable on stable

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,46 @@
 # Smarter-Claw Release Notes
 
+## 1.0.0-port.17 — OpenClaw 26.5.18 recovery candidate (2026-05-20)
+
+This recovery pass makes the plugin honest and testable on stable
+`openclaw@2026.5.18` while adding the consumer side of the Telegram
+native-button UX.
+
+### What changed since `1.0.0-port.16`
+
+- Added `openclaw.plugin.json` `contracts.tools` for
+  `enter_plan_mode`, `exit_plan_mode`, and `ask_user_question`, plus
+  `contracts.sessionAttachments: ["active-session"]`.
+- Added canonical `package.json#openclaw.install` and
+  `package.json#openclaw.build` metadata. The install floor is the
+  OpenClaw-required semver form `>=2026.5.18`, while the manifest keeps
+  the stable runtime target `2026.5.18`. Added a CI
+  `pnpm runtime-gate` that loads the built plugin and fails on missing
+  tool contracts, CLI descriptors, slash commands, session actions,
+  Control UI, or Telegram interactive handler registrations.
+- Registered `openclaw plan-clear` with explicit descriptor metadata so
+  OpenClaw can lazy-load/advertise it without guessing.
+- Added Telegram interactive namespace `smarter-claw-plan`:
+  approval cards expose Approve, Revise, Reject, Cancel buttons; question
+  cards expose option buttons; callbacks enforce sender authorization and
+  stale approval/question guards, then clear buttons after resolution.
+- `exit_plan_mode` now returns the persisted Markdown plan path in tool
+  details and best-effort sends the Markdown file plus rich approval
+  presentation through `api.session.workflow.sendSessionAttachment`.
+- `ask_user_question` now best-effort sends native option buttons through
+  the same active-session presentation path.
+- Fixed drift-cron's missing `tsx` dependency by using Node 22
+  `--experimental-strip-types` or the existing parity harness path.
+
+### Host compatibility truth
+
+Stock `openclaw@2026.5.18` still blocks third-party active-session
+attachments, so the plugin falls back to persisted Markdown paths and
+typed `/plan` commands there. Full Markdown attachment plus Telegram
+button parity requires the narrow OpenClaw host seam that allows trusted
+plugins declaring `contracts.sessionAttachments: ["active-session"]` to
+send active-session presentations.
+
 ## 1.0.0-port.16 — parity refresh, host bump to 2026.5.18, Wave-6 finding fixes (2026-05-20)
 
 The 6-wave Parity-Refresh closed the audit cycle and brought the plugin

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -3,6 +3,16 @@
   "name": "Smarter-Claw",
   "description": "Plan-Mode plugin for OpenClaw. Plan-then-execute workflow with mutation gate, archetype prompting, escalating retry, and rejection-cycle tracking. v1 port-in-progress (P-1 skeleton).",
   "minHostVersion": "2026.5.18",
+  "contracts": {
+    "tools": [
+      "enter_plan_mode",
+      "exit_plan_mode",
+      "ask_user_question"
+    ],
+    "sessionAttachments": [
+      "active-session"
+    ]
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "smarter-claw",
   "name": "Smarter-Claw",
   "description": "Plan-Mode plugin for OpenClaw. Plan-then-execute workflow with mutation gate, archetype prompting, escalating retry, and rejection-cycle tracking. v1 port-in-progress (P-1 skeleton).",
-  "minHostVersion": "2026.5.18",
+  "minHostVersion": "2026.5.19",
   "contracts": {
     "tools": [
       "enter_plan_mode",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@electricsheephq/smarter-claw",
-  "version": "1.0.0-port.16",
+  "version": "1.0.0-port.17",
   "description": "Smarter-Claw — Plan-Mode plugin for OpenClaw. Parity-refresh release candidate. Source-of-truth parity at openclaw-pr70071-rebase tip ea04ea52c7. v1.0 public release gated on upstream chat-stream SDK seam.",
   "type": "module",
   "main": "dist/src/index.js",
@@ -11,6 +11,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
+    "runtime-gate": "node scripts/runtime-registration-gate.mjs",
     "parity-harness": "node scripts/check-host-version-parity.mjs && vitest run tests/parity/parity-harness.test.ts",
     "patch:chat-stream-seam": "node scripts/install-chat-stream-seam.mjs",
     "patch:chat-stream-seam:verify": "node scripts/verify-chat-stream-seam.mjs",
@@ -24,6 +25,7 @@
     "scripts/verify-chat-stream-seam.mjs",
     "scripts/uninstall-chat-stream-seam.mjs",
     "scripts/check-host-version-parity.mjs",
+    "scripts/runtime-registration-gate.mjs",
     "README.md",
     "LICENSE",
     "TRADEMARK.md",
@@ -62,7 +64,16 @@
   "openclaw": {
     "extensions": [
       "./dist/src/index.js"
-    ]
+    ],
+    "install": {
+      "minHostVersion": ">=2026.5.18",
+      "npmSpec": "@electricsheephq/smarter-claw@1.0.0-port.17"
+    },
+    "build": {
+      "command": "pnpm build",
+      "entry": "dist/src/index.js",
+      "manifest": "dist/openclaw.plugin.json"
+    }
   },
   "engines": {
     "node": ">=22.0.0"

--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
     "TRADEMARK.md",
     "RELEASE_NOTES.md"
   ],
-  "dependencies": {},
   "devDependencies": {
     "@types/node": "^22.0.0",
     "openclaw": "2026.5.18",
+    "tsx": "4.20.6",
     "typebox": "^1.1.38",
     "typescript": "^5.6.0",
     "vitest": "^3.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@electricsheephq/smarter-claw",
-  "version": "1.0.0-port.17",
+  "version": "1.0.0-port.18",
   "description": "Smarter-Claw — Plan-Mode plugin for OpenClaw. Parity-refresh release candidate. Source-of-truth parity at openclaw-pr70071-rebase tip ea04ea52c7. v1.0 public release gated on upstream chat-stream SDK seam.",
   "type": "module",
   "main": "dist/src/index.js",
@@ -33,14 +33,14 @@
   ],
   "devDependencies": {
     "@types/node": "^22.0.0",
-    "openclaw": "2026.5.18",
+    "openclaw": "2026.5.19",
     "tsx": "4.20.6",
     "typebox": "^1.1.38",
     "typescript": "^5.6.0",
     "vitest": "^3.2.0"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.5.18"
+    "openclaw": ">=2026.5.19"
   },
   "keywords": [
     "openclaw",
@@ -66,8 +66,8 @@
       "./dist/src/index.js"
     ],
     "install": {
-      "minHostVersion": ">=2026.5.18",
-      "npmSpec": "@electricsheephq/smarter-claw@1.0.0-port.17"
+      "minHostVersion": ">=2026.5.19",
+      "npmSpec": "@electricsheephq/smarter-claw@1.0.0-port.18"
     },
     "build": {
       "command": "pnpm build",
@@ -76,6 +76,6 @@
     }
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.19.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       openclaw:
         specifier: 2026.5.18
         version: 2026.5.18
+      tsx:
+        specifier: 4.20.6
+        version: 4.20.6
       typebox:
         specifier: ^1.1.38
         version: 1.1.38
@@ -22,7 +25,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.0
-        version: 3.2.4(@types/node@22.19.17)(jiti@2.7.0)(yaml@2.9.0)
+        version: 3.2.4(@types/node@22.19.17)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0)
 
 packages:
 
@@ -225,16 +228,34 @@ packages:
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.27.7':
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.7':
@@ -243,16 +264,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.27.7':
     resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.27.7':
     resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.7':
@@ -261,10 +300,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.27.7':
     resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.7':
@@ -273,10 +324,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.27.7':
     resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.7':
@@ -285,10 +348,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.27.7':
     resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.7':
@@ -297,10 +372,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.27.7':
     resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.7':
@@ -309,10 +396,22 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.27.7':
     resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.27.7':
@@ -321,16 +420,34 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.27.7':
     resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.27.7':
     resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.27.7':
@@ -339,10 +456,22 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.27.7':
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.7':
@@ -351,11 +480,23 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/openharmony-arm64@0.27.7':
     resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
 
   '@esbuild/sunos-x64@0.27.7':
     resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
@@ -363,16 +504,34 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.27.7':
     resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.27.7':
     resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.7':
@@ -1462,6 +1621,11 @@ packages:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
 
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
@@ -1600,6 +1764,9 @@ packages:
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
+
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
@@ -2058,6 +2225,9 @@ packages:
   require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   retry@0.12.0:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
     engines: {node: '>= 4'}
@@ -2276,6 +2446,11 @@ packages:
   tslog@4.10.2:
     resolution: {integrity: sha512-XuELoRpMR+sq8fuWwX7P0bcj+PRNiicOKDEb3fGNURhxWVyykCi9BNq7c4uVz7h7P0sj8qgBsr5SWS6yBClq3g==}
     engines: {node: '>=16'}
+
+  tsx@4.20.6:
+    resolution: {integrity: sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
@@ -3014,79 +3189,157 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
     optional: true
 
   '@esbuild/android-arm64@0.27.7':
     optional: true
 
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
   '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
     optional: true
 
   '@esbuild/android-x64@0.27.7':
     optional: true
 
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
   '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
     optional: true
 
   '@esbuild/darwin-x64@0.27.7':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
   '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
     optional: true
 
   '@esbuild/linux-arm@0.27.7':
     optional: true
 
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
   '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
     optional: true
 
   '@esbuild/linux-loong64@0.27.7':
     optional: true
 
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
   '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
   '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.27.7':
     optional: true
 
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
   '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
   '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
     optional: true
 
   '@esbuild/win32-arm64@0.27.7':
     optional: true
 
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
   '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@esbuild/win32-x64@0.27.7':
@@ -3817,13 +4070,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(yaml@2.9.0))':
+  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.2(@types/node@22.19.17)(jiti@2.7.0)(yaml@2.9.0)
+      vite: 7.3.2(@types/node@22.19.17)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -4084,6 +4337,35 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
 
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
   esbuild@0.27.7:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.27.7
@@ -4282,6 +4564,10 @@ snapshots:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
+
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   glob@13.0.6:
     dependencies:
@@ -4752,6 +5038,8 @@ snapshots:
 
   require-main-filename@2.0.0: {}
 
+  resolve-pkg-maps@1.0.0: {}
+
   retry@0.12.0: {}
 
   retry@0.13.1: {}
@@ -5027,6 +5315,13 @@ snapshots:
 
   tslog@4.10.2: {}
 
+  tsx@4.20.6:
+    dependencies:
+      esbuild: 0.25.12
+      get-tsconfig: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
   type-is@2.0.1:
     dependencies:
       content-type: 1.0.5
@@ -5055,13 +5350,13 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-node@3.2.4(@types/node@22.19.17)(jiti@2.7.0)(yaml@2.9.0):
+  vite-node@3.2.4(@types/node@22.19.17)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.2(@types/node@22.19.17)(jiti@2.7.0)(yaml@2.9.0)
+      vite: 7.3.2(@types/node@22.19.17)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -5076,7 +5371,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(yaml@2.9.0):
+  vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -5088,13 +5383,14 @@ snapshots:
       '@types/node': 22.19.17
       fsevents: 2.3.3
       jiti: 2.7.0
+      tsx: 4.20.6
       yaml: 2.9.0
 
-  vitest@3.2.4(@types/node@22.19.17)(jiti@2.7.0)(yaml@2.9.0):
+  vitest@3.2.4(@types/node@22.19.17)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(yaml@2.9.0))
+      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -5112,8 +5408,8 @@ snapshots:
       tinyglobby: 0.2.16
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.2(@types/node@22.19.17)(jiti@2.7.0)(yaml@2.9.0)
-      vite-node: 3.2.4(@types/node@22.19.17)(jiti@2.7.0)(yaml@2.9.0)
+      vite: 7.3.2(@types/node@22.19.17)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@22.19.17)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.17

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^22.0.0
         version: 22.19.17
       openclaw:
-        specifier: 2026.5.18
-        version: 2026.5.18
+        specifier: 2026.5.19
+        version: 2026.5.19
       tsx:
         specifier: 4.20.6
         version: 4.20.6
@@ -2084,8 +2084,8 @@ packages:
       zod:
         optional: true
 
-  openclaw@2026.5.18:
-    resolution: {integrity: sha512-a9p2jdD0SEFUIxyCeOsf8gcO7fdo3vn1zGSYi04gA5mE+J1gHCSJTmk+R+hDPg6XOgHLXD+S2PrKi/74qTGPKw==}
+  openclaw@2026.5.19:
+    resolution: {integrity: sha512-5Pn5hcRDVv3eeWYDp4IPPuvyz3yD+Vrdobykl/vi35/49ZldWUz02pDT5rTGMCInDelNZGaWoXAfm5vFdqha8g==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
@@ -4846,7 +4846,7 @@ snapshots:
       ws: 8.20.1
       zod: 4.4.3
 
-  openclaw@2026.5.18:
+  openclaw@2026.5.19:
     dependencies:
       '@agentclientprotocol/sdk': 0.21.1(zod@4.4.3)
       '@clack/core': 1.3.1

--- a/scripts/check-host-version-parity.mjs
+++ b/scripts/check-host-version-parity.mjs
@@ -67,6 +67,7 @@ const pkg = loadJson("package.json");
 
 const minHostVersion = manifest.minHostVersion;
 const devDepOpenclaw = pkg.devDependencies?.openclaw;
+const pkgOpenClaw = pkg.openclaw;
 
 if (typeof minHostVersion !== "string" || minHostVersion.length === 0) {
   console.error(
@@ -94,6 +95,41 @@ if (minHostVersion !== devDepOpenclaw) {
   process.exit(2);
 }
 
+const expectedInstallFloor = `>=${minHostVersion}`;
+if (pkgOpenClaw?.install?.minHostVersion !== expectedInstallFloor) {
+  console.error(
+    `[host-version-parity] package.json openclaw.install.minHostVersion="${pkgOpenClaw?.install?.minHostVersion}" must be "${expectedInstallFloor}" for OpenClaw's canonical package install gate.`,
+  );
+  process.exit(2);
+}
+
+if (pkgOpenClaw?.build?.command !== "pnpm build") {
+  console.error(
+    `[host-version-parity] package.json openclaw.build.command must be "pnpm build"; got ${JSON.stringify(pkgOpenClaw?.build?.command)}.`,
+  );
+  process.exit(2);
+}
+
+const requiredTools = [
+  "enter_plan_mode",
+  "exit_plan_mode",
+  "ask_user_question",
+];
+const declaredTools = new Set(manifest.contracts?.tools ?? []);
+const missingTools = requiredTools.filter((tool) => !declaredTools.has(tool));
+if (missingTools.length > 0) {
+  console.error(
+    `[host-version-parity] openclaw.plugin.json contracts.tools missing: ${missingTools.join(", ")}.`,
+  );
+  process.exit(2);
+}
+if (!(manifest.contracts?.sessionAttachments ?? []).includes("active-session")) {
+  console.error(
+    '[host-version-parity] openclaw.plugin.json contracts.sessionAttachments must include "active-session".',
+  );
+  process.exit(2);
+}
+
 // Optional: also sanity-check peerDependencies.openclaw (range-spec
 // allowed; the invariant here is "the range INCLUDES minHostVersion").
 // We do a conservative startsWith on a `>=` prefix to keep this script
@@ -110,5 +146,5 @@ if (typeof peerOpenclaw === "string" && peerOpenclaw.startsWith(">=")) {
 }
 
 console.log(
-  `[host-version-parity] OK — minHostVersion=${minHostVersion} == devDependencies.openclaw=${devDepOpenclaw}${peerOpenclaw ? ` (peer=${peerOpenclaw})` : ""}`,
+  `[host-version-parity] OK — manifest minHostVersion=${minHostVersion} == devDependencies.openclaw=${devDepOpenclaw}${peerOpenclaw ? ` (peer=${peerOpenclaw})` : ""}; package install floor=${expectedInstallFloor}; contracts.tools=${requiredTools.join(",")}; sessionAttachments=active-session`,
 );

--- a/scripts/runtime-registration-gate.mjs
+++ b/scripts/runtime-registration-gate.mjs
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+/**
+ * Smarter-Claw runtime registration gate.
+ *
+ * Loads the built plugin entry exactly the way OpenClaw's plugin loader does
+ * and verifies the release-blocking registration surface:
+ *   - every registered agent tool is declared in openclaw.plugin.json contracts.tools
+ *   - CLI registration includes explicit descriptors for plan-clear
+ *   - slash commands, session actions, Control UI, interactive handlers, and
+ *     session workflow calls are all registered with usable metadata
+ *
+ * This gate stays local/cheap for CI, while still failing on the class of
+ * manifest-vs-runtime drift that broke stable 26.5.18 plugin loads.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const repoRoot = resolve(new URL(".", import.meta.url).pathname, "..");
+
+function readJson(path) {
+  return JSON.parse(readFileSync(resolve(repoRoot, path), "utf8"));
+}
+
+function fail(message) {
+  console.error(`[runtime-registration-gate] FAIL: ${message}`);
+  process.exit(1);
+}
+
+const manifest = readJson("openclaw.plugin.json");
+const pkg = readJson("package.json");
+const requiredTools = ["enter_plan_mode", "exit_plan_mode", "ask_user_question"];
+const requiredActions = [
+  "plan.accept",
+  "plan.edit",
+  "plan.reject",
+  "plan.cancel",
+  "plan.answer",
+  "plan.auto.toggle",
+];
+const requiredCommands = ["plan", "plan-mode"];
+
+const declaredTools = new Set(manifest.contracts?.tools ?? []);
+for (const tool of requiredTools) {
+  if (!declaredTools.has(tool)) {
+    fail(`openclaw.plugin.json contracts.tools missing ${tool}`);
+  }
+}
+if (!(manifest.contracts?.sessionAttachments ?? []).includes("active-session")) {
+  fail('openclaw.plugin.json contracts.sessionAttachments missing "active-session"');
+}
+if (pkg.openclaw?.build?.command !== "pnpm build") {
+  fail("package.json openclaw.build.command must be pnpm build");
+}
+if (pkg.openclaw?.install?.minHostVersion !== `>=${manifest.minHostVersion}`) {
+  fail(
+    "package.json openclaw.install.minHostVersion must be the canonical semver floor " +
+      `>=${manifest.minHostVersion}`,
+  );
+}
+
+const captures = {
+  tools: new Map(),
+  cli: [],
+  commands: new Map(),
+  actions: new Map(),
+  interactiveHandlers: new Map(),
+  controlUis: [],
+  sessionExtensions: [],
+  hooks: new Map(),
+};
+
+const logger = {
+  info() {},
+  warn() {},
+  error() {},
+  debug() {},
+};
+
+const api = {
+  id: "smarter-claw",
+  name: "Smarter-Claw",
+  pluginConfig: {},
+  logger,
+  registerTool(tool, opts = {}) {
+    const name = opts.name ?? tool?.name;
+    if (!name) fail("registerTool called without name metadata");
+    captures.tools.set(name, tool);
+  },
+  registerCli(registrar, opts = {}) {
+    captures.cli.push({ registrar, opts });
+  },
+  registerCommand(command) {
+    if (!command?.name) fail("registerCommand called without command.name");
+    captures.commands.set(command.name, command);
+  },
+  registerInteractiveHandler(registration) {
+    if (!registration?.channel || !registration?.namespace || typeof registration.handler !== "function") {
+      fail("registerInteractiveHandler called without channel/namespace/handler");
+    }
+    captures.interactiveHandlers.set(`${registration.channel}:${registration.namespace}`, registration);
+  },
+  on(name, handler) {
+    const existing = captures.hooks.get(name) ?? [];
+    existing.push(handler);
+    captures.hooks.set(name, existing);
+  },
+  session: {
+    state: {
+      registerSessionExtension(extension) {
+        captures.sessionExtensions.push(extension);
+      },
+    },
+    workflow: {
+      enqueueNextTurnInjection: async (injection) => ({
+        enqueued: true,
+        id: "runtime-gate-injection",
+        sessionKey: injection.sessionKey,
+      }),
+      sendSessionAttachment: async () => ({
+        ok: false,
+        error: "runtime gate does not deliver messages",
+      }),
+    },
+    controls: {
+      registerSessionAction(action) {
+        if (!action?.id || typeof action.handler !== "function") {
+          fail("registerSessionAction called without id/handler");
+        }
+        captures.actions.set(action.id, action);
+      },
+      registerControlUiDescriptor(descriptor) {
+        captures.controlUis.push(descriptor);
+      },
+    },
+  },
+};
+
+const entryUrl = pathToFileURL(resolve(repoRoot, pkg.openclaw?.build?.entry ?? "dist/src/index.js"));
+const module = await import(entryUrl.href);
+const entry = module.default ?? module;
+if (typeof entry?.register !== "function") {
+  fail("built plugin entry has no register(api) function");
+}
+
+entry.register(api);
+
+for (const tool of requiredTools) {
+  if (!captures.tools.has(tool)) {
+    fail(`runtime did not register tool ${tool}`);
+  }
+}
+for (const registeredTool of captures.tools.keys()) {
+  if (!declaredTools.has(registeredTool)) {
+    fail(`runtime registered undeclared tool ${registeredTool}`);
+  }
+}
+for (const action of requiredActions) {
+  if (!captures.actions.has(action)) {
+    fail(`runtime did not register session action ${action}`);
+  }
+}
+for (const command of requiredCommands) {
+  if (!captures.commands.has(command)) {
+    fail(`runtime did not register slash command ${command}`);
+  }
+}
+if (!captures.sessionExtensions.some((entry) => entry.namespace === "plan-mode")) {
+  fail("runtime did not register plan-mode session extension");
+}
+if (!captures.controlUis.some((entry) => entry?.id === "smarter-claw.plan-mode.sidebar")) {
+  fail("runtime did not register plan-mode Control UI descriptor");
+}
+if (!captures.interactiveHandlers.has("telegram:smarter-claw-plan")) {
+  fail("runtime did not register Telegram interactive handler smarter-claw-plan");
+}
+const planClear = captures.cli.find((entry) =>
+  (entry.opts?.descriptors ?? []).some(
+    (descriptor) =>
+      descriptor?.name === "plan-clear" &&
+      descriptor.description &&
+      descriptor.hasSubcommands === false,
+  ),
+);
+if (!planClear) {
+  fail("runtime did not register plan-clear CLI with explicit descriptor metadata");
+}
+
+console.log(
+  `[runtime-registration-gate] OK — tools=${captures.tools.size}, actions=${captures.actions.size}, commands=${captures.commands.size}, interactiveHandlers=${captures.interactiveHandlers.size}`,
+);

--- a/scripts/runtime-registration-gate.mjs
+++ b/scripts/runtime-registration-gate.mjs
@@ -15,9 +15,9 @@
 
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
-const repoRoot = resolve(new URL(".", import.meta.url).pathname, "..");
+const repoRoot = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
 
 function readJson(path) {
   return JSON.parse(readFileSync(resolve(repoRoot, path), "utf8"));
@@ -144,7 +144,7 @@ if (typeof entry?.register !== "function") {
   fail("built plugin entry has no register(api) function");
 }
 
-entry.register(api);
+await entry.register(api);
 
 for (const tool of requiredTools) {
   if (!captures.tools.has(tool)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,9 @@
  * add those hooks, the warning is already wired.
  */
 
+import { createRequire } from "node:module";
+import * as fs from "node:fs";
+import * as pathModule from "node:path";
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import {
@@ -56,6 +59,7 @@ import {
 import { decideEscalatingRetry } from "./runtime/escalating-retry.js";
 import { GrantLedger } from "./runtime/grant-ledger.js";
 import { enqueuePlanApprovedInjection } from "./runtime/injection-writer.js";
+import { createPlanModeNotifications } from "./runtime/plan-notifications.js";
 import { decidePlanTierModel } from "./runtime/plan-tier-model.js";
 import { createAskUserQuestionTool } from "./tools/ask-user-question.js";
 import { createEnterPlanModeTool } from "./tools/enter-plan-mode.js";
@@ -304,6 +308,31 @@ export default definePluginEntry({
       },
     );
 
+    // P-12: session-actions — operator-side resolution surface.
+    // /plan accept|reject|cancel|edit|answer + plan.auto.toggle. UI
+    // clients dispatch these by (pluginId, actionId). Telegram-native
+    // buttons and typed /plan commands both route through this same map.
+    const sessionActionRegistrations = createPlanModeSessionActions({
+      api,
+      store,
+    });
+    const sessionActionHandlers = new Map<
+      string,
+      (ctx: never) => unknown
+    >();
+    for (const action of sessionActionRegistrations) {
+      api.session.controls.registerSessionAction(action);
+      sessionActionHandlers.set(
+        action.id,
+        action.handler as (ctx: never) => unknown,
+      );
+    }
+    const notifications = createPlanModeNotifications({
+      api,
+      store,
+      actions: sessionActionHandlers as never,
+    });
+
     api.registerTool(createEnterPlanModeTool({ store }), {
       name: "enter_plan_mode",
     });
@@ -354,6 +383,7 @@ export default definePluginEntry({
               : {}),
           },
         },
+        notifications,
         autoApprove: {
           // The trigger mirrors `plan.accept`'s two-step resolution
           // (src/ui/session-actions.ts ~260-302):
@@ -434,34 +464,12 @@ export default definePluginEntry({
       createAskUserQuestionTool({
         store,
         logger: { warn: (msg: string) => api.logger.warn(msg) },
+        notifications,
       }),
       {
         name: "ask_user_question",
       },
     );
-
-    // P-12: session-actions — operator-side resolution surface.
-    // /plan accept|reject|cancel|edit|answer + plan.auto.toggle. UI
-    // clients dispatch these by (pluginId, actionId). Each handler
-    // verifies the approvalId (stale-event guard), then calls the
-    // PlanModeStore mutator + the appropriate injection-writer.
-    const sessionActionRegistrations = createPlanModeSessionActions({
-      api,
-      store,
-    });
-    const sessionActionHandlers = new Map<
-      string,
-      (ctx: never) => unknown
-    >();
-    for (const action of sessionActionRegistrations) {
-      api.session.controls.registerSessionAction(action);
-      // Snapshot the handler for the /plan slash-command dispatcher
-      // below. Keyed on the action id so /plan accept → plan.accept etc.
-      sessionActionHandlers.set(
-        action.id,
-        action.handler as (ctx: never) => unknown,
-      );
-    }
 
     // Hotfix (2026-05-13): register `/plan` and `/plan-mode` slash
     // commands so users can resolve approvals from chat (not just
@@ -491,7 +499,15 @@ export default definePluginEntry({
 
     // P-12: sweep CLI command — `openclaw plan-clear -s <sessionKey>`.
     // Operator rollback drain for sessions stuck in plan mode.
-    api.registerCli(createPlanClearCli({ store }));
+    api.registerCli(createPlanClearCli({ store }), {
+      descriptors: [
+        {
+          name: "plan-clear",
+          description: "Clear Smarter-Claw plan-mode state for a session.",
+          hasSubcommands: false,
+        },
+      ],
+    });
 
     // P-5: mutation gate (`before_tool_call` hook). Blocks mutating
     // tools when planMode === "plan". Algorithm is byte-identical to
@@ -812,21 +828,13 @@ export default definePluginEntry({
  *   - Detection fails (can't find openclaw): silent no-op (returns generic message)
  */
 function buildChatStreamSeamAdvisory(): string {
-  // Lazy-require fs to keep the plugin entry side-effect-free at import
-  // time for tests + parity harness.
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const fs = require("node:fs") as typeof import("node:fs");
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const pathModule = require("node:path") as typeof import("node:path");
-
   // Resolve openclaw install dir from this module's location.
   // The plugin imports `openclaw/plugin-sdk/...`, so Node has resolved
   // openclaw's package directory. We walk up from `require.resolve` if
   // available; otherwise fall back to relative path heuristic.
   let openclawDir: string | null = null;
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const req = require("node:module").createRequire(import.meta.url) as NodeRequire;
+    const req = createRequire(import.meta.url);
     const openclawPkg = req.resolve("openclaw/package.json");
     openclawDir = pathModule.dirname(openclawPkg);
   } catch {

--- a/src/runtime/plan-notifications.ts
+++ b/src/runtime/plan-notifications.ts
@@ -1,0 +1,540 @@
+import { randomBytes } from "node:crypto";
+import type {
+  OpenClawPluginApi,
+  PluginSessionActionContext,
+  PluginSessionActionResult,
+} from "openclaw/plugin-sdk/plugin-entry";
+import type { PersistPlanArchetypeMarkdownResult } from "../plan-mode/plan-archetype-persist.js";
+import type { PlanModeStore } from "../state/store.js";
+import type { PlanStep } from "../types.js";
+
+export const TELEGRAM_PLAN_INTERACTIVE_NAMESPACE = "smarter-claw-plan";
+
+type PresentationButtonStyle = "primary" | "secondary" | "success" | "danger";
+
+type MessagePresentation = {
+  title?: string;
+  tone?: "info" | "success" | "warning" | "danger" | "neutral";
+  blocks: Array<
+    | { type: "text"; text: string }
+    | { type: "context"; text: string }
+    | { type: "divider" }
+    | {
+        type: "buttons";
+        buttons: Array<{
+          label: string;
+          value: string;
+          style?: PresentationButtonStyle;
+          priority?: number;
+        }>;
+      }
+  >;
+};
+
+type SessionAttachmentParams = {
+  sessionKey: string;
+  files?: Array<{ path: string }>;
+  text?: string;
+  presentation?: MessagePresentation;
+  forceDocument?: boolean;
+  captionFormat?: "plain" | "html" | "markdown";
+  channelHints?: {
+    telegram?: {
+      disableNotification?: boolean;
+    };
+  };
+};
+
+type TelegramInteractiveContext = {
+  channel: "telegram";
+  auth?: { isAuthorizedSender?: boolean };
+  callback: {
+    payload: string;
+  };
+  respond: {
+    reply?: (params: { text: string }) => Promise<void> | void;
+    clearButtons?: () => Promise<void> | void;
+  };
+};
+
+type RegisterInteractiveHandler = (registration: {
+  channel: "telegram";
+  namespace: string;
+  handler: (ctx: TelegramInteractiveContext) => Promise<{ handled: true }>;
+}) => void;
+
+type OpenClawPluginApiWithRuntimeNotifications = OpenClawPluginApi & {
+  registerInteractiveHandler?: RegisterInteractiveHandler;
+  session?: OpenClawPluginApi["session"] & {
+    workflow?: OpenClawPluginApi["session"]["workflow"] & {
+      sendSessionAttachment?: (params: unknown) => Promise<{ ok: true } | { ok: false; error: string }>;
+    };
+  };
+};
+
+export type SessionActionHandler = (
+  ctx: PluginSessionActionContext,
+) => PluginSessionActionResult | void | Promise<PluginSessionActionResult | void>;
+
+type ApprovalTokenEntry = {
+  kind: "approval";
+  sessionKey: string;
+  approvalId: string;
+  action: "accept" | "revise" | "reject" | "cancel";
+  expiresAt: number;
+};
+
+type QuestionTokenEntry = {
+  kind: "question";
+  sessionKey: string;
+  questionId: string;
+  questionPrompt: string;
+  selectedOption: string;
+  expiresAt: number;
+};
+
+type TokenEntry = ApprovalTokenEntry | QuestionTokenEntry;
+type NewTokenEntry =
+  | Omit<ApprovalTokenEntry, "expiresAt">
+  | Omit<QuestionTokenEntry, "expiresAt">;
+type JsonPayload = Record<string, string | number | boolean | null>;
+
+const TOKEN_TTL_MS = 6 * 60 * 60 * 1000;
+const tokens = new Map<string, TokenEntry>();
+
+export function __resetPlanNotificationTokensForTest(): void {
+  tokens.clear();
+}
+
+function createToken(entry: NewTokenEntry): string {
+  const now = Date.now();
+  for (const [token, existing] of tokens) {
+    if (existing.expiresAt <= now) {
+      tokens.delete(token);
+    }
+  }
+  const token = randomBytes(9).toString("base64url");
+  tokens.set(token, {
+    ...entry,
+    expiresAt: now + TOKEN_TTL_MS,
+  } as TokenEntry);
+  return token;
+}
+
+function readToken(token: string): TokenEntry | undefined {
+  const entry = tokens.get(token);
+  if (!entry) return undefined;
+  if (entry.expiresAt <= Date.now()) {
+    tokens.delete(token);
+    return undefined;
+  }
+  return entry;
+}
+
+function callbackValue(action: string, token: string): string {
+  return `${TELEGRAM_PLAN_INTERACTIVE_NAMESPACE}:${action}:${token}`;
+}
+
+function renderPlanText(input: {
+  title: string;
+  summary?: string;
+  persistedPlan?: PersistPlanArchetypeMarkdownResult;
+}): string {
+  const lines = [`Plan approval requested: ${input.title}`];
+  if (input.summary) {
+    lines.push("", input.summary);
+  }
+  if (input.persistedPlan) {
+    lines.push("", `Markdown plan: ${input.persistedPlan.absPath}`);
+  }
+  lines.push(
+    "",
+    "Fallback commands: /plan approve, /plan revise <feedback>, /plan reject <feedback>, /plan cancel.",
+  );
+  return lines.join("\n");
+}
+
+function renderPlanPresentation(input: {
+  sessionKey: string;
+  approvalId: string;
+  title: string;
+  summary?: string;
+  plan: PlanStep[];
+  persistedPlan?: PersistPlanArchetypeMarkdownResult;
+}): MessagePresentation {
+  const accept = createToken({
+    kind: "approval",
+    sessionKey: input.sessionKey,
+    approvalId: input.approvalId,
+    action: "accept",
+  });
+  const revise = createToken({
+    kind: "approval",
+    sessionKey: input.sessionKey,
+    approvalId: input.approvalId,
+    action: "revise",
+  });
+  const reject = createToken({
+    kind: "approval",
+    sessionKey: input.sessionKey,
+    approvalId: input.approvalId,
+    action: "reject",
+  });
+  const cancel = createToken({
+    kind: "approval",
+    sessionKey: input.sessionKey,
+    approvalId: input.approvalId,
+    action: "cancel",
+  });
+  const firstSteps = input.plan
+    .slice(0, 4)
+    .map((step, index) => `${index + 1}. ${step.step}`)
+    .join("\n");
+  return {
+    title: input.title,
+    tone: "warning",
+    blocks: [
+      ...(input.summary ? [{ type: "text" as const, text: input.summary }] : []),
+      ...(firstSteps ? [{ type: "context" as const, text: firstSteps }] : []),
+      ...(input.persistedPlan
+        ? [
+            {
+              type: "context" as const,
+              text: `Markdown artifact: ${input.persistedPlan.filename}`,
+            },
+          ]
+        : []),
+      {
+        type: "buttons",
+        buttons: [
+          {
+            label: "Approve",
+            value: callbackValue("a", accept),
+            style: "success",
+            priority: 100,
+          },
+          {
+            label: "Revise",
+            value: callbackValue("v", revise),
+            style: "primary",
+            priority: 90,
+          },
+          {
+            label: "Reject",
+            value: callbackValue("r", reject),
+            style: "danger",
+            priority: 80,
+          },
+          {
+            label: "Cancel",
+            value: callbackValue("c", cancel),
+            style: "secondary",
+            priority: 70,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function renderQuestionPresentation(input: {
+  sessionKey: string;
+  questionId: string;
+  questionPrompt: string;
+  options: string[];
+}): MessagePresentation {
+  return {
+    title: "Question",
+    tone: "info",
+    blocks: [
+      { type: "text", text: input.questionPrompt },
+      {
+        type: "buttons",
+        buttons: input.options.map((option, index) => {
+          const token = createToken({
+            kind: "question",
+            sessionKey: input.sessionKey,
+            questionId: input.questionId,
+            questionPrompt: input.questionPrompt,
+            selectedOption: option,
+          });
+          return {
+            label: option,
+            value: callbackValue("q", token),
+            style: index === 0 ? "primary" : "secondary",
+            priority: 100 - index,
+          };
+        }),
+      },
+    ],
+  };
+}
+
+async function sendPresentation(
+  api: OpenClawPluginApiWithRuntimeNotifications,
+  params: SessionAttachmentParams,
+): Promise<void> {
+  const sendSessionAttachment = api.session?.workflow?.sendSessionAttachment;
+  if (!sendSessionAttachment) {
+    api.logger.warn(
+      "[smarter-claw] plan notification skipped: host has no session.workflow.sendSessionAttachment runtime seam",
+    );
+    return;
+  }
+  const result = await sendSessionAttachment(params as unknown);
+  if (!result.ok) {
+    api.logger.warn(
+      `[smarter-claw] plan notification delivery skipped: ${result.error}`,
+    );
+  }
+}
+
+async function reply(ctx: TelegramInteractiveContext, text: string): Promise<void> {
+  await ctx.respond.reply?.({ text });
+}
+
+async function clearButtons(ctx: TelegramInteractiveContext): Promise<void> {
+  await ctx.respond.clearButtons?.();
+}
+
+function isAuthorized(ctx: TelegramInteractiveContext): boolean {
+  return ctx.auth?.isAuthorizedSender === true;
+}
+
+async function dispatchSessionAction(
+  actions: Map<string, SessionActionHandler>,
+  actionId: string,
+  sessionKey: string,
+  payload: JsonPayload,
+): Promise<PluginSessionActionResult | void> {
+  const handler = actions.get(actionId);
+  if (!handler) {
+    return {
+      ok: false,
+      error: `session action not registered: ${actionId}`,
+      code: "ACTION_NOT_REGISTERED",
+    };
+  }
+  return await handler({
+    pluginId: "smarter-claw",
+    actionId,
+    sessionKey,
+    payload,
+  });
+}
+
+function isActionOk(result: PluginSessionActionResult | void): boolean {
+  return Boolean(result && result.ok !== false);
+}
+
+function actionError(result: PluginSessionActionResult | void): string {
+  if (!result || result.ok !== false) {
+    return "unknown action failure";
+  }
+  return `${result.code ?? "ERROR"} - ${result.error}`;
+}
+
+async function handleApprovalCallback(input: {
+  ctx: TelegramInteractiveContext;
+  entry: ApprovalTokenEntry;
+  actions: Map<string, SessionActionHandler>;
+  store: PlanModeStore;
+}): Promise<void> {
+  const snap = await input.store.readSnapshot(input.entry.sessionKey);
+  if (
+    !snap ||
+    snap.approvalId !== input.entry.approvalId ||
+    (snap.approval !== "pending" && snap.approval !== "rejected")
+  ) {
+    await clearButtons(input.ctx);
+    await reply(input.ctx, "That plan button is stale. Use /plan status for the current state.");
+    return;
+  }
+
+  const actionId =
+    input.entry.action === "accept"
+      ? "plan.accept"
+      : input.entry.action === "cancel"
+        ? "plan.cancel"
+        : "plan.reject";
+  const payload: JsonPayload =
+    input.entry.action === "accept"
+      ? { approvalId: input.entry.approvalId }
+      : input.entry.action === "revise"
+        ? {
+            approvalId: input.entry.approvalId,
+            feedback: "Please revise the plan.",
+          }
+        : input.entry.action === "reject"
+          ? {
+              approvalId: input.entry.approvalId,
+              feedback: "Rejected from Telegram.",
+            }
+          : {};
+  const result = await dispatchSessionAction(
+    input.actions,
+    actionId,
+    input.entry.sessionKey,
+    payload,
+  );
+  if (!isActionOk(result)) {
+    await clearButtons(input.ctx);
+    await reply(input.ctx, `Plan action failed: ${actionError(result)}`);
+    return;
+  }
+  await clearButtons(input.ctx);
+  const message =
+    input.entry.action === "accept"
+      ? "Plan approved. The agent will resume."
+      : input.entry.action === "cancel"
+        ? "Plan mode cancelled."
+        : "Plan sent back for revision.";
+  await reply(input.ctx, message);
+}
+
+async function handleQuestionCallback(input: {
+  ctx: TelegramInteractiveContext;
+  entry: QuestionTokenEntry;
+  actions: Map<string, SessionActionHandler>;
+  store: PlanModeStore;
+}): Promise<void> {
+  const snap = await input.store.readSnapshot(input.entry.sessionKey);
+  const pending = snap?.pendingQuestion;
+  if (!pending || pending.questionId !== input.entry.questionId) {
+    await clearButtons(input.ctx);
+    await reply(input.ctx, "That question button is stale. Use /plan status for the current state.");
+    return;
+  }
+  if (!pending.allowFreetext && !pending.options.includes(input.entry.selectedOption)) {
+    await clearButtons(input.ctx);
+    await reply(input.ctx, "That question option is stale. The agent has asked a newer question.");
+    return;
+  }
+
+  const result = await dispatchSessionAction(
+    input.actions,
+    "plan.answer",
+    input.entry.sessionKey,
+    {
+      questionId: input.entry.questionId,
+      questionPrompt: input.entry.questionPrompt,
+      selectedOption: input.entry.selectedOption,
+    },
+  );
+  if (!isActionOk(result)) {
+    await reply(input.ctx, `Answer failed: ${actionError(result)}`);
+    return;
+  }
+  const clear = await input.store.clearPendingQuestion({
+    sessionKey: input.entry.sessionKey,
+    expectedQuestionId: input.entry.questionId,
+  });
+  if (clear.kind === "failed") {
+    await input.ctx.respond.reply?.({
+      text:
+        "Answer recorded, but I could not clear the pending question marker. " +
+        "A repeated click will be ignored by the injection idempotency key.",
+    });
+  }
+  await clearButtons(input.ctx);
+  await reply(input.ctx, "Answer recorded. The agent will resume.");
+}
+
+export interface PlanApprovalNotificationInput {
+  sessionKey: string;
+  approvalId: string;
+  title: string;
+  summary?: string;
+  plan: PlanStep[];
+  persistedPlan?: PersistPlanArchetypeMarkdownResult;
+}
+
+export interface QuestionNotificationInput {
+  sessionKey: string;
+  questionId: string;
+  questionPrompt: string;
+  options: string[];
+}
+
+export interface PlanModeNotificationSink {
+  notifyPlanApproval(input: PlanApprovalNotificationInput): Promise<void>;
+  notifyQuestion(input: QuestionNotificationInput): Promise<void>;
+}
+
+export function createPlanModeNotifications(input: {
+  api: OpenClawPluginApi;
+  store: PlanModeStore;
+  actions: Map<string, SessionActionHandler>;
+}): PlanModeNotificationSink {
+  const api = input.api as OpenClawPluginApiWithRuntimeNotifications;
+  const registerInteractiveHandler = (
+    api as { registerInteractiveHandler?: RegisterInteractiveHandler }
+  ).registerInteractiveHandler;
+  registerInteractiveHandler?.({
+    channel: "telegram",
+    namespace: TELEGRAM_PLAN_INTERACTIVE_NAMESPACE,
+    handler: async (ctx: TelegramInteractiveContext) => {
+      if (!isAuthorized(ctx)) {
+        await reply(ctx, "You are not authorized to use this plan action.");
+        return { handled: true };
+      }
+      const [action, token] = ctx.callback.payload.split(":", 2);
+      if (!action || !token) {
+        await reply(ctx, "Invalid plan action payload.");
+        return { handled: true };
+      }
+      const entry = readToken(token);
+      if (!entry) {
+        await clearButtons(ctx);
+        await reply(ctx, "That plan action has expired. Use /plan status for the current state.");
+        return { handled: true };
+      }
+      if (entry.kind === "approval") {
+        await handleApprovalCallback({
+          ctx,
+          entry,
+          actions: input.actions,
+          store: input.store,
+        });
+        return { handled: true };
+      }
+      if (entry.kind === "question") {
+        await handleQuestionCallback({
+          ctx,
+          entry,
+          actions: input.actions,
+          store: input.store,
+        });
+        return { handled: true };
+      }
+      return { handled: true };
+    },
+  });
+
+  return {
+    async notifyPlanApproval(params) {
+      await sendPresentation(api, {
+        sessionKey: params.sessionKey,
+        files: params.persistedPlan ? [{ path: params.persistedPlan.absPath }] : [],
+        text: renderPlanText(params),
+        presentation: renderPlanPresentation(params),
+        forceDocument: params.persistedPlan ? true : undefined,
+        captionFormat: "plain",
+        channelHints: {
+          telegram: {
+            disableNotification: false,
+          },
+        },
+      });
+    },
+    async notifyQuestion(params) {
+      await sendPresentation(api, {
+        sessionKey: params.sessionKey,
+        files: [],
+        text: `Question: ${params.questionPrompt}`,
+        presentation: renderQuestionPresentation(params),
+        captionFormat: "plain",
+      });
+    },
+  };
+}

--- a/src/runtime/plan-notifications.ts
+++ b/src/runtime/plan-notifications.ts
@@ -370,7 +370,7 @@ async function handleApprovalCallback(input: {
               approvalId: input.entry.approvalId,
               feedback: "Rejected from Telegram.",
             }
-          : {};
+          : { approvalId: input.entry.approvalId };
   const result = await dispatchSessionAction(
     input.actions,
     actionId,

--- a/src/runtime/plan-notifications.ts
+++ b/src/runtime/plan-notifications.ts
@@ -106,6 +106,10 @@ export function __resetPlanNotificationTokensForTest(): void {
   tokens.clear();
 }
 
+export function __getPlanNotificationTokenCountForTest(): number {
+  return tokens.size;
+}
+
 function createToken(entry: NewTokenEntry): string {
   const now = Date.now();
   for (const [token, existing] of tokens) {
@@ -121,14 +125,20 @@ function createToken(entry: NewTokenEntry): string {
   return token;
 }
 
-function readToken(token: string): TokenEntry | undefined {
+function consumeToken(token: string): TokenEntry | undefined {
   const entry = tokens.get(token);
   if (!entry) return undefined;
+  tokens.delete(token);
   if (entry.expiresAt <= Date.now()) {
-    tokens.delete(token);
     return undefined;
   }
   return entry;
+}
+
+function discardTokens(values: string[]): void {
+  for (const token of values) {
+    tokens.delete(token);
+  }
 }
 
 function callbackValue(action: string, token: string): string {
@@ -161,7 +171,7 @@ function renderPlanPresentation(input: {
   summary?: string;
   plan: PlanStep[];
   persistedPlan?: PersistPlanArchetypeMarkdownResult;
-}): MessagePresentation {
+}): { presentation: MessagePresentation; tokens: string[] } {
   const accept = createToken({
     kind: "approval",
     sessionKey: input.sessionKey,
@@ -191,49 +201,52 @@ function renderPlanPresentation(input: {
     .map((step, index) => `${index + 1}. ${step.step}`)
     .join("\n");
   return {
-    title: input.title,
-    tone: "warning",
-    blocks: [
-      ...(input.summary ? [{ type: "text" as const, text: input.summary }] : []),
-      ...(firstSteps ? [{ type: "context" as const, text: firstSteps }] : []),
-      ...(input.persistedPlan
-        ? [
+    tokens: [accept, revise, reject, cancel],
+    presentation: {
+      title: input.title,
+      tone: "warning",
+      blocks: [
+        ...(input.summary ? [{ type: "text" as const, text: input.summary }] : []),
+        ...(firstSteps ? [{ type: "context" as const, text: firstSteps }] : []),
+        ...(input.persistedPlan
+          ? [
+              {
+                type: "context" as const,
+                text: `Markdown artifact: ${input.persistedPlan.filename}`,
+              },
+            ]
+          : []),
+        {
+          type: "buttons",
+          buttons: [
             {
-              type: "context" as const,
-              text: `Markdown artifact: ${input.persistedPlan.filename}`,
+              label: "Approve",
+              value: callbackValue("a", accept),
+              style: "success",
+              priority: 100,
             },
-          ]
-        : []),
-      {
-        type: "buttons",
-        buttons: [
-          {
-            label: "Approve",
-            value: callbackValue("a", accept),
-            style: "success",
-            priority: 100,
-          },
-          {
-            label: "Revise",
-            value: callbackValue("v", revise),
-            style: "primary",
-            priority: 90,
-          },
-          {
-            label: "Reject",
-            value: callbackValue("r", reject),
-            style: "danger",
-            priority: 80,
-          },
-          {
-            label: "Cancel",
-            value: callbackValue("c", cancel),
-            style: "secondary",
-            priority: 70,
-          },
-        ],
-      },
-    ],
+            {
+              label: "Revise",
+              value: callbackValue("v", revise),
+              style: "primary",
+              priority: 90,
+            },
+            {
+              label: "Reject",
+              value: callbackValue("r", reject),
+              style: "danger",
+              priority: 80,
+            },
+            {
+              label: "Cancel",
+              value: callbackValue("c", cancel),
+              style: "secondary",
+              priority: 70,
+            },
+          ],
+        },
+      ],
+    },
   };
 }
 
@@ -242,51 +255,58 @@ function renderQuestionPresentation(input: {
   questionId: string;
   questionPrompt: string;
   options: string[];
-}): MessagePresentation {
+}): { presentation: MessagePresentation; tokens: string[] } {
+  const mintedTokens: string[] = [];
   return {
-    title: "Question",
-    tone: "info",
-    blocks: [
-      { type: "text", text: input.questionPrompt },
-      {
-        type: "buttons",
-        buttons: input.options.map((option, index) => {
-          const token = createToken({
-            kind: "question",
-            sessionKey: input.sessionKey,
-            questionId: input.questionId,
-            questionPrompt: input.questionPrompt,
-            selectedOption: option,
-          });
-          return {
-            label: option,
-            value: callbackValue("q", token),
-            style: index === 0 ? "primary" : "secondary",
-            priority: 100 - index,
-          };
-        }),
-      },
-    ],
+    tokens: mintedTokens,
+    presentation: {
+      title: "Question",
+      tone: "info",
+      blocks: [
+        { type: "text", text: input.questionPrompt },
+        {
+          type: "buttons",
+          buttons: input.options.map((option, index) => {
+            const token = createToken({
+              kind: "question",
+              sessionKey: input.sessionKey,
+              questionId: input.questionId,
+              questionPrompt: input.questionPrompt,
+              selectedOption: option,
+            });
+            mintedTokens.push(token);
+            return {
+              label: option,
+              value: callbackValue("q", token),
+              style: index === 0 ? "primary" : "secondary",
+              priority: 100 - index,
+            };
+          }),
+        },
+      ],
+    },
   };
 }
 
 async function sendPresentation(
   api: OpenClawPluginApiWithRuntimeNotifications,
   params: SessionAttachmentParams,
-): Promise<void> {
+): Promise<boolean> {
   const sendSessionAttachment = api.session?.workflow?.sendSessionAttachment;
   if (!sendSessionAttachment) {
     api.logger.warn(
       "[smarter-claw] plan notification skipped: host has no session.workflow.sendSessionAttachment runtime seam",
     );
-    return;
+    return false;
   }
   const result = await sendSessionAttachment(params as unknown);
   if (!result.ok) {
     api.logger.warn(
       `[smarter-claw] plan notification delivery skipped: ${result.error}`,
     );
+    return false;
   }
+  return true;
 }
 
 async function reply(ctx: TelegramInteractiveContext, text: string): Promise<void> {
@@ -483,7 +503,7 @@ export function createPlanModeNotifications(input: {
         await reply(ctx, "Invalid plan action payload.");
         return { handled: true };
       }
-      const entry = readToken(token);
+      const entry = consumeToken(token);
       if (!entry) {
         await clearButtons(ctx);
         await reply(ctx, "That plan action has expired. Use /plan status for the current state.");
@@ -513,28 +533,46 @@ export function createPlanModeNotifications(input: {
 
   return {
     async notifyPlanApproval(params) {
-      await sendPresentation(api, {
-        sessionKey: params.sessionKey,
-        files: params.persistedPlan ? [{ path: params.persistedPlan.absPath }] : [],
-        text: renderPlanText(params),
-        presentation: renderPlanPresentation(params),
-        forceDocument: params.persistedPlan ? true : undefined,
-        captionFormat: "plain",
-        channelHints: {
-          telegram: {
-            disableNotification: false,
+      const rendered = renderPlanPresentation(params);
+      try {
+        const delivered = await sendPresentation(api, {
+          sessionKey: params.sessionKey,
+          files: params.persistedPlan ? [{ path: params.persistedPlan.absPath }] : [],
+          text: renderPlanText(params),
+          presentation: rendered.presentation,
+          forceDocument: params.persistedPlan ? true : undefined,
+          captionFormat: "plain",
+          channelHints: {
+            telegram: {
+              disableNotification: false,
+            },
           },
-        },
-      });
+        });
+        if (!delivered) {
+          discardTokens(rendered.tokens);
+        }
+      } catch (error) {
+        discardTokens(rendered.tokens);
+        throw error;
+      }
     },
     async notifyQuestion(params) {
-      await sendPresentation(api, {
-        sessionKey: params.sessionKey,
-        files: [],
-        text: `Question: ${params.questionPrompt}`,
-        presentation: renderQuestionPresentation(params),
-        captionFormat: "plain",
-      });
+      const rendered = renderQuestionPresentation(params);
+      try {
+        const delivered = await sendPresentation(api, {
+          sessionKey: params.sessionKey,
+          files: [],
+          text: `Question: ${params.questionPrompt}`,
+          presentation: rendered.presentation,
+          captionFormat: "plain",
+        });
+        if (!delivered) {
+          discardTokens(rendered.tokens);
+        }
+      } catch (error) {
+        discardTokens(rendered.tokens);
+        throw error;
+      }
     },
   };
 }

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -389,24 +389,50 @@ export class PlanModeStore {
    *   In-host the state-transition is wired in the runner; we encode it
    *   in the store directly.
    */
-  async exitPlanMode(input: { sessionKey: string }): Promise<
+  async exitPlanMode(input: { sessionKey: string; expectedApprovalId?: string }): Promise<
     | { kind: "exited"; state: PlanModeSessionState }
     | { kind: "noop"; state: PlanModeSessionState | undefined }
+    | {
+        kind: "skipped";
+        reason: "not_in_plan_mode" | "no_pending_approval" | "stale_approval_id";
+        state: PlanModeSessionState | undefined;
+      }
     | { kind: "failed"; error: Error }
   > {
-    const { sessionKey } = input;
+    const { sessionKey, expectedApprovalId } = input;
     try {
       let outcome:
         | { kind: "exited"; state: PlanModeSessionState }
-        | { kind: "noop"; state: PlanModeSessionState | undefined };
+        | { kind: "noop"; state: PlanModeSessionState | undefined }
+        | {
+            kind: "skipped";
+            reason: "not_in_plan_mode" | "no_pending_approval" | "stale_approval_id";
+            state: PlanModeSessionState | undefined;
+          };
 
       const { transition } = await this.gateway.withLock<{
         prev: PlanModeSessionState | undefined;
         next: PlanModeSessionState;
       }>(sessionKey, async (current) => {
-        // Idempotent: no payload, or already in normal mode.
+        // Idempotent: no payload, or already in normal mode. If the
+        // caller supplied an approval token, preserve the stale/no-pending
+        // distinction inside the same lock so callback races cannot cancel
+        // a newer approval cycle.
         if (!current || current.mode === "normal") {
-          outcome = { kind: "noop", state: current };
+          outcome = expectedApprovalId
+            ? { kind: "skipped", reason: "not_in_plan_mode", state: current }
+            : { kind: "noop", state: current };
+          return { next: null };
+        }
+        if (
+          expectedApprovalId &&
+          (current.approval !== "pending" && current.approval !== "rejected")
+        ) {
+          outcome = { kind: "skipped", reason: "no_pending_approval", state: current };
+          return { next: null };
+        }
+        if (expectedApprovalId && current.approvalId !== expectedApprovalId) {
+          outcome = { kind: "skipped", reason: "stale_approval_id", state: current };
           return { next: null };
         }
         const now = Date.now();

--- a/src/tools/ask-user-question.ts
+++ b/src/tools/ask-user-question.ts
@@ -80,7 +80,7 @@ export interface CreateAskUserQuestionToolInput {
   /**
    * Optional rich-channel notification sink. Production wiring sends
    * Telegram-native question buttons when the host exposes the
-   * active-session presentation seam; stable 26.5.18 falls back to
+   * active-session presentation seam; stable 26.5.19 falls back to
    * typed `/plan answer` when the host returns an unavailable result.
    */
   notifications?: Pick<PlanModeNotificationSink, "notifyQuestion">;

--- a/src/tools/ask-user-question.ts
+++ b/src/tools/ask-user-question.ts
@@ -42,6 +42,7 @@
 
 import { Type } from "typebox";
 import { describeAskUserQuestionTool } from "../plan-mode/tool-descriptions.js";
+import type { PlanModeNotificationSink } from "../runtime/plan-notifications.js";
 import type { PlanModeStore } from "../state/store.js";
 import { ToolInputError, readStringParam } from "./common.js";
 
@@ -76,6 +77,13 @@ export interface CreateAskUserQuestionToolInput {
   logger?: {
     warn?: (message: string) => void;
   };
+  /**
+   * Optional rich-channel notification sink. Production wiring sends
+   * Telegram-native question buttons when the host exposes the
+   * active-session presentation seam; stable 26.5.18 falls back to
+   * typed `/plan answer` when the host returns an unavailable result.
+   */
+  notifications?: Pick<PlanModeNotificationSink, "notifyQuestion">;
 }
 
 const SCHEMA = Type.Object(
@@ -200,6 +208,19 @@ export function createAskUserQuestionTool(
               opts.logger?.warn?.(
                 `ask_user_question: persistPendingQuestion failed (sessionKey=${ctx.sessionKey} questionId=${questionId}): ${result.error.message}`,
               );
+            } else {
+              try {
+                await opts.notifications?.notifyQuestion({
+                  sessionKey: ctx.sessionKey,
+                  questionId,
+                  questionPrompt: question,
+                  options,
+                });
+              } catch (notifyErr) {
+                opts.logger?.warn?.(
+                  `ask_user_question: notifyQuestion failed (sessionKey=${ctx.sessionKey} questionId=${questionId}): ${notifyErr instanceof Error ? notifyErr.message : String(notifyErr)}`,
+                );
+              }
             }
           } catch (persistErr) {
             // Defense-in-depth: persistPendingQuestion already

--- a/src/tools/exit-plan-mode.ts
+++ b/src/tools/exit-plan-mode.ts
@@ -60,6 +60,7 @@ import { computePlanPayloadHash } from "../helpers/payload-hash.js";
 import {
   persistPlanArchetypeMarkdown,
   PlanPersistStorageError,
+  type PersistPlanArchetypeMarkdownResult,
 } from "../plan-mode/plan-archetype-persist.js";
 import { renderFullPlanArchetypeMarkdown } from "../plan-mode/plan-render.js";
 import {
@@ -67,6 +68,7 @@ import {
   EXIT_PLAN_MODE_TOOL_DISPLAY_SUMMARY,
 } from "../plan-mode/tool-descriptions.js";
 import { PlanModeStore } from "../state/store.js";
+import type { PlanModeNotificationSink } from "../runtime/plan-notifications.js";
 import type { PlanStep } from "../types.js";
 import {
   PLAN_STEP_STATUSES,
@@ -234,6 +236,14 @@ export interface CreateExitPlanModeToolInput {
    * host_ref: src/agents/pi-embedded-subscribe.handlers.tools.ts:1949-1962
    */
   autoApprove?: ExitPlanModeAutoApproveOptions;
+  /**
+   * Optional rich-channel notification sink. Production wiring sends the
+   * persisted Markdown plan and native Telegram approval buttons when the
+   * host permits active-session plugin attachments. On plain 26.5.18 the
+   * host rejects that SDK call, so this path logs and the typed `/plan`
+   * fallback remains authoritative.
+   */
+  notifications?: Pick<PlanModeNotificationSink, "notifyPlanApproval">;
 }
 
 interface ToolContext {
@@ -624,8 +634,9 @@ export function createExitPlanModeTool(opts: CreateExitPlanModeToolInput) {
       // the building block a future host-side or bundled-capability
       // notifier would attach. Today, Telegram/Slack users get no
       // signal — the same gap the in-host has on non-Telegram channels.
+      let persistedPlan: PersistPlanArchetypeMarkdownResult | undefined;
       if (r.kind === "persisted") {
-        await persistPlanArchetypeIfConfigured({
+        persistedPlan = await persistPlanArchetypeIfConfigured({
           opts,
           ctx,
           plan: steps,
@@ -645,6 +656,28 @@ export function createExitPlanModeTool(opts: CreateExitPlanModeToolInput) {
             ? { references: archetype.references }
             : {}),
         });
+      }
+
+      if (r.kind === "persisted" && opts.notifications) {
+        try {
+          const snap = await opts.store.readSnapshot(sessionKey);
+          if (snap?.autoApprove !== true) {
+            await opts.notifications.notifyPlanApproval({
+              sessionKey,
+              approvalId: r.approvalId,
+              title,
+              ...(summary !== undefined ? { summary } : {}),
+              plan: steps,
+              ...(persistedPlan ? { persistedPlan } : {}),
+            });
+          }
+        } catch (notifyErr) {
+          opts.persister?.log?.warn?.(
+            `[smarter-claw] exit_plan_mode: plan notification failed: ${
+              notifyErr instanceof Error ? notifyErr.message : String(notifyErr)
+            }`,
+          );
+        }
       }
 
       // W1-F4 fix (2026-05-20): auto-approve trigger.
@@ -752,6 +785,14 @@ export function createExitPlanModeTool(opts: CreateExitPlanModeToolInput) {
           payloadHash,
           stepCount: steps.length,
           plan: steps,
+          ...(persistedPlan
+            ? {
+                persistedPlan: {
+                  path: persistedPlan.absPath,
+                  filename: persistedPlan.filename,
+                },
+              }
+            : {}),
           ...(title ? { title } : {}),
           ...(summary ? { summary } : {}),
           // PR-10 archetype fields. Spread only when the agent supplied
@@ -807,7 +848,7 @@ async function persistPlanArchetypeIfConfigured(input: {
   risks?: Array<{ risk: string; mitigation: string }>;
   verification?: string[];
   references?: string[];
-}): Promise<void> {
+}): Promise<PersistPlanArchetypeMarkdownResult | undefined> {
   const { opts, ctx } = input;
   const log = opts.persister?.log;
   if (!opts.persister) {
@@ -818,14 +859,14 @@ async function persistPlanArchetypeIfConfigured(input: {
       "[smarter-claw] exit_plan_mode: persister not configured; plan markdown NOT written. " +
         "Wire `persister` in createExitPlanModeTool({...}) to fulfil the archetype-prompt persistence promise.",
     );
-    return;
+    return undefined;
   }
   if (!ctx.agentId) {
     log?.warn?.(
       "[smarter-claw] exit_plan_mode: agentId missing from tool context; plan markdown NOT written. " +
         "The host SDK normally supplies agentId on OpenClawPluginToolContext.",
     );
-    return;
+    return undefined;
   }
   try {
     const markdown = renderFullPlanArchetypeMarkdown({
@@ -844,7 +885,7 @@ async function persistPlanArchetypeIfConfigured(input: {
         ? { references: input.references }
         : {}),
     });
-    const { filename } = await persistPlanArchetypeMarkdown({
+    const persisted = await persistPlanArchetypeMarkdown({
       agentId: ctx.agentId,
       title: input.title,
       markdown,
@@ -853,8 +894,9 @@ async function persistPlanArchetypeIfConfigured(input: {
         : {}),
     });
     log?.info?.(
-      `[smarter-claw] exit_plan_mode: persisted plan markdown agentId=${ctx.agentId} filename=${filename}`,
+      `[smarter-claw] exit_plan_mode: persisted plan markdown agentId=${ctx.agentId} filename=${persisted.filename}`,
     );
+    return persisted;
   } catch (err) {
     // Match the in-host bridge's two-bucket failure handling
     // (plan-archetype-bridge.ts:188-203): recoverable storage errors
@@ -867,13 +909,14 @@ async function persistPlanArchetypeIfConfigured(input: {
           `Operator action: check ~/.openclaw free space / permissions. ` +
           `Detail: ${err.message}`,
       );
-      return;
+      return undefined;
     }
     log?.warn?.(
       `[smarter-claw] exit_plan_mode: plan markdown persist failed: ${
         err instanceof Error ? err.message : String(err)
       }`,
     );
+    return undefined;
   }
 }
 

--- a/src/tools/exit-plan-mode.ts
+++ b/src/tools/exit-plan-mode.ts
@@ -239,7 +239,7 @@ export interface CreateExitPlanModeToolInput {
   /**
    * Optional rich-channel notification sink. Production wiring sends the
    * persisted Markdown plan and native Telegram approval buttons when the
-   * host permits active-session plugin attachments. On plain 26.5.18 the
+   * host permits active-session plugin attachments. On plain 26.5.19 the
    * host rejects that SDK call, so this path logs and the typed `/plan`
    * fallback remains authoritative.
    */
@@ -623,7 +623,7 @@ export function createExitPlanModeTool(opts: CreateExitPlanModeToolInput) {
       // "HTML" })` to push the persisted markdown to Telegram as the
       // user's action-required signal. The plugin port stops at the
       // PERSIST half — the push half is unimplementable on SDK
-      // `2026.5.18` because `api.session.workflow.sendSessionAttachment`
+      // `2026.5.19` because `api.session.workflow.sendSessionAttachment`
       // rejects 3P plugins (`host-hook-attachments.ts:216-218` —
       // `if (origin !== "bundled") return { ok: false, error:
       // "session attachments are restricted to bundled plugins" }`).

--- a/src/types.ts
+++ b/src/types.ts
@@ -223,7 +223,7 @@ export interface PlanModeSessionState {
    *  primary signal a future turn-limit watchdog would consume to
    *  auto-exit plan mode on a runaway loop. The watchdog itself is
    *  deferred — neither the in-host has a parity reference nor does
-   *  SDK 2026.5.18 expose a fit-for-purpose event-driven scheduler
+   *  SDK 2026.5.19 expose a fit-for-purpose event-driven scheduler
    *  seam (`registerSessionSchedulerJob` is cleanup-only;
    *  `scheduleSessionTurn` is cron-driven). See
    *  `docs/audits/parity-refresh/blocker-W1-E1.md` for the

--- a/src/ui/session-actions.ts
+++ b/src/ui/session-actions.ts
@@ -456,11 +456,35 @@ export function createPlanModeSessionActions(
     handler: async (ctx) => {
       const sk = requireSessionKey(ctx);
       if (!sk.ok) return sk.result;
-      const result = await store.exitPlanMode({ sessionKey: sk.sessionKey });
+      const p = readPayload(ctx.payload);
+      if (!p.ok) return p.result;
+      const expectedApprovalId = readStringField(p.value, "approvalId");
+      const result = await store.exitPlanMode({
+        sessionKey: sk.sessionKey,
+        ...(expectedApprovalId !== undefined ? { expectedApprovalId } : {}),
+      });
       if (result.kind === "failed") {
         return err(
           SESSION_ACTION_ERROR_CODES.STORE_ERROR,
           `exitPlanMode failed: ${result.error.message}`,
+        );
+      }
+      if (result.kind === "skipped") {
+        if (result.reason === "stale_approval_id") {
+          return err(
+            SESSION_ACTION_ERROR_CODES.STALE_APPROVAL_ID,
+            "expectedApprovalId did not match current approvalId; event is stale",
+          );
+        }
+        if (result.reason === "no_pending_approval") {
+          return err(
+            SESSION_ACTION_ERROR_CODES.NO_PENDING_APPROVAL,
+            "session has no actionable approval",
+          );
+        }
+        return err(
+          SESSION_ACTION_ERROR_CODES.NOT_IN_PLAN_MODE,
+          "session is not in plan mode",
         );
       }
       log.info(

--- a/tests/eva-live-smokes/harness.ts
+++ b/tests/eva-live-smokes/harness.ts
@@ -39,10 +39,13 @@ export interface HarnessCaptures {
   sessionExtensions: Array<{ namespace: string; description?: string }>;
   controlUis: unknown[];
   enqueuedInjections: unknown[];
+  sessionAttachments: unknown[];
+  interactiveHandlers: Map<string, (ctx: unknown) => unknown>;
   loggerInfo: string[];
   loggerWarn: string[];
   loggerError: string[];
   cliRegistrars: Array<(ctx: unknown) => void>;
+  cliOptions: unknown[];
   /** Slash commands registered via `api.registerCommand` (keyed by name). */
   commands: Map<string, unknown>;
 }
@@ -75,10 +78,13 @@ export function createHarness(options: {
     sessionExtensions: [],
     controlUis: [],
     enqueuedInjections: [],
+    sessionAttachments: [],
+    interactiveHandlers: new Map(),
     loggerInfo: [],
     loggerWarn: [],
     loggerError: [],
     cliRegistrars: [],
+    cliOptions: [],
     commands: new Map(),
   };
 
@@ -109,14 +115,23 @@ export function createHarness(options: {
       const name = opts?.name ?? "<unknown>";
       captures.tools.set(name, tool);
     }),
-    registerCli: vi.fn((registrar: (ctx: unknown) => void) => {
+    registerCli: vi.fn((registrar: (ctx: unknown) => void, opts?: unknown) => {
       captures.cliRegistrars.push(registrar);
+      captures.cliOptions.push(opts);
     }),
     registerCommand: vi.fn((command: { name?: string }) => {
       // `/plan` + `/plan-mode` slash commands (hotfix #93). Keyed by
       // command name so smokes can look them up + invoke the handler.
       captures.commands.set(command?.name ?? "<unknown>", command);
     }),
+    registerInteractiveHandler: vi.fn(
+      (registration: { channel: string; namespace: string; handler: (ctx: unknown) => unknown }) => {
+        captures.interactiveHandlers.set(
+          `${registration.channel}:${registration.namespace}`,
+          registration.handler,
+        );
+      },
+    ),
     session: {
       state: {
         registerSessionExtension: vi.fn(
@@ -132,6 +147,17 @@ export function createHarness(options: {
             enqueued: true,
             id: `inj-${captures.enqueuedInjections.length}`,
             sessionKey: (injection as { sessionKey: string }).sessionKey,
+          };
+        }),
+        sendSessionAttachment: vi.fn(async (attachment: unknown) => {
+          captures.sessionAttachments.push(attachment);
+          return {
+            ok: true,
+            channel: "telegram",
+            deliveredTo: "12345",
+            count: Array.isArray((attachment as { files?: unknown }).files)
+              ? ((attachment as { files: unknown[] }).files.length)
+              : 0,
           };
         }),
       },

--- a/tests/runtime/plan-notifications.test.ts
+++ b/tests/runtime/plan-notifications.test.ts
@@ -145,6 +145,41 @@ describe("plan notifications", () => {
     });
   });
 
+  it("dispatches Telegram cancel callbacks through plan.cancel with approvalId", async () => {
+    const { api, store, sendSessionAttachment, getHandler } = build();
+    const cancel = vi.fn(async () => ({ ok: true as const, continueAgent: false }));
+    const notifications = createPlanModeNotifications({
+      api: api as never,
+      store,
+      actions: new Map([["plan.cancel", cancel]]),
+    });
+    await notifications.notifyPlanApproval({
+      sessionKey: SESSION_KEY,
+      approvalId: "plan-11111111-1111-4111-8111-111111111111",
+      title: "Ship plan",
+      plan: [{ step: "Run focused tests", status: "pending" }],
+    });
+    const value = firstButtonValue(sendSessionAttachment.mock.calls[0]?.[0], "Cancel");
+    const payload = value.slice(`${TELEGRAM_PLAN_INTERACTIVE_NAMESPACE}:`.length);
+    const ctx = telegramCtx(payload);
+
+    await getHandler()?.(ctx);
+
+    expect(cancel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionId: "plan.cancel",
+        sessionKey: SESSION_KEY,
+        payload: {
+          approvalId: "plan-11111111-1111-4111-8111-111111111111",
+        },
+      }),
+    );
+    expect(ctx.respond.clearButtons).toHaveBeenCalledOnce();
+    expect(ctx.respond.reply).toHaveBeenCalledWith({
+      text: "Plan mode cancelled.",
+    });
+  });
+
   it("rejects stale Telegram approval callbacks without dispatching the action", async () => {
     const { gw, api, store, sendSessionAttachment, getHandler } = build();
     const accept = vi.fn(async () => ({ ok: true as const }));

--- a/tests/runtime/plan-notifications.test.ts
+++ b/tests/runtime/plan-notifications.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  __getPlanNotificationTokenCountForTest,
   __resetPlanNotificationTokensForTest,
   createPlanModeNotifications,
   TELEGRAM_PLAN_INTERACTIVE_NAMESPACE,
@@ -145,6 +146,34 @@ describe("plan notifications", () => {
     });
   });
 
+  it("invalidates Telegram approval callback tokens after first use", async () => {
+    const { api, store, sendSessionAttachment, getHandler } = build();
+    const accept = vi.fn(async () => ({ ok: true as const, continueAgent: true }));
+    const notifications = createPlanModeNotifications({
+      api: api as never,
+      store,
+      actions: new Map([["plan.accept", accept]]),
+    });
+    await notifications.notifyPlanApproval({
+      sessionKey: SESSION_KEY,
+      approvalId: "plan-11111111-1111-4111-8111-111111111111",
+      title: "Ship plan",
+      plan: [{ step: "Run focused tests", status: "pending" }],
+    });
+    const value = firstButtonValue(sendSessionAttachment.mock.calls[0]?.[0], "Approve");
+    const payload = value.slice(`${TELEGRAM_PLAN_INTERACTIVE_NAMESPACE}:`.length);
+
+    await getHandler()?.(telegramCtx(payload));
+    const replayCtx = telegramCtx(payload);
+    await getHandler()?.(replayCtx);
+
+    expect(accept).toHaveBeenCalledTimes(1);
+    expect(replayCtx.respond.clearButtons).toHaveBeenCalledOnce();
+    expect(replayCtx.respond.reply).toHaveBeenCalledWith({
+      text: "That plan action has expired. Use /plan status for the current state.",
+    });
+  });
+
   it("dispatches Telegram cancel callbacks through plan.cancel with approvalId", async () => {
     const { api, store, sendSessionAttachment, getHandler } = build();
     const cancel = vi.fn(async () => ({ ok: true as const, continueAgent: false }));
@@ -253,5 +282,25 @@ describe("plan notifications", () => {
     );
     expect((await store.readSnapshot(SESSION_KEY))?.pendingQuestion).toBeUndefined();
     expect(ctx.respond.clearButtons).toHaveBeenCalledOnce();
+  });
+
+  it("discards callback tokens when attachment delivery fails", async () => {
+    const { api, store, sendSessionAttachment } = build();
+    sendSessionAttachment.mockResolvedValueOnce({
+      ok: false,
+      error: "host rejected active-session attachments",
+    });
+    await createPlanModeNotifications({
+      api: api as never,
+      store,
+      actions: new Map(),
+    }).notifyPlanApproval({
+      sessionKey: SESSION_KEY,
+      approvalId: "plan-11111111-1111-4111-8111-111111111111",
+      title: "Ship plan",
+      plan: [{ step: "Run focused tests", status: "pending" }],
+    });
+
+    expect(__getPlanNotificationTokenCountForTest()).toBe(0);
   });
 });

--- a/tests/runtime/plan-notifications.test.ts
+++ b/tests/runtime/plan-notifications.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  __resetPlanNotificationTokensForTest,
+  createPlanModeNotifications,
+  TELEGRAM_PLAN_INTERACTIVE_NAMESPACE,
+} from "../../src/runtime/plan-notifications.js";
+import { InMemoryGateway } from "../../src/state/in-memory-gateway.js";
+import { PlanModeStore } from "../../src/state/store.js";
+
+const SESSION_KEY = "agent:main:main";
+
+function build() {
+  __resetPlanNotificationTokensForTest();
+  const gw = new InMemoryGateway();
+  gw.seed(SESSION_KEY, {
+    mode: "plan",
+    approval: "pending",
+    approvalId: "plan-11111111-1111-4111-8111-111111111111",
+    rejectionCount: 0,
+  });
+  const store = new PlanModeStore(gw);
+  let handler: ((ctx: unknown) => Promise<{ handled: true }>) | undefined;
+  const sendSessionAttachment = vi.fn(async () => ({
+    ok: true as const,
+    channel: "telegram",
+    deliveredTo: "12345",
+    count: 1,
+  }));
+  const api = {
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+    session: {
+      workflow: {
+        sendSessionAttachment,
+      },
+    },
+    registerInteractiveHandler: vi.fn((registration: { handler: typeof handler }) => {
+      handler = registration.handler;
+    }),
+  };
+  return { gw, store, api, sendSessionAttachment, getHandler: () => handler };
+}
+
+function firstButtonValue(call: unknown, label: string): string {
+  const presentation = (call as { presentation?: { blocks?: unknown[] } }).presentation;
+  const blocks = presentation?.blocks ?? [];
+  for (const block of blocks) {
+    const buttons = (block as { buttons?: Array<{ label: string; value: string }> }).buttons;
+    const found = buttons?.find((button) => button.label === label);
+    if (found) return found.value;
+  }
+  throw new Error(`missing button ${label}`);
+}
+
+function telegramCtx(payload: string) {
+  return {
+    channel: "telegram",
+    auth: { isAuthorizedSender: true },
+    callback: { payload },
+    respond: {
+      reply: vi.fn(async () => {}),
+      clearButtons: vi.fn(async () => {}),
+    },
+  };
+}
+
+describe("plan notifications", () => {
+  it("sends a Markdown plan attachment plus native Telegram approval buttons", async () => {
+    const { api, store, sendSessionAttachment } = build();
+    const actions = new Map();
+    await createPlanModeNotifications({
+      api: api as never,
+      store,
+      actions,
+    }).notifyPlanApproval({
+      sessionKey: SESSION_KEY,
+      approvalId: "plan-11111111-1111-4111-8111-111111111111",
+      title: "Ship plan",
+      summary: "Review before execution.",
+      plan: [{ step: "Run focused tests", status: "pending" }],
+      persistedPlan: {
+        absPath: "/tmp/plan.md",
+        filename: "plan.md",
+      },
+    });
+
+    expect(api.registerInteractiveHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "telegram",
+        namespace: TELEGRAM_PLAN_INTERACTIVE_NAMESPACE,
+      }),
+    );
+    expect(sendSessionAttachment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: SESSION_KEY,
+        files: [{ path: "/tmp/plan.md" }],
+        forceDocument: true,
+        presentation: expect.objectContaining({
+          title: "Ship plan",
+        }),
+      }),
+    );
+    const attachment = sendSessionAttachment.mock.calls[0]?.[0];
+    expect(firstButtonValue(attachment, "Approve")).toMatch(
+      new RegExp(`^${TELEGRAM_PLAN_INTERACTIVE_NAMESPACE}:a:`),
+    );
+  });
+
+  it("dispatches approved Telegram callbacks through plan.accept and clears buttons", async () => {
+    const { api, store, sendSessionAttachment, getHandler } = build();
+    const accept = vi.fn(async () => ({ ok: true as const, continueAgent: true }));
+    const notifications = createPlanModeNotifications({
+      api: api as never,
+      store,
+      actions: new Map([["plan.accept", accept]]),
+    });
+    await notifications.notifyPlanApproval({
+      sessionKey: SESSION_KEY,
+      approvalId: "plan-11111111-1111-4111-8111-111111111111",
+      title: "Ship plan",
+      plan: [{ step: "Run focused tests", status: "pending" }],
+    });
+    const value = firstButtonValue(sendSessionAttachment.mock.calls[0]?.[0], "Approve");
+    const payload = value.slice(`${TELEGRAM_PLAN_INTERACTIVE_NAMESPACE}:`.length);
+    const ctx = telegramCtx(payload);
+
+    await getHandler()?.(ctx);
+
+    expect(accept).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionId: "plan.accept",
+        sessionKey: SESSION_KEY,
+        payload: {
+          approvalId: "plan-11111111-1111-4111-8111-111111111111",
+        },
+      }),
+    );
+    expect(ctx.respond.clearButtons).toHaveBeenCalledOnce();
+    expect(ctx.respond.reply).toHaveBeenCalledWith({
+      text: "Plan approved. The agent will resume.",
+    });
+  });
+
+  it("rejects stale Telegram approval callbacks without dispatching the action", async () => {
+    const { gw, api, store, sendSessionAttachment, getHandler } = build();
+    const accept = vi.fn(async () => ({ ok: true as const }));
+    const notifications = createPlanModeNotifications({
+      api: api as never,
+      store,
+      actions: new Map([["plan.accept", accept]]),
+    });
+    await notifications.notifyPlanApproval({
+      sessionKey: SESSION_KEY,
+      approvalId: "plan-11111111-1111-4111-8111-111111111111",
+      title: "Ship plan",
+      plan: [{ step: "Run focused tests", status: "pending" }],
+    });
+    gw.seed(SESSION_KEY, {
+      mode: "plan",
+      approval: "pending",
+      approvalId: "plan-22222222-2222-4222-8222-222222222222",
+      rejectionCount: 0,
+    });
+    const value = firstButtonValue(sendSessionAttachment.mock.calls[0]?.[0], "Approve");
+    const payload = value.slice(`${TELEGRAM_PLAN_INTERACTIVE_NAMESPACE}:`.length);
+    const ctx = telegramCtx(payload);
+
+    await getHandler()?.(ctx);
+
+    expect(accept).not.toHaveBeenCalled();
+    expect(ctx.respond.clearButtons).toHaveBeenCalledOnce();
+    expect(ctx.respond.reply).toHaveBeenCalledWith({
+      text: "That plan button is stale. Use /plan status for the current state.",
+    });
+  });
+
+  it("dispatches Telegram question option callbacks and clears pending question state", async () => {
+    const { api, store, sendSessionAttachment, getHandler } = build();
+    await store.persistPendingQuestion({
+      sessionKey: SESSION_KEY,
+      questionId: "q-call-1",
+      questionPrompt: "Major or minor bump?",
+      options: ["major", "minor"],
+      allowFreetext: false,
+    });
+    const answer = vi.fn(async () => ({ ok: true as const, continueAgent: true }));
+    const notifications = createPlanModeNotifications({
+      api: api as never,
+      store,
+      actions: new Map([["plan.answer", answer]]),
+    });
+    await notifications.notifyQuestion({
+      sessionKey: SESSION_KEY,
+      questionId: "q-call-1",
+      questionPrompt: "Major or minor bump?",
+      options: ["major", "minor"],
+    });
+    const value = firstButtonValue(sendSessionAttachment.mock.calls[0]?.[0], "major");
+    const payload = value.slice(`${TELEGRAM_PLAN_INTERACTIVE_NAMESPACE}:`.length);
+    const ctx = telegramCtx(payload);
+
+    await getHandler()?.(ctx);
+
+    expect(answer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionId: "plan.answer",
+        sessionKey: SESSION_KEY,
+        payload: {
+          questionId: "q-call-1",
+          questionPrompt: "Major or minor bump?",
+          selectedOption: "major",
+        },
+      }),
+    );
+    expect((await store.readSnapshot(SESSION_KEY))?.pendingQuestion).toBeUndefined();
+    expect(ctx.respond.clearButtons).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/tools/ask-user-question.test.ts
+++ b/tests/tools/ask-user-question.test.ts
@@ -238,8 +238,10 @@ describe("W1-F5 ask_user_question — pending-question persistence", () => {
   });
 
   it("when notification sink is wired, sends native question options after persist", async () => {
-    const { store } = stubStore();
-    const notifyQuestion = vi.fn(async () => {});
+    const { store, calls } = stubStore();
+    const notifyQuestion = vi.fn(async () => {
+      expect(calls).toHaveLength(1);
+    });
     const factory = createAskUserQuestionTool({
       store: store as never,
       notifications: { notifyQuestion },

--- a/tests/tools/ask-user-question.test.ts
+++ b/tests/tools/ask-user-question.test.ts
@@ -237,6 +237,28 @@ describe("W1-F5 ask_user_question — pending-question persistence", () => {
     expect(warn).not.toHaveBeenCalled();
   });
 
+  it("when notification sink is wired, sends native question options after persist", async () => {
+    const { store } = stubStore();
+    const notifyQuestion = vi.fn(async () => {});
+    const factory = createAskUserQuestionTool({
+      store: store as never,
+      notifications: { notifyQuestion },
+    });
+    const t = factory({ sessionKey: SESSION_KEY });
+    const r = await t.execute("call-1", {
+      question: "Major or minor bump?",
+      options: ["major", "minor"],
+    });
+
+    expect((r.details as { status: string }).status).toBe("question_submitted");
+    expect(notifyQuestion).toHaveBeenCalledWith({
+      sessionKey: SESSION_KEY,
+      questionId: "q-call-1",
+      questionPrompt: "Major or minor bump?",
+      options: ["major", "minor"],
+    });
+  });
+
   it("when store wired but no sessionKey, skips persist and logs warn", async () => {
     const { store, calls } = stubStore();
     const warn = vi.fn();

--- a/tests/tools/ask-user-question.test.ts
+++ b/tests/tools/ask-user-question.test.ts
@@ -239,8 +239,9 @@ describe("W1-F5 ask_user_question — pending-question persistence", () => {
 
   it("when notification sink is wired, sends native question options after persist", async () => {
     const { store, calls } = stubStore();
+    const callsSeenAtNotify: number[] = [];
     const notifyQuestion = vi.fn(async () => {
-      expect(calls).toHaveLength(1);
+      callsSeenAtNotify.push(calls.length);
     });
     const factory = createAskUserQuestionTool({
       store: store as never,
@@ -253,6 +254,7 @@ describe("W1-F5 ask_user_question — pending-question persistence", () => {
     });
 
     expect((r.details as { status: string }).status).toBe("question_submitted");
+    expect(callsSeenAtNotify).toEqual([1]);
     expect(notifyQuestion).toHaveBeenCalledWith({
       sessionKey: SESSION_KEY,
       questionId: "q-call-1",

--- a/tests/tools/exit-plan-mode.test.ts
+++ b/tests/tools/exit-plan-mode.test.ts
@@ -574,6 +574,9 @@ describe("exit_plan_mode — W1-F2 markdown persister", () => {
         plan: [{ step: "do thing", status: "pending" }],
         persistedPlan: expect.objectContaining({
           filename: expect.stringMatching(/^plan-\d{4}-\d{2}-\d{2}-notify-plan\.md$/),
+          absPath: expect.stringMatching(
+            /\/plans\/plan-\d{4}-\d{2}-\d{2}-notify-plan\.md$/,
+          ),
         }),
       }),
     );

--- a/tests/tools/exit-plan-mode.test.ts
+++ b/tests/tools/exit-plan-mode.test.ts
@@ -19,7 +19,7 @@
 import * as fsp from "node:fs/promises";
 import * as os from "node:os";
 import * as nodePath from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createExitPlanModeTool } from "../../src/tools/exit-plan-mode.js";
 import { isPlanApprovalId } from "../../src/helpers/approval-id.js";
 import { InMemoryGateway } from "../../src/state/in-memory-gateway.js";
@@ -497,6 +497,7 @@ describe("exit_plan_mode — W1-F2 markdown persister", () => {
 
   function buildWithPersister(opts?: {
     extraLog?: { info?: string[]; warn?: string[] };
+    notifyPlanApproval?: ReturnType<typeof vi.fn>;
   }) {
     const gw = new InMemoryGateway();
     gw.seed(SESSION_KEY, {
@@ -517,6 +518,9 @@ describe("exit_plan_mode — W1-F2 markdown persister", () => {
           warn: (m) => warn.push(m),
         },
       },
+      ...(opts?.notifyPlanApproval
+        ? { notifications: { notifyPlanApproval: opts.notifyPlanApproval } }
+        : {}),
     });
     return { gw, store, factory, info, warn };
   }
@@ -542,6 +546,37 @@ describe("exit_plan_mode — W1-F2 markdown persister", () => {
     expect(body).toContain("# Refactor websocket reconnect race");
     expect(body).toContain("## Plan");
     expect(body).toContain("- [ ] do thing");
+    expect((result.details as { persistedPlan?: { path?: string; filename?: string } }).persistedPlan).toEqual({
+      path: path.join(plansDir, filename),
+      filename,
+    });
+  });
+
+  it("sends plan approval notifications with the persisted markdown path when wired", async () => {
+    const notifyPlanApproval = vi.fn(async () => {});
+    const { factory } = buildWithPersister({ notifyPlanApproval });
+    const tool = factory({ sessionKey: SESSION_KEY, agentId: "main" });
+    const result = await tool.execute("c1", {
+      title: "Notify plan",
+      summary: "Review before execution.",
+      plan: [{ step: "do thing", status: "pending" }],
+    });
+
+    expect((result.details as { status: string }).status).toBe(
+      "approval-requested",
+    );
+    expect(notifyPlanApproval).toHaveBeenCalledOnce();
+    expect(notifyPlanApproval.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        sessionKey: SESSION_KEY,
+        title: "Notify plan",
+        summary: "Review before execution.",
+        plan: [{ step: "do thing", status: "pending" }],
+        persistedPlan: expect.objectContaining({
+          filename: expect.stringMatching(/^plan-\d{4}-\d{2}-\d{2}-notify-plan\.md$/),
+        }),
+      }),
+    );
   });
 
   it("writes the full archetype (summary + analysis + assumptions + risks + verification + references)", async () => {

--- a/tests/ui/session-actions.test.ts
+++ b/tests/ui/session-actions.test.ts
@@ -516,6 +516,44 @@ describe("P-12 session-actions — plan.cancel", () => {
     expect(gw.peek(SESSION_KEY)?.mode).toBe("normal");
   });
 
+  it("transitions to normal mode with a matching approvalId", async () => {
+    const gw = new InMemoryGateway();
+    const store = new PlanModeStore(gw);
+    const { api } = makeStubApi();
+    const actions = createPlanModeSessionActions({ api, store });
+    const handler = actions.find((a) => a.id === "plan.cancel")!.handler;
+    gw.seed(SESSION_KEY, planModeSession());
+
+    const r = await handler({
+      pluginId: "smarter-claw",
+      actionId: "plan.cancel",
+      sessionKey: SESSION_KEY,
+      payload: { approvalId: APPROVAL_ID },
+    });
+    if (!r || !r.ok) throw new Error("expected ok");
+    expect(r.continueAgent).toBe(false);
+    expect(gw.peek(SESSION_KEY)?.mode).toBe("normal");
+  });
+
+  it("rejects with STALE_APPROVAL_ID when approvalId mismatches", async () => {
+    const gw = new InMemoryGateway();
+    const store = new PlanModeStore(gw);
+    const { api } = makeStubApi();
+    const actions = createPlanModeSessionActions({ api, store });
+    const handler = actions.find((a) => a.id === "plan.cancel")!.handler;
+    gw.seed(SESSION_KEY, planModeSession());
+
+    const r = await handler({
+      pluginId: "smarter-claw",
+      actionId: "plan.cancel",
+      sessionKey: SESSION_KEY,
+      payload: { approvalId: "plan-different" },
+    });
+    if (!r || r.ok !== false) throw new Error("expected error");
+    expect(r.code).toBe(SESSION_ACTION_ERROR_CODES.STALE_APPROVAL_ID);
+    expect(gw.peek(SESSION_KEY)?.mode).toBe("plan");
+  });
+
   it("idempotent: no-op when already in normal mode", async () => {
     const gw = new InMemoryGateway();
     const store = new PlanModeStore(gw);


### PR DESCRIPTION
## Why

Smarter-Claw needs a clean, testable recovery path on stable `openclaw@2026.5.19`, which is the current npm `latest`, without pretending third-party plugins already have every host seam. This PR fixes the release blockers around plugin metadata/runtime registration, restores Telegram-friendly approval/question delivery where the host allows it, and keeps typed `/plan` plus persisted Markdown paths as the stock-26.5.19 fallback.

Closes #95.
Closes #96.

## What Changed

- Bumps the recovery candidate to `1.0.0-port.18`.
- Bumps the SDK/test target to `openclaw@2026.5.19`.
- Bumps the runtime/install floor to `2026.5.19`:
  - `openclaw.plugin.json#minHostVersion`
  - `package.json#openclaw.install.minHostVersion`
  - `peerDependencies.openclaw`
- Raises the package Node engine floor to `>=22.19.0`, matching OpenClaw 2026.5.19.
- Declares the registered agent tools in `openclaw.plugin.json`:
  - `enter_plan_mode`
  - `exit_plan_mode`
  - `ask_user_question`
- Adds `contracts.sessionAttachments: ["active-session"]` so the plugin can consume the trusted host seam when available.
- Adds canonical `package.json#openclaw` install/build metadata.
- Adds `pnpm runtime-gate`, which loads the built plugin and fails if tool contracts, CLI descriptors, slash commands, session actions, session extension, Control UI descriptor, or Telegram interactive handler registration drift.
- Registers `plan-clear` with explicit CLI descriptor metadata.
- Adds Telegram interactive namespace `smarter-claw-plan` for native approval/question buttons:
  - approve, revise, reject, cancel
  - fixed-option answers
  - short single-use callback tokens
  - sender auth checks
  - stale approval/question guards
  - clear-buttons-on-resolution behavior
- `exit_plan_mode` now returns the persisted Markdown path in tool details and best-effort sends the Markdown file plus rich approval presentation through `sendSessionAttachment`.
- `ask_user_question` now best-effort sends native option buttons through the same presentation path.
- Telegram callback tokens are discarded when attachment delivery fails, so stock 26.5.19 fallback paths do not leave unreachable tokens behind.
- Drift cron now uses an explicit `tsx@4.20.6` dev dependency for TypeScript runners with `.js` import specifiers.
- README and release notes state the compatibility truth: stock 26.5.19 has typed `/plan` and persisted-path fallback; native active-session attachments/buttons require the narrow trusted host seam.

## Host Seam Note

Full Markdown attachment plus Telegram native-button parity depends on the companion OpenClaw PR that allows trusted workflow plugins declaring `contracts.sessionAttachments:["active-session"]` to deliver active-session presentations. I checked the stock `openclaw@2026.5.19` package after this bump: `sendSessionAttachment` is still bundled-only and still requires attachment files, so Smarter-Claw logs the skipped delivery and remains usable through typed `/plan` commands and persisted plan paths until that host seam lands.

## Validation

Local validation ran from `/Volumes/LEXAR/repos/Smarter-Claw-recovery-26.5.18`:

- `npm view openclaw version dist-tags --json`
  - npm `latest` is `2026.5.19`; beta is `2026.5.20-beta.1`.
- `gh release list -R openclaw/openclaw --limit 10`
  - latest non-prerelease tag is `v2026.5.19`.
- `pnpm install --frozen-lockfile --config.minimum-release-age=0`
- `pnpm typecheck`
- `pnpm build`
- `pnpm runtime-gate`
  - `tools=3`, `actions=6`, `commands=2`, `interactiveHandlers=1`
- `pnpm test -- tests/runtime/plan-notifications.test.ts tests/ui/session-actions.test.ts tests/state/store.test.ts`
  - Vitest repo wiring ran the full suite: 40 files, 880 tests passed.
- `pnpm parity-harness`
  - host-version parity passed for `2026.5.19`; focused parity harness passed.
- `pnpm exec tsx --version`
  - `tsx v4.20.6`
- `pnpm exec tsx parity-harness/runners/plugin-under-test.ts`
  - 162/162 cases parity-clean across 9 checks.
- `pnpm exec tsx parity-harness/diff.ts`
  - exited successfully.
- `pnpm pack --dry-run`
  - package tarball is `@electricsheephq/smarter-claw@1.0.0-port.18`.

Heavy/live Telegram smoke remains a post-merge/runtime validation item once the companion OpenClaw host seam is available in the target install.
