### PR TITLE
Target OpenClaw v2026.6.1 beta

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,9 @@ jobs:
             if (p.openclaw?.install?.minHostVersion !== '>=' + m.minHostVersion) {
               throw new Error('package openclaw.install.minHostVersion must be >=' + m.minHostVersion);
             }
+            if (p.openclaw?.target?.version !== m.minHostVersion) {
+              throw new Error('package openclaw.target.version must match manifest minHostVersion');
+            }
             const tools = new Set(m.contracts?.tools || []);
             for (const tool of ['enter_plan_mode', 'exit_plan_mode', 'ask_user_question']) {
               if (!tools.has(tool)) throw new Error('manifest contracts.tools missing ' + tool);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Runtime registration gate
+        run: pnpm runtime-gate
+
       # Run vitest. The reporter-JSON-numTests check guards against
       # silent zero-tests-discovered failures.
       #
@@ -114,8 +117,19 @@ jobs:
           # Manifest sanity — ensure version + minHostVersion are present.
           node -e "
             const m = JSON.parse(require('fs').readFileSync('/tmp/sc-extract/package/dist/openclaw.plugin.json','utf8'));
+            const p = JSON.parse(require('fs').readFileSync('/tmp/sc-extract/package/package.json','utf8'));
             if (!m.id || !m.minHostVersion) {
               throw new Error('manifest missing id or minHostVersion: ' + JSON.stringify(m));
+            }
+            if (p.openclaw?.install?.minHostVersion !== '>=' + m.minHostVersion) {
+              throw new Error('package openclaw.install.minHostVersion must be >=' + m.minHostVersion);
+            }
+            const tools = new Set(m.contracts?.tools || []);
+            for (const tool of ['enter_plan_mode', 'exit_plan_mode', 'ask_user_question']) {
+              if (!tools.has(tool)) throw new Error('manifest contracts.tools missing ' + tool);
+            }
+            if (!(m.contracts?.sessionAttachments || []).includes('active-session')) {
+              throw new Error('manifest contracts.sessionAttachments missing active-session');
             }
             console.log('manifest id=' + m.id + ' minHostVersion=' + m.minHostVersion);
           "

--- a/.github/workflows/drift-cron.yml
+++ b/.github/workflows/drift-cron.yml
@@ -93,7 +93,7 @@ jobs:
           # For now, a placeholder that surfaces "harness not wired
           # yet" without failing the job.
           if [ -f parity-harness/runners/plugin-under-test.ts ]; then
-            node --experimental-strip-types parity-harness/runners/plugin-under-test.ts || true
+            pnpm exec tsx parity-harness/runners/plugin-under-test.ts || true
           else
             pnpm parity-harness || true
           fi
@@ -113,7 +113,7 @@ jobs:
             exit 0
           fi
           set +e
-          node --experimental-strip-types parity-harness/diff.ts > /tmp/diff-output.txt 2>&1
+          pnpm exec tsx parity-harness/diff.ts > /tmp/diff-output.txt 2>&1
           rc=$?
           set -e
           cat /tmp/diff-output.txt

--- a/.github/workflows/drift-cron.yml
+++ b/.github/workflows/drift-cron.yml
@@ -93,7 +93,9 @@ jobs:
           # For now, a placeholder that surfaces "harness not wired
           # yet" without failing the job.
           if [ -f parity-harness/runners/plugin-under-test.ts ]; then
-            pnpm exec tsx parity-harness/runners/plugin-under-test.ts || true
+            node --experimental-strip-types parity-harness/runners/plugin-under-test.ts || true
+          else
+            pnpm parity-harness || true
           fi
           echo "Plugin runner step complete."
 
@@ -111,7 +113,7 @@ jobs:
             exit 0
           fi
           set +e
-          pnpm exec tsx parity-harness/diff.ts > /tmp/diff-output.txt 2>&1
+          node --experimental-strip-types parity-harness/diff.ts > /tmp/diff-output.txt 2>&1
           rc=$?
           set -e
           cat /tmp/diff-output.txt

--- a/README.md
+++ b/README.md
@@ -201,9 +201,9 @@ pnpm build           # tsc → dist/
 | OpenClaw | Smarter Claw |
 |---|---|
 | `v2026.6.1-beta.1` GitHub release | `1.0.0-port.19` (current 6.1 beta target RC; npm SDK fallback `2026.5.31-beta.4`) |
-| `2026.5.19` and later | `1.0.0-port.18` (recovery RC) |
-| `2026.5.18` and later | `1.0.0-port.17` (stable-load + Telegram bridge consumer RC) |
-| `2026.5.18` and later | `1.0.0-port.16` (parity-refresh RC; no Telegram-native button bridge) |
+| `2026.5.19` ... `<v2026.6.1-beta.1` | `1.0.0-port.18` (recovery RC) |
+| `2026.5.18` ... `<2026.5.19` | `1.0.0-port.17` (stable-load + Telegram bridge consumer RC) |
+| Historical `2026.5.18` RC, superseded by `1.0.0-port.17` | `1.0.0-port.16` (parity-refresh RC; no Telegram-native button bridge) |
 | `2026.5.10-beta.5` ... `<2026.5.18` | `1.0.0-port.15` (legacy; chat-stream patcher applies here only) |
 
 Install-time compatibility is enforced via

--- a/README.md
+++ b/README.md
@@ -4,14 +4,17 @@ Plan Mode plugin for [OpenClaw](https://github.com/openclaw/openclaw) — plan-t
 
 ## Status
 
-**`1.0.0-port.17` — OpenClaw 26.5.18 recovery candidate (2026-05-20).**
+**`1.0.0-port.18` — OpenClaw 26.5.19 recovery candidate (2026-05-21).**
 
 The 6-wave parity refresh closed all 2 P0 + 14/17 P1 Wave-1 findings,
 built a 156-case mechanical parity-harness CI gate, and bumped the
-minimum host version to `openclaw@2026.5.18`. Port `.17` adds the
+minimum host version to `openclaw@2026.5.19`. Port `.18` keeps the
+stable-load contracts from `.17`, updates the SDK/test target to the
+current npm `latest`, and tracks OpenClaw's Node 22.19 runtime floor.
+Port `.17` adds the
 stable-load contracts (`contracts.tools`), explicit CLI descriptors,
 the runtime registration gate, and Telegram-native plan/question button
-wiring. On stock `openclaw@2026.5.18`, the typed `/plan` fallback and
+wiring. On stock `openclaw@2026.5.19`, the typed `/plan` fallback and
 persisted Markdown plan path remain authoritative; Markdown attachment
 delivery and native Telegram buttons activate when the host includes the
 trusted `contracts.sessionAttachments: ["active-session"]` SDK seam.
@@ -55,7 +58,7 @@ The mutation gate (`before_tool_call`) works without this flag, but most
 of the plugin requires it. An advisory message fires on every new session
 start when the flag is missing.
 
-Minimum host version: `openclaw >= 2026.5.18` (declared via the canonical
+Minimum host version: `openclaw >= 2026.5.19` (declared via the canonical
 `package.json#openclaw.install.minHostVersion` floor and mirrored in
 `openclaw.plugin.json` for runtime metadata).
 
@@ -64,11 +67,11 @@ Minimum host version: `openclaw >= 2026.5.18` (declared via the canonical
 The plugin's v0.x sidebar UI works out of the box. For the v1.0 **inline UI** (mode-switcher chip, inline plan cards, input-bar suppression on pending approval), Smarter-Claw needs SDK seams that aren't in the upstream openclaw release yet — they're filed as draft PR [openclaw/openclaw#80982](https://github.com/openclaw/openclaw/pull/80982).
 
 > **Status: upstream-blocked.** The patcher targets the `2026.5.10-beta.5`
-> baseline; on the current `minHostVersion` (`2026.5.18`) the content-hashed
+> baseline; on the current `minHostVersion` (`2026.5.19`) the content-hashed
 > bundle filenames the manifest keys on have rotated (`loader-DdN5GTsW.js`
 > → `loader-CxUWY2_6.js`; `protocol-BBwaRnfZ.js` → `protocol-CdYy0xVK.js`
 > + `protocol-B17omF7t.js`), so the patcher's SHA pre-flight refuses to
-> apply (`process.exitCode === 3` / `4`). **Operators on `2026.5.18`
+> apply (`process.exitCode === 3` / `4`). **Operators on `2026.5.19`
 > should skip this section** — sidebar UI + `/plan` slash commands cover
 > the supported UX. See [`docs/audits/parity-refresh/blocker-W1-S17-webchat-ui.md`](./docs/audits/parity-refresh/blocker-W1-S17-webchat-ui.md)
 > for the full investigation and the upstream tracking
@@ -92,7 +95,7 @@ node scripts/install-chat-stream-seam.mjs --host /path/to/your/openclaw
 ```
 
 What the patcher does:
-- Validates the installed openclaw version matches the patcher's manifest (refuses on mismatch — `2026.5.18` exits 3)
+- Validates the installed openclaw version matches the patcher's manifest (refuses on mismatch — current stable hosts exit 3)
 - SHA256-checks the 2 dist files that will be replaced against the manifest's expected baseline (refuses on drift — use `--force` to override at your own risk)
 - Backs up the originals into `node_modules/openclaw/.smarter-claw-backups/`
 - Replaces 2 compiled JS bundle files with seam-built equivalents (~370KB total; ~80 lines of new code inside larger bundles)
@@ -101,7 +104,7 @@ What the patcher does:
 
 The patch is a **temporary tactical unblock for the legacy `2026.5.10-beta.5` baseline**. When upstream openclaw merges PR #80982 into a published release, we'll bump `peerDependencies.openclaw` + drop the patcher.
 
-## What works in 1.0.0-port.17
+## What works in 1.0.0-port.18
 
 | Feature | Status |
 |---|---|
@@ -123,8 +126,8 @@ The patch is a **temporary tactical unblock for the legacy `2026.5.10-beta.5` ba
 | `autoApprove` toggle (state mutator) | ✅ |
 | Approval grant ledger + structured debug log | ✅ |
 | Parity harness (Layer 1, 2, 3-cron) | ✅ |
-| Telegram-native approval/question buttons | ✅ with OpenClaw active-session attachment seam; `/plan` fallback on stock `26.5.18` |
-| Markdown plan artifact persistence + attachment | ✅ persisted on stock `26.5.18`; attached when host seam is available |
+| Telegram-native approval/question buttons | ✅ with OpenClaw active-session attachment seam; `/plan` fallback on stock `26.5.19` |
+| Markdown plan artifact persistence + attachment | ✅ persisted on stock `26.5.19`; attached when host seam is available |
 
 ## Deferred to v1.0 (upstream-blocked)
 
@@ -170,7 +173,7 @@ at the in-host code it mirrors (see `host_ref:` comments in each file).
 | `api.session.controls.registerControlUiDescriptor` | Sidebar widget descriptor |
 | `api.session.workflow.enqueueNextTurnInjection` | `[PLAN_DECISION]:` and `[QUESTION_ANSWER]:` writers |
 | `api.registerInteractiveHandler` | `smarter-claw-plan` Telegram callback namespace for approve/revise/reject/cancel and option answers |
-| `api.session.workflow.sendSessionAttachment` | Best-effort active-session plan/question presentation delivery; falls back when stock `26.5.18` blocks third-party attachments |
+| `api.session.workflow.sendSessionAttachment` | Best-effort active-session plan/question presentation delivery; falls back when stock `26.5.19` blocks third-party attachments |
 | `api.registerCli` | `openclaw plan-clear` rollback drain command |
 
 ## Develop
@@ -189,7 +192,8 @@ pnpm build           # tsc → dist/
 
 | OpenClaw | Smarter Claw |
 |---|---|
-| `2026.5.18` and later | `1.0.0-port.17` (current recovery RC) |
+| `2026.5.19` and later | `1.0.0-port.18` (current recovery RC) |
+| `2026.5.18` and later | `1.0.0-port.17` (stable-load + Telegram bridge consumer RC) |
 | `2026.5.18` and later | `1.0.0-port.16` (parity-refresh RC; no Telegram-native button bridge) |
 | `2026.5.10-beta.5` ... `<2026.5.18` | `1.0.0-port.15` (legacy; chat-stream patcher applies here only) |
 

--- a/README.md
+++ b/README.md
@@ -4,25 +4,31 @@ Plan Mode plugin for [OpenClaw](https://github.com/openclaw/openclaw) — plan-t
 
 ## Status
 
-**`1.0.0-port.18` — OpenClaw 26.5.19 recovery candidate (2026-05-21).**
+**`1.0.0-port.19` — OpenClaw `v2026.6.1-beta.1` release-target candidate (2026-06-01).**
 
 The 6-wave parity refresh closed all 2 P0 + 14/17 P1 Wave-1 findings,
-built a 156-case mechanical parity-harness CI gate, and bumped the
-minimum host version to `openclaw@2026.5.19`. Port `.18` keeps the
-stable-load contracts from `.17`, updates the SDK/test target to the
-current npm `latest`, and tracks OpenClaw's Node 22.19 runtime floor.
-Port `.17` adds the
-stable-load contracts (`contracts.tools`), explicit CLI descriptors,
-the runtime registration gate, and Telegram-native plan/question button
-wiring. On stock `openclaw@2026.5.19`, the typed `/plan` fallback and
-persisted Markdown plan path remain authoritative; Markdown attachment
-delivery and native Telegram buttons activate when the host includes the
-trusted `contracts.sessionAttachments: ["active-session"]` SDK seam.
+built a 156-case mechanical parity-harness CI gate, and now targets the
+OpenClaw GitHub release [`v2026.6.1-beta.1`](https://github.com/openclaw/openclaw/releases/tag/v2026.6.1-beta.1)
+at commit `2fc497e67b9cf40b2c12a9355afd785e7f8672dc`. The matching
+`openclaw@2026.6.1-beta.1` npm package is not published, so package
+install/typecheck uses the nearest published beta SDK
+`openclaw@2026.5.31-beta.4` while `package.json#openclaw.target`,
+`openclaw.plugin.json#minHostVersion`, the peer dependency, and the
+install floor all pin the real 6.1 beta host target.
+
+Port `.19` keeps the stable-load contracts from `.17`/`.18`, adds explicit
+release-gate classification for the stock host's active-session attachment
+block, and mirrors pending plan approval state into OpenClaw's managed
+TaskFlow runtime when that 6.1 surface is available. On stock
+`v2026.6.1-beta.1`, typed `/plan` commands, sidebar actions, persisted
+Markdown plan paths, and TaskFlow/workboard visibility are the supported
+fallback; Markdown attachment delivery and native Telegram buttons activate
+only when the host allows trusted third-party active-session attachments.
 See [`docs/audits/parity-refresh/FINAL-REPORT.md`](./docs/audits/parity-refresh/FINAL-REPORT.md)
 for the full ship-readiness account.
 
-`v1.0` public release is gated on the upstream OpenClaw chat-stream renderer
-SDK seam — see [RELEASE_NOTES.md](./RELEASE_NOTES.md) "deferred to v1.0" +
+Inline chat-stream UI remains gated on the upstream OpenClaw chat-stream
+renderer SDK seam — see [RELEASE_NOTES.md](./RELEASE_NOTES.md) "deferred to v1.0" +
 [upstream draft PR `openclaw/openclaw#80982`](https://github.com/openclaw/openclaw/pull/80982).
 
 For implementation history + the architecture rationale see
@@ -58,7 +64,7 @@ The mutation gate (`before_tool_call`) works without this flag, but most
 of the plugin requires it. An advisory message fires on every new session
 start when the flag is missing.
 
-Minimum host version: `openclaw >= 2026.5.19` (declared via the canonical
+Minimum host version: `openclaw >= 2026.6.1-beta.1` (declared via the canonical
 `package.json#openclaw.install.minHostVersion` floor and mirrored in
 `openclaw.plugin.json` for runtime metadata).
 
@@ -67,11 +73,11 @@ Minimum host version: `openclaw >= 2026.5.19` (declared via the canonical
 The plugin's v0.x sidebar UI works out of the box. For the v1.0 **inline UI** (mode-switcher chip, inline plan cards, input-bar suppression on pending approval), Smarter-Claw needs SDK seams that aren't in the upstream openclaw release yet — they're filed as draft PR [openclaw/openclaw#80982](https://github.com/openclaw/openclaw/pull/80982).
 
 > **Status: upstream-blocked.** The patcher targets the `2026.5.10-beta.5`
-> baseline; on the current `minHostVersion` (`2026.5.19`) the content-hashed
+> baseline; on the current `minHostVersion` (`2026.6.1-beta.1`) the content-hashed
 > bundle filenames the manifest keys on have rotated (`loader-DdN5GTsW.js`
 > → `loader-CxUWY2_6.js`; `protocol-BBwaRnfZ.js` → `protocol-CdYy0xVK.js`
 > + `protocol-B17omF7t.js`), so the patcher's SHA pre-flight refuses to
-> apply (`process.exitCode === 3` / `4`). **Operators on `2026.5.19`
+> apply (`process.exitCode === 3` / `4`). **Operators on `v2026.6.1-beta.1`
 > should skip this section** — sidebar UI + `/plan` slash commands cover
 > the supported UX. See [`docs/audits/parity-refresh/blocker-W1-S17-webchat-ui.md`](./docs/audits/parity-refresh/blocker-W1-S17-webchat-ui.md)
 > for the full investigation and the upstream tracking
@@ -104,7 +110,7 @@ What the patcher does:
 
 The patch is a **temporary tactical unblock for the legacy `2026.5.10-beta.5` baseline**. When upstream openclaw merges PR #80982 into a published release, we'll bump `peerDependencies.openclaw` + drop the patcher.
 
-## What works in 1.0.0-port.18
+## What works in 1.0.0-port.19
 
 | Feature | Status |
 |---|---|
@@ -126,8 +132,9 @@ The patch is a **temporary tactical unblock for the legacy `2026.5.10-beta.5` ba
 | `autoApprove` toggle (state mutator) | ✅ |
 | Approval grant ledger + structured debug log | ✅ |
 | Parity harness (Layer 1, 2, 3-cron) | ✅ |
-| Telegram-native approval/question buttons | ✅ with OpenClaw active-session attachment seam; `/plan` fallback on stock `26.5.19` |
-| Markdown plan artifact persistence + attachment | ✅ persisted on stock `26.5.19`; attached when host seam is available |
+| Managed TaskFlow/workboard visibility for pending plan approvals | ✅ when OpenClaw exposes `runtime.tasks.managedFlows`; no-op fallback otherwise |
+| Telegram-native approval/question buttons | ✅ with OpenClaw active-session attachment seam; `/plan` fallback on stock `v2026.6.1-beta.1` |
+| Markdown plan artifact persistence + attachment | ✅ persisted on stock `v2026.6.1-beta.1`; attached when host seam is available |
 
 ## Deferred to v1.0 (upstream-blocked)
 
@@ -172,8 +179,9 @@ at the in-host code it mirrors (see `host_ref:` comments in each file).
 | `api.session.controls.registerSessionAction` (×6) | `plan.accept` / `plan.edit` / `plan.reject` / `plan.cancel` / `plan.answer` / `plan.auto.toggle` |
 | `api.session.controls.registerControlUiDescriptor` | Sidebar widget descriptor |
 | `api.session.workflow.enqueueNextTurnInjection` | `[PLAN_DECISION]:` and `[QUESTION_ANSWER]:` writers |
+| `api.runtime.tasks.managedFlows` / legacy `api.runtime.taskFlow` | Best-effort managed TaskFlow bridge for pending plan approval visibility |
 | `api.registerInteractiveHandler` | `smarter-claw-plan` Telegram callback namespace for approve/revise/reject/cancel and option answers |
-| `api.session.workflow.sendSessionAttachment` | Best-effort active-session plan/question presentation delivery; falls back when stock `26.5.19` blocks third-party attachments |
+| `api.session.workflow.sendSessionAttachment` | Best-effort active-session plan/question presentation delivery; falls back when stock `v2026.6.1-beta.1` blocks third-party attachments |
 | `api.registerCli` | `openclaw plan-clear` rollback drain command |
 
 ## Develop
@@ -192,7 +200,8 @@ pnpm build           # tsc → dist/
 
 | OpenClaw | Smarter Claw |
 |---|---|
-| `2026.5.19` and later | `1.0.0-port.18` (current recovery RC) |
+| `v2026.6.1-beta.1` GitHub release | `1.0.0-port.19` (current 6.1 beta target RC; npm SDK fallback `2026.5.31-beta.4`) |
+| `2026.5.19` and later | `1.0.0-port.18` (recovery RC) |
 | `2026.5.18` and later | `1.0.0-port.17` (stable-load + Telegram bridge consumer RC) |
 | `2026.5.18` and later | `1.0.0-port.16` (parity-refresh RC; no Telegram-native button bridge) |
 | `2026.5.10-beta.5` ... `<2026.5.18` | `1.0.0-port.15` (legacy; chat-stream patcher applies here only) |

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ What the patcher does:
 
 The patch is a **temporary tactical unblock for the legacy `2026.5.10-beta.5` baseline**. When upstream openclaw merges PR #80982 into a published release, we'll bump `peerDependencies.openclaw` + drop the patcher.
 
-## What works in 1.0.0-port.16
+## What works in 1.0.0-port.17
 
 | Feature | Status |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -4,15 +4,18 @@ Plan Mode plugin for [OpenClaw](https://github.com/openclaw/openclaw) — plan-t
 
 ## Status
 
-**`1.0.0-port.16` — parity-refresh release candidate (2026-05-20).**
+**`1.0.0-port.17` — OpenClaw 26.5.18 recovery candidate (2026-05-20).**
 
 The 6-wave parity refresh closed all 2 P0 + 14/17 P1 Wave-1 findings,
 built a 156-case mechanical parity-harness CI gate, and bumped the
-minimum host version to `openclaw@2026.5.18`. The plugin is
-**release-ready** against `openclaw@2026.5.18`+; sidebar UI + slash
-commands work end-to-end. **868 unit tests + 4 Eva-live-smokes pass;
-parity-harness 156+/156+ cases parity-clean across 8+ checks; all
-green on Ubuntu CI**. See [`docs/audits/parity-refresh/FINAL-REPORT.md`](./docs/audits/parity-refresh/FINAL-REPORT.md)
+minimum host version to `openclaw@2026.5.18`. Port `.17` adds the
+stable-load contracts (`contracts.tools`), explicit CLI descriptors,
+the runtime registration gate, and Telegram-native plan/question button
+wiring. On stock `openclaw@2026.5.18`, the typed `/plan` fallback and
+persisted Markdown plan path remain authoritative; Markdown attachment
+delivery and native Telegram buttons activate when the host includes the
+trusted `contracts.sessionAttachments: ["active-session"]` SDK seam.
+See [`docs/audits/parity-refresh/FINAL-REPORT.md`](./docs/audits/parity-refresh/FINAL-REPORT.md)
 for the full ship-readiness account.
 
 `v1.0` public release is gated on the upstream OpenClaw chat-stream renderer
@@ -52,8 +55,9 @@ The mutation gate (`before_tool_call`) works without this flag, but most
 of the plugin requires it. An advisory message fires on every new session
 start when the flag is missing.
 
-Minimum host version: `openclaw >= 2026.5.18` (declared via
-`minHostVersion` in `openclaw.plugin.json`).
+Minimum host version: `openclaw >= 2026.5.18` (declared via the canonical
+`package.json#openclaw.install.minHostVersion` floor and mirrored in
+`openclaw.plugin.json` for runtime metadata).
 
 ## Optional: chat-stream seam patch (for inline UI before upstream merges)
 
@@ -119,6 +123,8 @@ The patch is a **temporary tactical unblock for the legacy `2026.5.10-beta.5` ba
 | `autoApprove` toggle (state mutator) | ✅ |
 | Approval grant ledger + structured debug log | ✅ |
 | Parity harness (Layer 1, 2, 3-cron) | ✅ |
+| Telegram-native approval/question buttons | ✅ with OpenClaw active-session attachment seam; `/plan` fallback on stock `26.5.18` |
+| Markdown plan artifact persistence + attachment | ✅ persisted on stock `26.5.18`; attached when host seam is available |
 
 ## Deferred to v1.0 (upstream-blocked)
 
@@ -163,6 +169,8 @@ at the in-host code it mirrors (see `host_ref:` comments in each file).
 | `api.session.controls.registerSessionAction` (×6) | `plan.accept` / `plan.edit` / `plan.reject` / `plan.cancel` / `plan.answer` / `plan.auto.toggle` |
 | `api.session.controls.registerControlUiDescriptor` | Sidebar widget descriptor |
 | `api.session.workflow.enqueueNextTurnInjection` | `[PLAN_DECISION]:` and `[QUESTION_ANSWER]:` writers |
+| `api.registerInteractiveHandler` | `smarter-claw-plan` Telegram callback namespace for approve/revise/reject/cancel and option answers |
+| `api.session.workflow.sendSessionAttachment` | Best-effort active-session plan/question presentation delivery; falls back when stock `26.5.18` blocks third-party attachments |
 | `api.registerCli` | `openclaw plan-clear` rollback drain command |
 
 ## Develop
@@ -172,7 +180,8 @@ git clone https://github.com/electricsheephq/Smarter-Claw.git
 cd Smarter-Claw
 pnpm install
 pnpm typecheck       # tsc --noEmit
-pnpm test            # vitest run — 551 tests across 26 files
+pnpm test            # vitest run
+pnpm runtime-gate    # built-plugin registration contract smoke
 pnpm build           # tsc → dist/
 ```
 
@@ -180,11 +189,14 @@ pnpm build           # tsc → dist/
 
 | OpenClaw | Smarter Claw |
 |---|---|
-| `2026.5.18` and later | `1.0.0-port.16` (current parity-refresh RC) |
+| `2026.5.18` and later | `1.0.0-port.17` (current recovery RC) |
+| `2026.5.18` and later | `1.0.0-port.16` (parity-refresh RC; no Telegram-native button bridge) |
 | `2026.5.10-beta.5` ... `<2026.5.18` | `1.0.0-port.15` (legacy; chat-stream patcher applies here only) |
 
-`minHostVersion` is enforced via `openclaw.plugin.json`. Earlier host
-versions don't have the required SDK seams.
+Install-time compatibility is enforced via
+`package.json#openclaw.install.minHostVersion`; runtime metadata is mirrored
+in `openclaw.plugin.json`. Earlier host versions don't have the required SDK
+seams.
 
 ## Known limitations
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,24 @@
 # Smarter-Claw Release Notes
 
+## 1.0.0-port.18 — OpenClaw 26.5.19 latest-stable bump (2026-05-21)
+
+This maintenance pass moves the recovery candidate from stable
+`openclaw@2026.5.18` to npm `latest`, `openclaw@2026.5.19`.
+
+### What changed since `1.0.0-port.17`
+
+- Bumped the SDK/test target to `openclaw@2026.5.19`.
+- Bumped `openclaw.plugin.json` `minHostVersion` to `2026.5.19`.
+- Bumped canonical `package.json#openclaw.install.minHostVersion` to
+  `>=2026.5.19` and `peerDependencies.openclaw` to `>=2026.5.19`.
+- Bumped the package candidate to `1.0.0-port.18`.
+- Raised the package Node engine floor to `>=22.19.0`, matching
+  OpenClaw 2026.5.19's published package engine requirement.
+- Kept the same compatibility truth: stock `openclaw@2026.5.19` still
+  rejects third-party active-session attachments, so typed `/plan`
+  commands and persisted Markdown paths remain the stable fallback until
+  the trusted host seam lands.
+
 ## 1.0.0-port.17 — OpenClaw 26.5.18 recovery candidate (2026-05-20)
 
 This recovery pass makes the plugin honest and testable on stable

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,61 @@
 # Smarter-Claw Release Notes
 
+## 1.0.0-port.19 — OpenClaw v2026.6.1-beta.1 release target (2026-06-01)
+
+This maintenance pass moves the recovery candidate from the `2026.5.x`
+line to the OpenClaw GitHub release
+[`v2026.6.1-beta.1`](https://github.com/openclaw/openclaw/releases/tag/v2026.6.1-beta.1)
+at commit `2fc497e67b9cf40b2c12a9355afd785e7f8672dc`.
+
+### Compatibility truth
+
+- `openclaw@2026.6.1-beta.1` is not published on npm. The package keeps
+  `package.json#openclaw.target.version`, `openclaw.plugin.json`
+  `minHostVersion`, `peerDependencies.openclaw`, and
+  `package.json#openclaw.install.minHostVersion` pinned to
+  `2026.6.1-beta.1`, while install/typecheck uses the nearest published
+  npm beta SDK, `openclaw@2026.5.31-beta.4`.
+- Stock `v2026.6.1-beta.1` still rejects third-party active-session
+  attachments with `session attachments are restricted to bundled plugins`.
+  Native Telegram buttons and Markdown delivery stay best-effort; typed
+  `/plan` commands, sidebar actions, and persisted Markdown plan paths are
+  the supported fallback.
+- Stock `v2026.6.1-beta.1` does not include the chat-stream renderer seam
+  from upstream PR `openclaw/openclaw#80982`. Inline plan cards, input-bar
+  suppression, and the mode-switcher chip remain upstream-gated.
+
+### What changed since `1.0.0-port.18`
+
+- Bumped the package candidate to `1.0.0-port.19`.
+- Bumped the runtime/install compatibility target to
+  `2026.6.1-beta.1` and added explicit GitHub-release target metadata.
+- Updated the host-version parity gate so a GitHub-only OpenClaw release can
+  use an explicitly declared npm SDK fallback without hiding drift.
+- Added release-gate classification for the stock 6.1 active-session
+  attachment block. The runtime now logs the specific host seam gate and
+  names the `/plan`/Markdown fallback instead of treating the block as a
+  generic delivery failure.
+- Added a best-effort managed TaskFlow bridge. When OpenClaw exposes
+  `api.runtime.tasks.managedFlows` (or the legacy `api.runtime.taskFlow`
+  alias), Smarter-Claw creates a managed TaskFlow for pending plan approval
+  and finishes or updates it when the plan is approved, edited, or rejected.
+  This makes pending plans visible to the 6.1 task/workboard affordances
+  without making TaskFlow availability a hard install requirement.
+- Added focused release-gate tests for target metadata, attachment seam
+  classification, and TaskFlow visibility.
+
+### Release gates still open
+
+1. **Full native active-session attachment parity** requires an OpenClaw
+   host change that lets trusted third-party plugins declaring
+   `contracts.sessionAttachments: ["active-session"]` send active-session
+   presentations.
+2. **Inline chat-stream UI parity** remains blocked on upstream PR
+   `openclaw/openclaw#80982` or an equivalent public renderer seam.
+3. **Full live parity certification** still needs remote GitHub/Crabbox
+   scenario validation against the actual `v2026.6.1-beta.1` host before
+   tagging or publishing.
+
 ## 1.0.0-port.18 — OpenClaw 26.5.19 latest-stable bump (2026-05-21)
 
 This maintenance pass moves the recovery candidate from stable

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,46 @@
 # Smarter-Claw Release Notes
 
+## 1.0.0-port.17 — OpenClaw 26.5.18 recovery candidate (2026-05-20)
+
+This recovery pass makes the plugin honest and testable on stable
+`openclaw@2026.5.18` while adding the consumer side of the Telegram
+native-button UX.
+
+### What changed since `1.0.0-port.16`
+
+- Added `openclaw.plugin.json` `contracts.tools` for
+  `enter_plan_mode`, `exit_plan_mode`, and `ask_user_question`, plus
+  `contracts.sessionAttachments: ["active-session"]`.
+- Added canonical `package.json#openclaw.install` and
+  `package.json#openclaw.build` metadata. The install floor is the
+  OpenClaw-required semver form `>=2026.5.18`, while the manifest keeps
+  the stable runtime target `2026.5.18`. Added a CI
+  `pnpm runtime-gate` that loads the built plugin and fails on missing
+  tool contracts, CLI descriptors, slash commands, session actions,
+  Control UI, or Telegram interactive handler registrations.
+- Registered `openclaw plan-clear` with explicit descriptor metadata so
+  OpenClaw can lazy-load/advertise it without guessing.
+- Added Telegram interactive namespace `smarter-claw-plan`:
+  approval cards expose Approve, Revise, Reject, Cancel buttons; question
+  cards expose option buttons; callbacks enforce sender authorization and
+  stale approval/question guards, then clear buttons after resolution.
+- `exit_plan_mode` now returns the persisted Markdown plan path in tool
+  details and best-effort sends the Markdown file plus rich approval
+  presentation through `api.session.workflow.sendSessionAttachment`.
+- `ask_user_question` now best-effort sends native option buttons through
+  the same active-session presentation path.
+- Fixed drift-cron's missing `tsx` dependency by using Node 22
+  `--experimental-strip-types` or the existing parity harness path.
+
+### Host compatibility truth
+
+Stock `openclaw@2026.5.18` still blocks third-party active-session
+attachments, so the plugin falls back to persisted Markdown paths and
+typed `/plan` commands there. Full Markdown attachment plus Telegram
+button parity requires the narrow OpenClaw host seam that allows trusted
+plugins declaring `contracts.sessionAttachments: ["active-session"]` to
+send active-session presentations.
+
 ## 1.0.0-port.16 — parity refresh, host bump to 2026.5.18, Wave-6 finding fixes (2026-05-20)
 
 The 6-wave Parity-Refresh closed the audit cycle and brought the plugin

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -3,6 +3,16 @@
   "name": "Smarter-Claw",
   "description": "Plan-Mode plugin for OpenClaw. Plan-then-execute workflow with mutation gate, archetype prompting, escalating retry, and rejection-cycle tracking. v1 port-in-progress (P-1 skeleton).",
   "minHostVersion": "2026.5.18",
+  "contracts": {
+    "tools": [
+      "enter_plan_mode",
+      "exit_plan_mode",
+      "ask_user_question"
+    ],
+    "sessionAttachments": [
+      "active-session"
+    ]
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "smarter-claw",
   "name": "Smarter-Claw",
   "description": "Plan-Mode plugin for OpenClaw. Plan-then-execute workflow with mutation gate, archetype prompting, escalating retry, and rejection-cycle tracking. v1 port-in-progress (P-1 skeleton).",
-  "minHostVersion": "2026.5.18",
+  "minHostVersion": "2026.5.19",
   "contracts": {
     "tools": [
       "enter_plan_mode",

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,8 +1,8 @@
 {
   "id": "smarter-claw",
   "name": "Smarter-Claw",
-  "description": "Plan-Mode plugin for OpenClaw. Plan-then-execute workflow with mutation gate, archetype prompting, escalating retry, and rejection-cycle tracking. v1 port-in-progress (P-1 skeleton).",
-  "minHostVersion": "2026.5.19",
+  "description": "Plan-Mode plugin for OpenClaw v2026.6.1-beta.1. Plan-then-execute workflow with mutation gate, archetype prompting, escalating retry, rejection-cycle tracking, and task-flow visibility for pending approvals.",
+  "minHostVersion": "2026.6.1-beta.1",
   "contracts": {
     "tools": [
       "enter_plan_mode",
@@ -57,6 +57,8 @@
     }
   },
   "documentation": {
-    "requiredOperatorConfig": "Smarter-Claw's full plan-mode behavior (archetype injection, auto-continue, escalating retry) requires the conversation-access flag: `plugins.entries.smarter-claw.hooks.allowConversationAccess: true`. The mutation gate works without this flag. See the README's 'Required Operator Config' section."
+    "requiredOperatorConfig": "Smarter-Claw's full plan-mode behavior (archetype injection, auto-continue, escalating retry) requires the conversation-access flag: `plugins.entries.smarter-claw.hooks.allowConversationAccess: true`. The mutation gate works without this flag. See the README's 'Required Operator Config' section.",
+    "releaseTarget": "OpenClaw v2026.6.1-beta.1 (GitHub release tag v2026.6.1-beta.1, commit 2fc497e67b9cf40b2c12a9355afd785e7f8672dc). The matching npm package is not published; SDK fallback validation uses openclaw@2026.5.31-beta.4 plus release-tag seam audits.",
+    "hostSeamGates": "Stock v2026.6.1-beta.1 still restricts active-session attachments to bundled plugins and does not include the chat-stream renderer seam from upstream PR #80982. Smarter-Claw keeps /plan slash commands, sidebar actions, persisted Markdown plan paths, and task-flow visibility as the releasable fallback."
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@electricsheephq/smarter-claw",
-  "version": "1.0.0-port.16",
+  "version": "1.0.0-port.17",
   "description": "Smarter-Claw — Plan-Mode plugin for OpenClaw. Parity-refresh release candidate. Source-of-truth parity at openclaw-pr70071-rebase tip ea04ea52c7. v1.0 public release gated on upstream chat-stream SDK seam.",
   "type": "module",
   "main": "dist/src/index.js",
@@ -11,6 +11,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
+    "runtime-gate": "node scripts/runtime-registration-gate.mjs",
     "parity-harness": "node scripts/check-host-version-parity.mjs && vitest run tests/parity/parity-harness.test.ts",
     "patch:chat-stream-seam": "node scripts/install-chat-stream-seam.mjs",
     "patch:chat-stream-seam:verify": "node scripts/verify-chat-stream-seam.mjs",
@@ -24,6 +25,7 @@
     "scripts/verify-chat-stream-seam.mjs",
     "scripts/uninstall-chat-stream-seam.mjs",
     "scripts/check-host-version-parity.mjs",
+    "scripts/runtime-registration-gate.mjs",
     "README.md",
     "LICENSE",
     "TRADEMARK.md",
@@ -62,7 +64,16 @@
   "openclaw": {
     "extensions": [
       "./dist/src/index.js"
-    ]
+    ],
+    "install": {
+      "minHostVersion": ">=2026.5.18",
+      "npmSpec": "@electricsheephq/smarter-claw@1.0.0-port.17"
+    },
+    "build": {
+      "command": "pnpm build",
+      "entry": "dist/src/index.js",
+      "manifest": "dist/openclaw.plugin.json"
+    }
   },
   "engines": {
     "node": ">=22.0.0"

--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
     "TRADEMARK.md",
     "RELEASE_NOTES.md"
   ],
-  "dependencies": {},
   "devDependencies": {
     "@types/node": "^22.0.0",
     "openclaw": "2026.5.18",
+    "tsx": "4.20.6",
     "typebox": "^1.1.38",
     "typescript": "^5.6.0",
     "vitest": "^3.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@electricsheephq/smarter-claw",
-  "version": "1.0.0-port.17",
+  "version": "1.0.0-port.18",
   "description": "Smarter-Claw — Plan-Mode plugin for OpenClaw. Parity-refresh release candidate. Source-of-truth parity at openclaw-pr70071-rebase tip ea04ea52c7. v1.0 public release gated on upstream chat-stream SDK seam.",
   "type": "module",
   "main": "dist/src/index.js",
@@ -33,14 +33,14 @@
   ],
   "devDependencies": {
     "@types/node": "^22.0.0",
-    "openclaw": "2026.5.18",
+    "openclaw": "2026.5.19",
     "tsx": "4.20.6",
     "typebox": "^1.1.38",
     "typescript": "^5.6.0",
     "vitest": "^3.2.0"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.5.18"
+    "openclaw": ">=2026.5.19"
   },
   "keywords": [
     "openclaw",
@@ -66,8 +66,8 @@
       "./dist/src/index.js"
     ],
     "install": {
-      "minHostVersion": ">=2026.5.18",
-      "npmSpec": "@electricsheephq/smarter-claw@1.0.0-port.17"
+      "minHostVersion": ">=2026.5.19",
+      "npmSpec": "@electricsheephq/smarter-claw@1.0.0-port.18"
     },
     "build": {
       "command": "pnpm build",
@@ -76,6 +76,6 @@
     }
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.19.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@electricsheephq/smarter-claw",
-  "version": "1.0.0-port.18",
-  "description": "Smarter-Claw — Plan-Mode plugin for OpenClaw. Parity-refresh release candidate. Source-of-truth parity at openclaw-pr70071-rebase tip ea04ea52c7. v1.0 public release gated on upstream chat-stream SDK seam.",
+  "version": "1.0.0-port.19",
+  "description": "Smarter-Claw — Plan-Mode plugin for OpenClaw v2026.6.1-beta.1. Parity-refresh release candidate with explicit host seam gates for active-session attachments and chat-stream inline UI.",
   "type": "module",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -33,14 +33,14 @@
   ],
   "devDependencies": {
     "@types/node": "^22.0.0",
-    "openclaw": "2026.5.19",
+    "openclaw": "2026.5.31-beta.4",
     "tsx": "4.20.6",
     "typebox": "^1.1.38",
     "typescript": "^5.6.0",
     "vitest": "^3.2.0"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.5.19"
+    "openclaw": ">=2026.6.1-beta.1"
   },
   "keywords": [
     "openclaw",
@@ -65,9 +65,22 @@
     "extensions": [
       "./dist/src/index.js"
     ],
+    "target": {
+      "version": "2026.6.1-beta.1",
+      "source": "github-release",
+      "tag": "v2026.6.1-beta.1",
+      "commit": "2fc497e67b9cf40b2c12a9355afd785e7f8672dc",
+      "npmPackageAvailable": false
+    },
+    "sdkValidation": {
+      "npmFallbackVersion": "2026.5.31-beta.4",
+      "githubReleaseTag": "v2026.6.1-beta.1",
+      "githubReleaseCommit": "2fc497e67b9cf40b2c12a9355afd785e7f8672dc",
+      "reason": "OpenClaw v2026.6.1-beta.1 is published as a GitHub release but is not available on npm; use the nearest published beta SDK for package install/typecheck and validate runtime seams against the release tag."
+    },
     "install": {
-      "minHostVersion": ">=2026.5.19",
-      "npmSpec": "@electricsheephq/smarter-claw@1.0.0-port.18"
+      "minHostVersion": ">=2026.6.1-beta.1",
+      "npmSpec": "@electricsheephq/smarter-claw@1.0.0-port.19"
     },
     "build": {
       "command": "pnpm build",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       openclaw:
         specifier: 2026.5.18
         version: 2026.5.18
+      tsx:
+        specifier: 4.20.6
+        version: 4.20.6
       typebox:
         specifier: ^1.1.38
         version: 1.1.38
@@ -22,7 +25,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.0
-        version: 3.2.4(@types/node@22.19.17)(jiti@2.7.0)(yaml@2.9.0)
+        version: 3.2.4(@types/node@22.19.17)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0)
 
 packages:
 
@@ -225,16 +228,34 @@ packages:
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.27.7':
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.7':
@@ -243,16 +264,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.27.7':
     resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.27.7':
     resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.7':
@@ -261,10 +300,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.27.7':
     resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.7':
@@ -273,10 +324,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.27.7':
     resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.7':
@@ -285,10 +348,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.27.7':
     resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.7':
@@ -297,10 +372,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.27.7':
     resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.7':
@@ -309,10 +396,22 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.27.7':
     resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.27.7':
@@ -321,16 +420,34 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.27.7':
     resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.27.7':
     resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.27.7':
@@ -339,10 +456,22 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.27.7':
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.7':
@@ -351,11 +480,23 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/openharmony-arm64@0.27.7':
     resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
 
   '@esbuild/sunos-x64@0.27.7':
     resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
@@ -363,16 +504,34 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.27.7':
     resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.27.7':
     resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.7':
@@ -1462,6 +1621,11 @@ packages:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
 
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
@@ -1600,6 +1764,9 @@ packages:
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
+
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
@@ -2058,6 +2225,9 @@ packages:
   require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   retry@0.12.0:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
     engines: {node: '>= 4'}
@@ -2276,6 +2446,11 @@ packages:
   tslog@4.10.2:
     resolution: {integrity: sha512-XuELoRpMR+sq8fuWwX7P0bcj+PRNiicOKDEb3fGNURhxWVyykCi9BNq7c4uVz7h7P0sj8qgBsr5SWS6yBClq3g==}
     engines: {node: '>=16'}
+
+  tsx@4.20.6:
+    resolution: {integrity: sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
@@ -3014,79 +3189,157 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
     optional: true
 
   '@esbuild/android-arm64@0.27.7':
     optional: true
 
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
   '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
     optional: true
 
   '@esbuild/android-x64@0.27.7':
     optional: true
 
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
   '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
     optional: true
 
   '@esbuild/darwin-x64@0.27.7':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
   '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
     optional: true
 
   '@esbuild/linux-arm@0.27.7':
     optional: true
 
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
   '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
     optional: true
 
   '@esbuild/linux-loong64@0.27.7':
     optional: true
 
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
   '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
   '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.27.7':
     optional: true
 
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
   '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
   '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
     optional: true
 
   '@esbuild/win32-arm64@0.27.7':
     optional: true
 
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
   '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@esbuild/win32-x64@0.27.7':
@@ -3817,13 +4070,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(yaml@2.9.0))':
+  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.2(@types/node@22.19.17)(jiti@2.7.0)(yaml@2.9.0)
+      vite: 7.3.2(@types/node@22.19.17)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -4084,6 +4337,35 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
 
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
   esbuild@0.27.7:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.27.7
@@ -4282,6 +4564,10 @@ snapshots:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
+
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   glob@13.0.6:
     dependencies:
@@ -4752,6 +5038,8 @@ snapshots:
 
   require-main-filename@2.0.0: {}
 
+  resolve-pkg-maps@1.0.0: {}
+
   retry@0.12.0: {}
 
   retry@0.13.1: {}
@@ -5027,6 +5315,13 @@ snapshots:
 
   tslog@4.10.2: {}
 
+  tsx@4.20.6:
+    dependencies:
+      esbuild: 0.25.12
+      get-tsconfig: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
   type-is@2.0.1:
     dependencies:
       content-type: 1.0.5
@@ -5055,13 +5350,13 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-node@3.2.4(@types/node@22.19.17)(jiti@2.7.0)(yaml@2.9.0):
+  vite-node@3.2.4(@types/node@22.19.17)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.2(@types/node@22.19.17)(jiti@2.7.0)(yaml@2.9.0)
+      vite: 7.3.2(@types/node@22.19.17)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -5076,7 +5371,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(yaml@2.9.0):
+  vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -5088,13 +5383,14 @@ snapshots:
       '@types/node': 22.19.17
       fsevents: 2.3.3
       jiti: 2.7.0
+      tsx: 4.20.6
       yaml: 2.9.0
 
-  vitest@3.2.4(@types/node@22.19.17)(jiti@2.7.0)(yaml@2.9.0):
+  vitest@3.2.4(@types/node@22.19.17)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(yaml@2.9.0))
+      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@22.19.17)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -5112,8 +5408,8 @@ snapshots:
       tinyglobby: 0.2.16
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.2(@types/node@22.19.17)(jiti@2.7.0)(yaml@2.9.0)
-      vite-node: 3.2.4(@types/node@22.19.17)(jiti@2.7.0)(yaml@2.9.0)
+      vite: 7.3.2(@types/node@22.19.17)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@22.19.17)(jiti@2.7.0)(tsx@4.20.6)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.17

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^22.0.0
         version: 22.19.17
       openclaw:
-        specifier: 2026.5.18
-        version: 2026.5.18
+        specifier: 2026.5.19
+        version: 2026.5.19
       tsx:
         specifier: 4.20.6
         version: 4.20.6
@@ -2084,8 +2084,8 @@ packages:
       zod:
         optional: true
 
-  openclaw@2026.5.18:
-    resolution: {integrity: sha512-a9p2jdD0SEFUIxyCeOsf8gcO7fdo3vn1zGSYi04gA5mE+J1gHCSJTmk+R+hDPg6XOgHLXD+S2PrKi/74qTGPKw==}
+  openclaw@2026.5.19:
+    resolution: {integrity: sha512-5Pn5hcRDVv3eeWYDp4IPPuvyz3yD+Vrdobykl/vi35/49ZldWUz02pDT5rTGMCInDelNZGaWoXAfm5vFdqha8g==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
@@ -4846,7 +4846,7 @@ snapshots:
       ws: 8.20.1
       zod: 4.4.3
 
-  openclaw@2026.5.18:
+  openclaw@2026.5.19:
     dependencies:
       '@agentclientprotocol/sdk': 0.21.1(zod@4.4.3)
       '@clack/core': 1.3.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^22.0.0
         version: 22.19.17
       openclaw:
-        specifier: 2026.5.19
-        version: 2026.5.19
+        specifier: 2026.5.31-beta.4
+        version: 2026.5.31-beta.4
       tsx:
         specifier: 4.20.6
         version: 4.20.6
@@ -29,168 +29,19 @@ importers:
 
 packages:
 
-  '@agentclientprotocol/sdk@0.21.1':
-    resolution: {integrity: sha512-ZTLH+o9QxcZDLX/9ww+W7C2iExnXFM+vD/uGFVSlR61Kzj9FaxUqBC6Rv/kwgA7qVWYUEI9c5ZNqCuO9PM4rKg==}
+  '@agentclientprotocol/sdk@0.22.1':
+    resolution: {integrity: sha512-DfqXtl/8gO9NImq094MTaCXEU2vkhh6v7q/kT+9UjZxUqj8hYaya2OjLVIqn16MzNHcXEpShTR2RIauLSYeDQQ==}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
-  '@anthropic-ai/sdk@0.91.1':
-    resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
+  '@anthropic-ai/sdk@0.100.1':
+    resolution: {integrity: sha512-RANcEe7LpiLczkKGOwoXOTuFdPhuubS0i4xaAKOMpcqc55YO0mukgxppV7eygx3DXNjxWT6RYOLPyOy0aIAmwg==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
     peerDependenciesMeta:
       zod:
         optional: true
-
-  '@aws-crypto/crc32@5.2.0':
-    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
-    engines: {node: '>=16.0.0'}
-
-  '@aws-crypto/sha256-browser@5.2.0':
-    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
-
-  '@aws-crypto/sha256-js@5.2.0':
-    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
-    engines: {node: '>=16.0.0'}
-
-  '@aws-crypto/supports-web-crypto@5.2.0':
-    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
-
-  '@aws-crypto/util@5.2.0':
-    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
-
-  '@aws-sdk/client-bedrock-runtime@3.1045.0':
-    resolution: {integrity: sha512-aPC6gAz9uKRiwfnKB7peTs6yD0FpSzmVnSkx0f2QtJfosFM6J6KtBvR1lMKby050K4C4PAyEScwA5YTsGfTcGA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/core@3.974.8':
-    resolution: {integrity: sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-env@3.972.34':
-    resolution: {integrity: sha512-XT0jtf8Fw9JE6ppsQeoNnZRiG+jqRixMT1v1ZR17G60UvVdsQmTG8nbEyHuEPfMxDXEhfdARaM/XiEhca4lGHQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-http@3.972.36':
-    resolution: {integrity: sha512-DPoGWfy7J7RKxvbf5kOKIGQkD2ek3dbKgzKIGrnLuvZBz5myU+Im/H6pmc14QcnFbqHMqxvtWSgRDSJW3qXLQg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-ini@3.972.38':
-    resolution: {integrity: sha512-oDzUBu2MGJFgoar05sPMCwSrhw44ASyccrHzj66vO69OZqi7I6hZZxXfuPLC8OCzW7C+sU+bI73XHij41yekgQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-login@3.972.38':
-    resolution: {integrity: sha512-g1NosS8qe4OF++G2UFCM5ovSkgipC7YYor5KCWatG0UoMSO5YFj9C8muePlyVmOBV/WTI16Jo3/s1NUo/o1Bww==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-node@3.972.39':
-    resolution: {integrity: sha512-HEswDQyxUtadoZ/bJsPPENHg7R0Lzym5LuMksJeHvqhCOpP+rtkDLKI4/ZChH4w3cf5kG8n6bZuI8PzajoiqMg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-process@3.972.34':
-    resolution: {integrity: sha512-T3IFs4EVmVi1dVN5RciFnklCANSzvrQd/VuHY9ThHSQmYkTogjcGkoJEr+oNUPQZnso52183088NqysMPji1/Q==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-sso@3.972.38':
-    resolution: {integrity: sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-web-identity@3.972.38':
-    resolution: {integrity: sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/eventstream-handler-node@3.972.14':
-    resolution: {integrity: sha512-m4X56gxG76/CKfxNVbOFuYwnAZcHgS6HOH8lgp15HoGHIAVTcZfZrXvcYzJFOMLEJgVn+JHBu6EiNV+xSNXXFg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-eventstream@3.972.10':
-    resolution: {integrity: sha512-QUqLs7Af1II9X4fCRAu+EGHG3KHyOp4RkuLhRKoA3NuFlh6TL8i+zXBl8w2LUxqm44B/Kom45hgSlwA1SpTsXQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-host-header@3.972.10':
-    resolution: {integrity: sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-logger@3.972.10':
-    resolution: {integrity: sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-recursion-detection@3.972.11':
-    resolution: {integrity: sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-sdk-s3@3.972.37':
-    resolution: {integrity: sha512-Km7M+i8DrLArVzrid1gfxeGhYHBd3uxvE77g0s5a52zPSVosxzQBnJ0gwWb6NIp/DOk8gsBMhi7V+cpJG0ndTA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-user-agent@3.972.38':
-    resolution: {integrity: sha512-iz+B29TXcAZsJpwB+AwG/TTGA5l/VnmMZ2UxtiySOZjI6gCdmviXPwdgzcmuazMy16rXoPY4mYCGe7zdNKfx5A==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-websocket@3.972.16':
-    resolution: {integrity: sha512-86+S9oCyRVGzoMRpQhxkArp7kD2K75GPmaNevd9B6EyNhWoNvnCZZ3WbgN4j7ZT+jvtvBCGZvI2XHsWZJ+BRIg==}
-    engines: {node: '>= 14.0.0'}
-
-  '@aws-sdk/nested-clients@3.997.6':
-    resolution: {integrity: sha512-WBDnqatJl+kGObpfmfSxqnXeYTu3Me8wx8WCtvoxX3pfWrrTv8I4WTMSSs7PZqcRcVh8WeUKMgGFjMG+52SR1w==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/region-config-resolver@3.972.13':
-    resolution: {integrity: sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/signature-v4-multi-region@3.996.25':
-    resolution: {integrity: sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/token-providers@3.1041.0':
-    resolution: {integrity: sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/token-providers@3.1045.0':
-    resolution: {integrity: sha512-/o4qcty0DmQola0DBniRVeBakYY6ALOvKEFo1AtJpTmMn/cJ+Fk3RWGe5ieT/f/eYbHG9k5E7poKge/E+WGv4Q==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/types@3.973.8':
-    resolution: {integrity: sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/util-arn-parser@3.972.3':
-    resolution: {integrity: sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/util-endpoints@3.996.8':
-    resolution: {integrity: sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/util-format-url@3.972.10':
-    resolution: {integrity: sha512-DEKiHNJVtNxdyTeQspzY+15Po/kHm6sF0Cs4HV9Q2+lplB63+DrvdeiSoOSdWEWAoO2RcY1veoXVDz2tWxWCgQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/util-locate-window@3.965.5':
-    resolution: {integrity: sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/util-user-agent-browser@3.972.10':
-    resolution: {integrity: sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==}
-
-  '@aws-sdk/util-user-agent-node@3.973.24':
-    resolution: {integrity: sha512-ZWwlkjcIp7cEL8ZfTpTAPNkwx25p7xol0xlKoWVVf22+nsjwmLcHYtTPjIV1cSpmB/b6DaK4cb1fSkvCXHgRdw==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      aws-crt: '>=1.0.0'
-    peerDependenciesMeta:
-      aws-crt:
-        optional: true
-
-  '@aws-sdk/xml-builder@3.972.22':
-    resolution: {integrity: sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws/lambda-invoke-store@0.2.4':
-    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
-    engines: {node: '>=18.0.0'}
 
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
@@ -207,26 +58,9 @@ packages:
     resolution: {integrity: sha512-S0My7XPGIgpRWMDG8uRqalbgT+a6FmCUdOW+HaIOVVpUPHOb7RrpvjTjiODadKp06fsrVDJZlIzc6yCTp4AnxA==}
     engines: {node: '>= 20.12.0'}
 
-  '@earendil-works/pi-agent-core@0.75.1':
-    resolution: {integrity: sha512-JVpX/Zle/enBzEM6he9sE0ASMo8Yhm8q7nOuPQjR/BXhkTBUevrNz7wtTV8VFvgjyhsXzbAsNCP5A4LiCcDx/A==}
+  '@earendil-works/pi-tui@0.78.0':
+    resolution: {integrity: sha512-3a705FnsVVUhAyceShNB3kS2rpxcxLcx+hqB0u6MMMpHwQGbW+m++MqA6r7eOzq/8FLx5e3vDh38h/SVTk2qzw==}
     engines: {node: '>=22.19.0'}
-
-  '@earendil-works/pi-ai@0.75.1':
-    resolution: {integrity: sha512-/bhCWS2R+qHLBDnN+d1t1QRUxtZk7sZpMcrlexPq3W++3bJ0Df0GjhM2FToTubhoCsjOBdBOuRYcV8FNPfRUVQ==}
-    engines: {node: '>=22.19.0'}
-    hasBin: true
-
-  '@earendil-works/pi-coding-agent@0.75.1':
-    resolution: {integrity: sha512-QMbmv8lFQ8P98kpuMc/z1ATTq7t0lQ+Bo3GLiOKQ/HonO34n4E1+395FCqlmG8zJEhiMp4yqVTzlj7BALQMlqw==}
-    engines: {node: '>=22.19.0'}
-    hasBin: true
-
-  '@earendil-works/pi-tui@0.75.1':
-    resolution: {integrity: sha512-IFDSvCXcXMoIxFKxdhqc7ybX8p86KpdxoTUTYEq3FHilMFkBqlXqZD0jZBitqxStBjjMkAlhjS1bKS0IOXSpsg==}
-    engines: {node: '>=22.19.0'}
-
-  '@emnapi/runtime@1.10.0':
-    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -540,17 +374,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@google/genai@1.52.0':
-    resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      '@modelcontextprotocol/sdk': ^1.25.2
-    peerDependenciesMeta:
-      '@modelcontextprotocol/sdk':
-        optional: true
-
-  '@google/genai@2.3.0':
-    resolution: {integrity: sha512-rXDhXUBj31gZafcwQFbXvt8jMrMxZoK7ECjQpk88UfA/OkZls3PtZDprT9lM3jjqRtwRjQoNLoPoNq6MlV8qLw==}
+  '@google/genai@2.7.0':
+    resolution: {integrity: sha512-tv0DRtcndt2oEhBYy+5mA0TaXH98+L1Gt0AP9unBfH7DP20KhB7+O3QqAN1Lz+laMARGTHS7BFQSNpLbl4gm1g==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@modelcontextprotocol/sdk': ^1.25.2
@@ -570,11 +395,11 @@ packages:
     peerDependencies:
       grammy: ^1.0.0
 
-  '@grammyjs/types@3.26.0':
-    resolution: {integrity: sha512-jlnyfxfev/2o68HlvAGRocAXgdPPX5QabG7jZlbqC2r9DZyWBfzTlg+nu3O3Fy4EhgLWu28hZ/8wr7DsNamP9A==}
+  '@grammyjs/types@3.27.3':
+    resolution: {integrity: sha512-yUKMLliGsGbnxu96YUJ7km7B0zy4PzeH/Jvti5705R/LeKDMqkDV4DckMSt+OrliWQpTwQljHE0QLol5zgxBkg==}
 
-  '@homebridge/ciao@1.3.8':
-    resolution: {integrity: sha512-lNhpCsZVbdbjz2trFjQdzQ3cUIMZQMIMksi7wd3ntTIYgdaGLqT1Ms97DfVIJYHzRuduf56ISvgU8RRLTpK/ng==}
+  '@homebridge/ciao@1.3.9':
+    resolution: {integrity: sha512-TMy9zy173jDOpnFXDqL3BPIQn5lfcAkSsivYQatCCakoHk4fLGd7QjfAaNGYE3Ox+/ZI6Lq0e1gGcz1qdw/IbA==}
     hasBin: true
 
   '@hono/node-server@1.19.14':
@@ -582,159 +407,6 @@ packages:
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
-
-  '@img/colour@1.1.0':
-    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
-    engines: {node: '>=18'}
-
-  '@img/sharp-darwin-arm64@0.34.5':
-    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@img/sharp-darwin-x64@0.34.5':
-    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [darwin]
-
-  '@img/sharp-libvips-darwin-arm64@1.2.4':
-    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@img/sharp-libvips-darwin-x64@1.2.4':
-    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@img/sharp-libvips-linux-arm64@1.2.4':
-    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-arm@1.2.4':
-    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
-    cpu: [arm]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-ppc64@1.2.4':
-    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-riscv64@1.2.4':
-    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-s390x@1.2.4':
-    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-x64@1.2.4':
-    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
-    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
-    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@img/sharp-linux-arm64@0.34.5':
-    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-arm@0.34.5':
-    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-ppc64@0.34.5':
-    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-riscv64@0.34.5':
-    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-s390x@0.34.5':
-    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-x64@0.34.5':
-    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linuxmusl-arm64@0.34.5':
-    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@img/sharp-linuxmusl-x64@0.34.5':
-    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@img/sharp-wasm32@0.34.5':
-    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [wasm32]
-
-  '@img/sharp-win32-arm64@0.34.5':
-    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [win32]
-
-  '@img/sharp-win32-ia32@0.34.5':
-    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [ia32]
-    os: [win32]
-
-  '@img/sharp-win32-x64@0.34.5':
-    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [win32]
 
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
@@ -776,76 +448,8 @@ packages:
   '@lydell/node-pty@1.2.0-beta.12':
     resolution: {integrity: sha512-qIK890UwPupoj07osVvgOIa++1mxeHbcGry4PKRHhNVNs81V2SCG34eJr46GybiOmBtc8Sj5PB1/GGM5PL549g==}
 
-  '@mariozechner/clipboard-darwin-arm64@0.3.6':
-    resolution: {integrity: sha512-HjaisYCAbHi/1+N1yDAQHc8ZXGffufIUT5NSOSVR3f3AuMDusxTtnbK8tZ7JFDkShua1oNGZoNwQHsc8MPtE0Q==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@mariozechner/clipboard-darwin-universal@0.3.6':
-    resolution: {integrity: sha512-8BWtPjOtJOJoykml3w0fx0zRrfWP31mXrJwfoA7xzNprkZw1uolCNfgmjDiVBseoKjp16EGITz7bN+61qn8dWA==}
-    engines: {node: '>= 10'}
-    os: [darwin]
-
-  '@mariozechner/clipboard-darwin-x64@0.3.6':
-    resolution: {integrity: sha512-p9syiZD1kU4I+1ya7f7g+zD1GiUvR8fdlRlNmgsZNWlyjtc8rlV2EjTLd/35x1LsdBq020GVvtzp0ZmPgBI09Q==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@mariozechner/clipboard-linux-arm64-gnu@0.3.6':
-    resolution: {integrity: sha512-5JFf5rGofrm+V29HNF+wLthXphHdQpMbKDUYJ5tML6/Z5DLlLOV/9Ak4kDPtYyZ+Dzf+kAusE0VsFg4+tfP1IA==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@mariozechner/clipboard-linux-arm64-musl@0.3.6':
-    resolution: {integrity: sha512-JlVjxxw0GbGC0djXYWRIqyteO3J1KZ/QG3udlEFaOD5TLOM1FnmXXAPDQBqr+aBVr720ef9K00dirYnJ0LDCtw==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.6':
-    resolution: {integrity: sha512-4t8BUi5zZ+L77otFQVnVSlaTyAX4TVk9EqQm4syMrEQp96trFEHEwwNHcNEBGzYv5+K7mxay50TthYkz47OWzQ==}
-    engines: {node: '>= 10'}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
-  '@mariozechner/clipboard-linux-x64-gnu@0.3.6':
-    resolution: {integrity: sha512-trtPwcNLW37irwQCJLtCxLw757jjJZk3TSnY/MU9bhtWtA3K9b/eLW0e4RGhUXDoFRds9opNWWaUDuFLa8dm0w==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@mariozechner/clipboard-linux-x64-musl@0.3.6':
-    resolution: {integrity: sha512-WfnzIvOCCWQiN0MmltCEo6cLceUDbYe+I7xyFZjaps5A+2Op/M2CY7Rey+C4ucQhrvmpoHmTSFgY9ODWk7snoA==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@mariozechner/clipboard-win32-arm64-msvc@0.3.6':
-    resolution: {integrity: sha512-+8+1aHYsBPUjmW3otmWlg+Hijt0iJvoBBs5e0mxFeUd4gDaKMB8Bn6x7c6KVtscg7E5j5NFXnwQqNSIAO4p8zQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@mariozechner/clipboard-win32-x64-msvc@0.3.6':
-    resolution: {integrity: sha512-S4xfPmERC8ZkiLHe3vekZCjdDwNEETCuvCgQK2kP6/TnvmUkq1y2Pk+DjM4t8uh9KMX9bH4zs5ePcKa8GTXmfg==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [win32]
-
-  '@mariozechner/clipboard@0.3.6':
-    resolution: {integrity: sha512-MXdtr+6+ntlIVHdrZYuZNQydu6o8yZswFJ2Ln81j2O/Y9B/LDHvEaIm95xWNPkjGTWriSOeLnQJRFs6dYb60bg==}
-    engines: {node: '>= 10'}
-
-  '@mistralai/mistralai@2.2.1':
-    resolution: {integrity: sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==}
+  '@mistralai/mistralai@2.2.5':
+    resolution: {integrity: sha512-ATbWzKkNzNAZ+gtw9MI/c/ULTMG80tKUiRNIbQFfg4OP0uEZZpTfXZeBCNfs5Dq0uqMQ/tQWc4o6RRJQtMrpDA==}
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -861,86 +465,8 @@ packages:
     resolution: {integrity: sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==}
     engines: {node: '>=14.0.0'}
 
-  '@napi-rs/canvas-android-arm64@0.1.100':
-    resolution: {integrity: sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [android]
-
-  '@napi-rs/canvas-darwin-arm64@0.1.100':
-    resolution: {integrity: sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@napi-rs/canvas-darwin-x64@0.1.100':
-    resolution: {integrity: sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.100':
-    resolution: {integrity: sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==}
-    engines: {node: '>= 10'}
-    cpu: [arm]
-    os: [linux]
-
-  '@napi-rs/canvas-linux-arm64-gnu@0.1.100':
-    resolution: {integrity: sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@napi-rs/canvas-linux-arm64-musl@0.1.100':
-    resolution: {integrity: sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
-    resolution: {integrity: sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==}
-    engines: {node: '>= 10'}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
-  '@napi-rs/canvas-linux-x64-gnu@0.1.100':
-    resolution: {integrity: sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@napi-rs/canvas-linux-x64-musl@0.1.100':
-    resolution: {integrity: sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
-    resolution: {integrity: sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@napi-rs/canvas-win32-x64-msvc@0.1.100':
-    resolution: {integrity: sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [win32]
-
-  '@napi-rs/canvas@0.1.100':
-    resolution: {integrity: sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==}
-    engines: {node: '>= 10'}
-
-  '@nodable/entities@2.1.0':
-    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
-
-  '@openclaw/fs-safe@0.2.4':
-    resolution: {integrity: sha512-Fo3WTQhxu0asD/rZqIKBqhX6fuZfjyHxSW5yTKfcRx+D9BRAcz0AGoVh+3ur/4XRvZkvsh3Ud8XTw006yRYLgg==}
+  '@openclaw/fs-safe@0.3.0':
+    resolution: {integrity: sha512-uIBE441CIt1kIURoP9qRGKZ8LkGyfD9ZzeESjwAd29ZPWtghws/5GR3Pjb67jKdcJHP1I6roNXcvnhzAU7lHlA==}
     engines: {node: '>=20.11'}
 
   '@openclaw/proxyline@0.3.3':
@@ -1120,186 +646,8 @@ packages:
   '@silvia-odwyer/photon-node@0.3.4':
     resolution: {integrity: sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==}
 
-  '@smithy/config-resolver@4.4.17':
-    resolution: {integrity: sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/core@3.24.1':
-    resolution: {integrity: sha512-3mT7o4qQyUWttYnVK3A0Z/u3Xha3E81tXn32Tz6vjZiUXhBrkEivpw1hBYfh84iFF9CSzkBU9Y1DJ3Q6RQ231g==}
-    engines: {node: '>=18.0.0'}
-    deprecated: Deprecated due to bug in browser bundling instructions https://github.com/smithy-lang/smithy-typescript/issues/2025
-
-  '@smithy/credential-provider-imds@4.2.14':
-    resolution: {integrity: sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/eventstream-codec@4.2.14':
-    resolution: {integrity: sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/eventstream-serde-browser@4.2.14':
-    resolution: {integrity: sha512-8IelTCtTctWRbb+0Dcy+C0aICh1qa0qWXqgjcXDmMuCvPJRnv26hiDZoAau2ILOniki65mCPKqOQs/BaWvO4CQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/eventstream-serde-config-resolver@4.3.14':
-    resolution: {integrity: sha512-sqHiHpYRYo3FJlaIxD1J8PhbcmJAm7IuM16mVnwSkCToD7g00IBZzKuiLNMGmftULmEUX6/UAz8/NN5uMP8bVA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/eventstream-serde-node@4.2.14':
-    resolution: {integrity: sha512-Ht/8BuGlKfFTy0H3+8eEu0vdpwGztCnaLLXtpXNdQqiR7Hj4vFScU3T436vRAjATglOIPjJXronY+1WxxNLSiw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/eventstream-serde-universal@4.2.14':
-    resolution: {integrity: sha512-lWyt4T2XQZUZgK3tQ3Wn0w3XBvZsK/vjTuJl6bXbnGZBHH0ZUSONTYiK9TgjTTzU54xQr3DRFwpjmhp0oLm3gg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/fetch-http-handler@5.3.17':
-    resolution: {integrity: sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/hash-node@4.2.14':
-    resolution: {integrity: sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/invalid-dependency@4.2.14':
-    resolution: {integrity: sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/is-array-buffer@2.2.0':
-    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/is-array-buffer@4.2.2':
-    resolution: {integrity: sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/middleware-content-length@4.2.14':
-    resolution: {integrity: sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/middleware-endpoint@4.4.32':
-    resolution: {integrity: sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/middleware-retry@4.6.1':
-    resolution: {integrity: sha512-eTaQhxs0rfUuAkL2MSKrH8DTO7YCeAgrdN0B2/RAeuHmXQ+x52dk5qUBsi/jtcqe5LxItgq5AG5tI6Cp8c0sow==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/middleware-serde@4.2.20':
-    resolution: {integrity: sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/middleware-stack@4.2.14':
-    resolution: {integrity: sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/node-config-provider@4.3.14':
-    resolution: {integrity: sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/node-http-handler@4.6.1':
-    resolution: {integrity: sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/property-provider@4.2.14':
-    resolution: {integrity: sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/protocol-http@5.3.14':
-    resolution: {integrity: sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/querystring-builder@4.2.14':
-    resolution: {integrity: sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/querystring-parser@4.2.14':
-    resolution: {integrity: sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/shared-ini-file-loader@4.4.9':
-    resolution: {integrity: sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/signature-v4@5.3.14':
-    resolution: {integrity: sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/smithy-client@4.12.13':
-    resolution: {integrity: sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/types@4.14.1':
-    resolution: {integrity: sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/url-parser@4.2.14':
-    resolution: {integrity: sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-base64@4.3.2':
-    resolution: {integrity: sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-body-length-browser@4.2.2':
-    resolution: {integrity: sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-body-length-node@4.2.3':
-    resolution: {integrity: sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-buffer-from@2.2.0':
-    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/util-buffer-from@4.2.2':
-    resolution: {integrity: sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-config-provider@4.2.2':
-    resolution: {integrity: sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-defaults-mode-browser@4.3.49':
-    resolution: {integrity: sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-defaults-mode-node@4.2.54':
-    resolution: {integrity: sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-endpoints@3.4.2':
-    resolution: {integrity: sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-hex-encoding@4.2.2':
-    resolution: {integrity: sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-middleware@4.2.14':
-    resolution: {integrity: sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-retry@4.4.1':
-    resolution: {integrity: sha512-qkgWgwn1xw0GoY9Ea/B6FrYSPfHA0zyOtJkokwxZuvucRf2+2lfTut6adi4e4Y7LEAaxsFG7r6i05mtDCxbHKA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-stream@4.5.25':
-    resolution: {integrity: sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-uri-escape@4.2.2':
-    resolution: {integrity: sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-utf8@2.3.0':
-    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/util-utf8@4.2.2':
-    resolution: {integrity: sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==}
-    engines: {node: '>=18.0.0'}
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
   '@tokenizer/inflate@0.4.1':
     resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
@@ -1383,9 +731,6 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
-  argparse@2.0.1:
-    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
-
   asn1.js@5.4.1:
     resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
 
@@ -1415,9 +760,6 @@ packages:
 
   bottleneck@2.19.5:
     resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
-
-  bowser@2.14.1:
-    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
@@ -1468,6 +810,11 @@ packages:
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
+
+  clawpdf@0.3.0:
+    resolution: {integrity: sha512-41+3AnKk9yek2sm+/9XvUlDTN8Wi+ag7fmxZuqw+ySn4lqaf/fCgLeamqPLiXY4gVbizKEHGoTG/JrIIFNE2rw==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   cliui@6.0.0:
     resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
@@ -1553,12 +900,8 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
-  detect-libc@2.1.2:
-    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
-    engines: {node: '>=8'}
-
-  diff@8.0.4:
-    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
+  diff@9.0.0:
+    resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
     engines: {node: '>=0.3.1'}
 
   dijkstrajs@1.0.3:
@@ -1677,6 +1020,9 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fast-string-truncated-width@3.0.3:
     resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
 
@@ -1688,13 +1034,6 @@ packages:
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
-
-  fast-xml-builder@1.1.5:
-    resolution: {integrity: sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==}
-
-  fast-xml-parser@5.7.2:
-    resolution: {integrity: sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==}
-    hasBin: true
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1753,8 +1092,8 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
-  get-east-asian-width@1.5.0:
-    resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
     engines: {node: '>=18'}
 
   get-intrinsic@1.3.0:
@@ -1787,8 +1126,8 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
-  grammy@1.42.0:
-    resolution: {integrity: sha512-1AdCge+AkjSdp2FwfICSFnVbl8Mq3KVHJDy+DgTI9+D6keJ0zWALPRKas5jv/8psiCzL4N2cEOcGW7O45Kn39g==}
+  grammy@1.43.0:
+    resolution: {integrity: sha512-7dYm06A945mXuIk/5HUlSjeyIYChW8vCEiU2dkOKKqJJzwAWxTkCc91Eqbz7TgODh2rtFFKWI/fekowWHOkmjQ==}
     engines: {node: ^12.20.0 || >=14.13.1}
 
   has-symbols@1.1.0:
@@ -1799,16 +1138,17 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
-  highlight.js@10.7.3:
-    resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
+  highlight.js@11.11.1:
+    resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
+    engines: {node: '>=12.0.0'}
 
   hono@4.12.14:
     resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
     engines: {node: '>=16.9.0'}
 
-  hosted-git-info@9.0.2:
-    resolution: {integrity: sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==}
-    engines: {node: ^20.17.0 || >=22.9.0}
+  hosted-git-info@10.1.1:
+    resolution: {integrity: sha512-DeOnSPAvOndYKfw075gt8yZzQ7S2hNztw34zBTfhIzLhmBTswIBg5/y+pqu/VD5cYWm5goAFTusDmUEmKZ0PEQ==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
   html-escaper@3.0.3:
     resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
@@ -1819,10 +1159,6 @@ packages:
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
-
-  http-proxy-agent@7.0.2:
-    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
-    engines: {node: '>= 14'}
 
   http_ece@1.2.0:
     resolution: {integrity: sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==}
@@ -1856,10 +1192,6 @@ packages:
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
-
-  ipaddr.js@2.4.0:
-    resolution: {integrity: sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==}
-    engines: {node: '>= 10'}
 
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
@@ -1911,11 +1243,8 @@ packages:
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
-  koffi@2.16.1:
-    resolution: {integrity: sha512-0Ie6CfD026dNfWSosDw9dPxPzO9Rlyo0N8m5r05S8YjytIpuilzMFDMY4IDy/8xQsTwpuVinhncD+S8n3bcYZQ==}
-
-  kysely@0.29.1:
-    resolution: {integrity: sha512-mOW4e+UMfrV1u/+a4uXO72mkwEJCIL4Tb/OQ8wU8jY5spUHxLKFfC1AnfNhfSoHubnIRly3u/xgnMdD0Vzq2RQ==}
+  kysely@0.29.2:
+    resolution: {integrity: sha512-s6WVJyEZrbm6jhBpiKHsGHyePMrVQKJ85wZCFCr9W4QHv6WTjWIrdvTmO9hDEA3bNK0xkrE2DqrHsXMLWuZpQg==}
     engines: {node: '>=22.0.0'}
 
   lie@3.3.0:
@@ -1929,9 +1258,6 @@ packages:
     peerDependenciesMeta:
       canvas:
         optional: true
-
-  linkify-it@5.0.0:
-    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
 
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
@@ -1950,10 +1276,6 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  markdown-it@14.1.1:
-    resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
-    hasBin: true
-
   marked@15.0.12:
     resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
     engines: {node: '>= 18'}
@@ -1962,9 +1284,6 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
-
-  mdurl@2.0.0:
-    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
@@ -2060,8 +1379,8 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
-  openai@6.26.0:
-    resolution: {integrity: sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==}
+  openai@6.39.1:
+    resolution: {integrity: sha512-z3dO9fEWOXBzlXynVb/xZ/tujzUjFWQWn3C0n0mw6Vo0zJTbEkaN4b2cLWjhJ6haJQx8LlREoafHRl+Gu/Hl+A==}
     hasBin: true
     peerDependencies:
       ws: ^8.18.0
@@ -2072,20 +1391,8 @@ packages:
       zod:
         optional: true
 
-  openai@6.38.0:
-    resolution: {integrity: sha512-AoMplt2UalrpgUDMh3L09QWjNRlgJPipclQvA6sYAaeF6nHNBMgmikAZGmcYLn8on4d9sQY9Q8bOLfrBS7Lc8g==}
-    hasBin: true
-    peerDependencies:
-      ws: ^8.18.0
-      zod: ^3.25 || ^4.0
-    peerDependenciesMeta:
-      ws:
-        optional: true
-      zod:
-        optional: true
-
-  openclaw@2026.5.19:
-    resolution: {integrity: sha512-5Pn5hcRDVv3eeWYDp4IPPuvyz3yD+Vrdobykl/vi35/49ZldWUz02pDT5rTGMCInDelNZGaWoXAfm5vFdqha8g==}
+  openclaw@2026.5.31-beta.4:
+    resolution: {integrity: sha512-fCBDLAtGp4uxu1Q1fWjz4sF5xJ+spm4JXlxXwhKEvvny3/01XbE/ZdljVlSCpSaGR8eQHEUFm9wx8cxuh80M9Q==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
@@ -2119,10 +1426,6 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
-  path-expression-matcher@1.5.0:
-    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
-    engines: {node: '>=14.0.0'}
-
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
@@ -2140,10 +1443,6 @@ packages:
   pathval@2.0.1:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
-
-  pdfjs-dist@5.7.284:
-    resolution: {integrity: sha512-h4EdYQczmGhbOlqc3PPZwxevn7ApdWPbovAuWXOB/DjIyigSnwfy2oze7c6mRcSr9XgLp3eN3EeL4DyySTPMFw==}
-    engines: {node: '>=22.13.0 || >=24'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -2183,10 +1482,6 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
-  punycode.js@2.3.1:
-    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
-    engines: {node: '>=6'}
-
   qrcode@1.5.4:
     resolution: {integrity: sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==}
     engines: {node: '>=10.13.0'}
@@ -2196,12 +1491,16 @@ packages:
     resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
     engines: {node: '>=0.6'}
 
-  quickjs-wasi@2.2.0:
-    resolution: {integrity: sha512-zQxXmQMrEoD3S+jQdYsloq4qAuaxKFHZj6hHqOYGwB2iQZH+q9e/lf5zQPXCKOk0WJuAjzRFbO4KwHIp2D05Iw==}
+  quickjs-wasi@3.0.0:
+    resolution: {integrity: sha512-X7ouKC4ZVf9bXQ8rsE7+L6TeBbesejAJH61x16xRaGAQGfBHHRcniWgzJZZVtHc8rS9yVsY+Tvk8/usAosg4bg==}
 
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
+
+  rastermill@0.3.1:
+    resolution: {integrity: sha512-CX4nij6+ZLHYIaojJNfLTr7W+AiH/IPJi6E9Aw1br2///1KZL2KBOHd68rkcLedc47MPvb4hhH+fzYeGFa4A/Q==}
+    engines: {node: '>=22'}
 
   raw-body@3.0.2:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
@@ -2254,11 +1553,6 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  semver@7.7.4:
-    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
@@ -2275,10 +1569,6 @@ packages:
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
-
-  sharp@0.34.5:
-    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -2355,6 +1645,9 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -2375,9 +1668,6 @@ packages:
 
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
-
-  strnum@2.2.3:
-    resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
 
   strtok3@10.3.5:
     resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
@@ -2421,11 +1711,6 @@ packages:
     resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
     engines: {node: '>=14.16'}
 
-  tokenjuice@0.7.1:
-    resolution: {integrity: sha512-eO048hm9UcGHASjYkIWEij8QN68amGp+S1nJyo685qB1/ol+VGEYjPglcVPvCbJbZyFHvI+BBAMvOfnqYCtpsQ==}
-    engines: {node: '>=20'}
-    hasBin: true
-
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
@@ -2459,6 +1744,9 @@ packages:
   typebox@1.1.38:
     resolution: {integrity: sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==}
 
+  typebox@1.1.39:
+    resolution: {integrity: sha512-vj0afVtOfLQvv0GR0VxVagYxsXN64btL7Z9XoaG0ZggH3mruMMkOO6hXdgMsjCY3shZgEvooAWVeznQVs5c43w==}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -2468,9 +1756,6 @@ packages:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
-
-  uc.micro@2.1.0:
-    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   uhyphen@0.2.0:
     resolution: {integrity: sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==}
@@ -2579,8 +1864,8 @@ packages:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
-  web-tree-sitter@0.26.8:
-    resolution: {integrity: sha512-4sUwi7ZyOrIk5KLgYLkc2A/F0LFMQnBhfb+2Cdl7ik4ePJ6JD+fk4ofI2sA5eGawBKBaK4Vntt7Ww5KcEsay4A==}
+  web-tree-sitter@0.26.9:
+    resolution: {integrity: sha512-YJwSHANl6XFgeEjB8nitgj0qZYt5gkIesJ4w2srS2wcLB4GUa4xcOkM0YaMsU6WNR53YVIkDSY7Ej4pf3IXtCA==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -2612,8 +1897,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.20.1:
-    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -2666,436 +1951,16 @@ packages:
 
 snapshots:
 
-  '@agentclientprotocol/sdk@0.21.1(zod@4.4.3)':
+  '@agentclientprotocol/sdk@0.22.1(zod@4.4.3)':
     dependencies:
       zod: 4.4.3
 
-  '@anthropic-ai/sdk@0.91.1(zod@4.4.3)':
+  '@anthropic-ai/sdk@0.100.1(zod@4.4.3)':
     dependencies:
       json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
     optionalDependencies:
       zod: 4.4.3
-
-  '@aws-crypto/crc32@5.2.0':
-    dependencies:
-      '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.8
-      tslib: 2.8.1
-
-  '@aws-crypto/sha256-browser@5.2.0':
-    dependencies:
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-crypto/supports-web-crypto': 5.2.0
-      '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.8
-      '@aws-sdk/util-locate-window': 3.965.5
-      '@smithy/util-utf8': 2.3.0
-      tslib: 2.8.1
-
-  '@aws-crypto/sha256-js@5.2.0':
-    dependencies:
-      '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.8
-      tslib: 2.8.1
-
-  '@aws-crypto/supports-web-crypto@5.2.0':
-    dependencies:
-      tslib: 2.8.1
-
-  '@aws-crypto/util@5.2.0':
-    dependencies:
-      '@aws-sdk/types': 3.973.8
-      '@smithy/util-utf8': 2.3.0
-      tslib: 2.8.1
-
-  '@aws-sdk/client-bedrock-runtime@3.1045.0':
-    dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/credential-provider-node': 3.972.39
-      '@aws-sdk/eventstream-handler-node': 3.972.14
-      '@aws-sdk/middleware-eventstream': 3.972.10
-      '@aws-sdk/middleware-host-header': 3.972.10
-      '@aws-sdk/middleware-logger': 3.972.10
-      '@aws-sdk/middleware-recursion-detection': 3.972.11
-      '@aws-sdk/middleware-user-agent': 3.972.38
-      '@aws-sdk/middleware-websocket': 3.972.16
-      '@aws-sdk/region-config-resolver': 3.972.13
-      '@aws-sdk/token-providers': 3.1045.0
-      '@aws-sdk/types': 3.973.8
-      '@aws-sdk/util-endpoints': 3.996.8
-      '@aws-sdk/util-user-agent-browser': 3.972.10
-      '@aws-sdk/util-user-agent-node': 3.973.24
-      '@smithy/config-resolver': 4.4.17
-      '@smithy/core': 3.24.1
-      '@smithy/eventstream-serde-browser': 4.2.14
-      '@smithy/eventstream-serde-config-resolver': 4.3.14
-      '@smithy/eventstream-serde-node': 4.2.14
-      '@smithy/fetch-http-handler': 5.3.17
-      '@smithy/hash-node': 4.2.14
-      '@smithy/invalid-dependency': 4.2.14
-      '@smithy/middleware-content-length': 4.2.14
-      '@smithy/middleware-endpoint': 4.4.32
-      '@smithy/middleware-retry': 4.6.1
-      '@smithy/middleware-serde': 4.2.20
-      '@smithy/middleware-stack': 4.2.14
-      '@smithy/node-config-provider': 4.3.14
-      '@smithy/node-http-handler': 4.6.1
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/smithy-client': 4.12.13
-      '@smithy/types': 4.14.1
-      '@smithy/url-parser': 4.2.14
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-body-length-browser': 4.2.2
-      '@smithy/util-body-length-node': 4.2.3
-      '@smithy/util-defaults-mode-browser': 4.3.49
-      '@smithy/util-defaults-mode-node': 4.2.54
-      '@smithy/util-endpoints': 3.4.2
-      '@smithy/util-middleware': 4.2.14
-      '@smithy/util-retry': 4.4.1
-      '@smithy/util-stream': 4.5.25
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/core@3.974.8':
-    dependencies:
-      '@aws-sdk/types': 3.973.8
-      '@aws-sdk/xml-builder': 3.972.22
-      '@smithy/core': 3.24.1
-      '@smithy/node-config-provider': 4.3.14
-      '@smithy/property-provider': 4.2.14
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/signature-v4': 5.3.14
-      '@smithy/smithy-client': 4.12.13
-      '@smithy/types': 4.14.1
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-middleware': 4.2.14
-      '@smithy/util-retry': 4.4.1
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-env@3.972.34':
-    dependencies:
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/types': 3.973.8
-      '@smithy/property-provider': 4.2.14
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-http@3.972.36':
-    dependencies:
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/types': 3.973.8
-      '@smithy/fetch-http-handler': 5.3.17
-      '@smithy/node-http-handler': 4.6.1
-      '@smithy/property-provider': 4.2.14
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/smithy-client': 4.12.13
-      '@smithy/types': 4.14.1
-      '@smithy/util-stream': 4.5.25
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-ini@3.972.38':
-    dependencies:
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/credential-provider-env': 3.972.34
-      '@aws-sdk/credential-provider-http': 3.972.36
-      '@aws-sdk/credential-provider-login': 3.972.38
-      '@aws-sdk/credential-provider-process': 3.972.34
-      '@aws-sdk/credential-provider-sso': 3.972.38
-      '@aws-sdk/credential-provider-web-identity': 3.972.38
-      '@aws-sdk/nested-clients': 3.997.6
-      '@aws-sdk/types': 3.973.8
-      '@smithy/credential-provider-imds': 4.2.14
-      '@smithy/property-provider': 4.2.14
-      '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/credential-provider-login@3.972.38':
-    dependencies:
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/nested-clients': 3.997.6
-      '@aws-sdk/types': 3.973.8
-      '@smithy/property-provider': 4.2.14
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/credential-provider-node@3.972.39':
-    dependencies:
-      '@aws-sdk/credential-provider-env': 3.972.34
-      '@aws-sdk/credential-provider-http': 3.972.36
-      '@aws-sdk/credential-provider-ini': 3.972.38
-      '@aws-sdk/credential-provider-process': 3.972.34
-      '@aws-sdk/credential-provider-sso': 3.972.38
-      '@aws-sdk/credential-provider-web-identity': 3.972.38
-      '@aws-sdk/types': 3.973.8
-      '@smithy/credential-provider-imds': 4.2.14
-      '@smithy/property-provider': 4.2.14
-      '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/credential-provider-process@3.972.34':
-    dependencies:
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/types': 3.973.8
-      '@smithy/property-provider': 4.2.14
-      '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-sso@3.972.38':
-    dependencies:
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/nested-clients': 3.997.6
-      '@aws-sdk/token-providers': 3.1041.0
-      '@aws-sdk/types': 3.973.8
-      '@smithy/property-provider': 4.2.14
-      '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/credential-provider-web-identity@3.972.38':
-    dependencies:
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/nested-clients': 3.997.6
-      '@aws-sdk/types': 3.973.8
-      '@smithy/property-provider': 4.2.14
-      '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/eventstream-handler-node@3.972.14':
-    dependencies:
-      '@aws-sdk/types': 3.973.8
-      '@smithy/eventstream-codec': 4.2.14
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-eventstream@3.972.10':
-    dependencies:
-      '@aws-sdk/types': 3.973.8
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-host-header@3.972.10':
-    dependencies:
-      '@aws-sdk/types': 3.973.8
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-logger@3.972.10':
-    dependencies:
-      '@aws-sdk/types': 3.973.8
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-recursion-detection@3.972.11':
-    dependencies:
-      '@aws-sdk/types': 3.973.8
-      '@aws/lambda-invoke-store': 0.2.4
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-sdk-s3@3.972.37':
-    dependencies:
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/types': 3.973.8
-      '@aws-sdk/util-arn-parser': 3.972.3
-      '@smithy/core': 3.24.1
-      '@smithy/node-config-provider': 4.3.14
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/signature-v4': 5.3.14
-      '@smithy/smithy-client': 4.12.13
-      '@smithy/types': 4.14.1
-      '@smithy/util-config-provider': 4.2.2
-      '@smithy/util-middleware': 4.2.14
-      '@smithy/util-stream': 4.5.25
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-user-agent@3.972.38':
-    dependencies:
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/types': 3.973.8
-      '@aws-sdk/util-endpoints': 3.996.8
-      '@smithy/core': 3.24.1
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/types': 4.14.1
-      '@smithy/util-retry': 4.4.1
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-websocket@3.972.16':
-    dependencies:
-      '@aws-sdk/types': 3.973.8
-      '@aws-sdk/util-format-url': 3.972.10
-      '@smithy/eventstream-codec': 4.2.14
-      '@smithy/eventstream-serde-browser': 4.2.14
-      '@smithy/fetch-http-handler': 5.3.17
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/signature-v4': 5.3.14
-      '@smithy/types': 4.14.1
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-hex-encoding': 4.2.2
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-
-  '@aws-sdk/nested-clients@3.997.6':
-    dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/middleware-host-header': 3.972.10
-      '@aws-sdk/middleware-logger': 3.972.10
-      '@aws-sdk/middleware-recursion-detection': 3.972.11
-      '@aws-sdk/middleware-user-agent': 3.972.38
-      '@aws-sdk/region-config-resolver': 3.972.13
-      '@aws-sdk/signature-v4-multi-region': 3.996.25
-      '@aws-sdk/types': 3.973.8
-      '@aws-sdk/util-endpoints': 3.996.8
-      '@aws-sdk/util-user-agent-browser': 3.972.10
-      '@aws-sdk/util-user-agent-node': 3.973.24
-      '@smithy/config-resolver': 4.4.17
-      '@smithy/core': 3.24.1
-      '@smithy/fetch-http-handler': 5.3.17
-      '@smithy/hash-node': 4.2.14
-      '@smithy/invalid-dependency': 4.2.14
-      '@smithy/middleware-content-length': 4.2.14
-      '@smithy/middleware-endpoint': 4.4.32
-      '@smithy/middleware-retry': 4.6.1
-      '@smithy/middleware-serde': 4.2.20
-      '@smithy/middleware-stack': 4.2.14
-      '@smithy/node-config-provider': 4.3.14
-      '@smithy/node-http-handler': 4.6.1
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/smithy-client': 4.12.13
-      '@smithy/types': 4.14.1
-      '@smithy/url-parser': 4.2.14
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-body-length-browser': 4.2.2
-      '@smithy/util-body-length-node': 4.2.3
-      '@smithy/util-defaults-mode-browser': 4.3.49
-      '@smithy/util-defaults-mode-node': 4.2.54
-      '@smithy/util-endpoints': 3.4.2
-      '@smithy/util-middleware': 4.2.14
-      '@smithy/util-retry': 4.4.1
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/region-config-resolver@3.972.13':
-    dependencies:
-      '@aws-sdk/types': 3.973.8
-      '@smithy/config-resolver': 4.4.17
-      '@smithy/node-config-provider': 4.3.14
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@aws-sdk/signature-v4-multi-region@3.996.25':
-    dependencies:
-      '@aws-sdk/middleware-sdk-s3': 3.972.37
-      '@aws-sdk/types': 3.973.8
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/signature-v4': 5.3.14
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@aws-sdk/token-providers@3.1041.0':
-    dependencies:
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/nested-clients': 3.997.6
-      '@aws-sdk/types': 3.973.8
-      '@smithy/property-provider': 4.2.14
-      '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/token-providers@3.1045.0':
-    dependencies:
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/nested-clients': 3.997.6
-      '@aws-sdk/types': 3.973.8
-      '@smithy/property-provider': 4.2.14
-      '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/types@3.973.8':
-    dependencies:
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@aws-sdk/util-arn-parser@3.972.3':
-    dependencies:
-      tslib: 2.8.1
-
-  '@aws-sdk/util-endpoints@3.996.8':
-    dependencies:
-      '@aws-sdk/types': 3.973.8
-      '@smithy/types': 4.14.1
-      '@smithy/url-parser': 4.2.14
-      '@smithy/util-endpoints': 3.4.2
-      tslib: 2.8.1
-
-  '@aws-sdk/util-format-url@3.972.10':
-    dependencies:
-      '@aws-sdk/types': 3.973.8
-      '@smithy/querystring-builder': 4.2.14
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@aws-sdk/util-locate-window@3.965.5':
-    dependencies:
-      tslib: 2.8.1
-
-  '@aws-sdk/util-user-agent-browser@3.972.10':
-    dependencies:
-      '@aws-sdk/types': 3.973.8
-      '@smithy/types': 4.14.1
-      bowser: 2.14.1
-      tslib: 2.8.1
-
-  '@aws-sdk/util-user-agent-node@3.973.24':
-    dependencies:
-      '@aws-sdk/middleware-user-agent': 3.972.38
-      '@aws-sdk/types': 3.973.8
-      '@smithy/node-config-provider': 4.3.14
-      '@smithy/types': 4.14.1
-      '@smithy/util-config-provider': 4.2.2
-      tslib: 2.8.1
-
-  '@aws-sdk/xml-builder@3.972.22':
-    dependencies:
-      '@nodable/entities': 2.1.0
-      '@smithy/types': 4.14.1
-      fast-xml-parser: 5.7.2
-      tslib: 2.8.1
-
-  '@aws/lambda-invoke-store@0.2.4': {}
 
   '@babel/runtime@7.29.2': {}
 
@@ -3113,81 +1978,10 @@ snapshots:
       fast-wrap-ansi: 0.2.0
       sisteransi: 1.0.5
 
-  '@earendil-works/pi-agent-core@0.75.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)':
+  '@earendil-works/pi-tui@0.78.0':
     dependencies:
-      '@earendil-works/pi-ai': 0.75.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
-      ignore: 7.0.5
-      typebox: 1.1.38
-      yaml: 2.9.0
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - aws-crt
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@earendil-works/pi-ai@0.75.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)':
-    dependencies:
-      '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
-      '@aws-sdk/client-bedrock-runtime': 3.1045.0
-      '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
-      '@mistralai/mistralai': 2.2.1
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
-      openai: 6.26.0(ws@8.20.1)(zod@4.4.3)
-      partial-json: 0.1.7
-      typebox: 1.1.38
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - aws-crt
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@earendil-works/pi-coding-agent@0.75.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)':
-    dependencies:
-      '@earendil-works/pi-agent-core': 0.75.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
-      '@earendil-works/pi-ai': 0.75.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
-      '@earendil-works/pi-tui': 0.75.1
-      '@silvia-odwyer/photon-node': 0.3.4
-      chalk: 5.6.2
-      diff: 8.0.4
-      glob: 13.0.6
-      highlight.js: 10.7.3
-      hosted-git-info: 9.0.2
-      ignore: 7.0.5
-      jiti: 2.7.0
-      minimatch: 10.2.5
-      proper-lockfile: 4.1.2
-      typebox: 1.1.38
-      undici: 8.3.0
-      yaml: 2.9.0
-    optionalDependencies:
-      '@mariozechner/clipboard': 0.3.6
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - aws-crt
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@earendil-works/pi-tui@0.75.1':
-    dependencies:
-      get-east-asian-width: 1.5.0
+      get-east-asian-width: 1.6.0
       marked: 15.0.12
-    optionalDependencies:
-      koffi: 2.16.1
-
-  '@emnapi/runtime@1.10.0':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
 
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
@@ -3345,12 +2139,12 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
-  '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
+  '@google/genai@2.7.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
     dependencies:
       google-auth-library: 10.6.2
       p-retry: 4.6.2
       protobufjs: 7.5.5
-      ws: 8.20.1
+      ws: 8.21.0
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
     transitivePeerDependencies:
@@ -3358,32 +2152,19 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@google/genai@2.3.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
-    dependencies:
-      google-auth-library: 10.6.2
-      p-retry: 4.6.2
-      protobufjs: 7.5.5
-      ws: 8.20.1
-    optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  '@grammyjs/runner@2.0.3(grammy@1.42.0)':
+  '@grammyjs/runner@2.0.3(grammy@1.43.0)':
     dependencies:
       abort-controller: 3.0.0
-      grammy: 1.42.0
+      grammy: 1.43.0
 
-  '@grammyjs/transformer-throttler@1.2.1(grammy@1.42.0)':
+  '@grammyjs/transformer-throttler@1.2.1(grammy@1.43.0)':
     dependencies:
       bottleneck: 2.19.5
-      grammy: 1.42.0
+      grammy: 1.43.0
 
-  '@grammyjs/types@3.26.0': {}
+  '@grammyjs/types@3.27.3': {}
 
-  '@homebridge/ciao@1.3.8':
+  '@homebridge/ciao@1.3.9':
     dependencies:
       debug: 4.4.3
       fast-deep-equal: 3.1.3
@@ -3395,103 +2176,6 @@ snapshots:
   '@hono/node-server@1.19.14(hono@4.12.14)':
     dependencies:
       hono: 4.12.14
-
-  '@img/colour@1.1.0':
-    optional: true
-
-  '@img/sharp-darwin-arm64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.2.4
-    optional: true
-
-  '@img/sharp-darwin-x64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.2.4
-    optional: true
-
-  '@img/sharp-libvips-darwin-arm64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-darwin-x64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-arm64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-arm@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-ppc64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-riscv64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-s390x@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-x64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
-    optional: true
-
-  '@img/sharp-linux-arm64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-arm@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-ppc64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-ppc64': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-riscv64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-riscv64': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-s390x@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-x64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.2.4
-    optional: true
-
-  '@img/sharp-linuxmusl-arm64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
-    optional: true
-
-  '@img/sharp-linuxmusl-x64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
-    optional: true
-
-  '@img/sharp-wasm32@0.34.5':
-    dependencies:
-      '@emnapi/runtime': 1.10.0
-    optional: true
-
-  '@img/sharp-win32-arm64@0.34.5':
-    optional: true
-
-  '@img/sharp-win32-ia32@0.34.5':
-    optional: true
-
-  '@img/sharp-win32-x64@0.34.5':
-    optional: true
 
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
@@ -3526,53 +2210,9 @@ snapshots:
       '@lydell/node-pty-win32-arm64': 1.2.0-beta.12
       '@lydell/node-pty-win32-x64': 1.2.0-beta.12
 
-  '@mariozechner/clipboard-darwin-arm64@0.3.6':
-    optional: true
-
-  '@mariozechner/clipboard-darwin-universal@0.3.6':
-    optional: true
-
-  '@mariozechner/clipboard-darwin-x64@0.3.6':
-    optional: true
-
-  '@mariozechner/clipboard-linux-arm64-gnu@0.3.6':
-    optional: true
-
-  '@mariozechner/clipboard-linux-arm64-musl@0.3.6':
-    optional: true
-
-  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.6':
-    optional: true
-
-  '@mariozechner/clipboard-linux-x64-gnu@0.3.6':
-    optional: true
-
-  '@mariozechner/clipboard-linux-x64-musl@0.3.6':
-    optional: true
-
-  '@mariozechner/clipboard-win32-arm64-msvc@0.3.6':
-    optional: true
-
-  '@mariozechner/clipboard-win32-x64-msvc@0.3.6':
-    optional: true
-
-  '@mariozechner/clipboard@0.3.6':
-    optionalDependencies:
-      '@mariozechner/clipboard-darwin-arm64': 0.3.6
-      '@mariozechner/clipboard-darwin-universal': 0.3.6
-      '@mariozechner/clipboard-darwin-x64': 0.3.6
-      '@mariozechner/clipboard-linux-arm64-gnu': 0.3.6
-      '@mariozechner/clipboard-linux-arm64-musl': 0.3.6
-      '@mariozechner/clipboard-linux-riscv64-gnu': 0.3.6
-      '@mariozechner/clipboard-linux-x64-gnu': 0.3.6
-      '@mariozechner/clipboard-linux-x64-musl': 0.3.6
-      '@mariozechner/clipboard-win32-arm64-msvc': 0.3.6
-      '@mariozechner/clipboard-win32-x64-msvc': 0.3.6
-    optional: true
-
-  '@mistralai/mistralai@2.2.1':
+  '@mistralai/mistralai@2.2.5':
     dependencies:
-      ws: 8.20.1
+      ws: 8.21.0
       zod: 4.4.3
       zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
@@ -3603,57 +2243,7 @@ snapshots:
 
   '@mozilla/readability@0.6.0': {}
 
-  '@napi-rs/canvas-android-arm64@0.1.100':
-    optional: true
-
-  '@napi-rs/canvas-darwin-arm64@0.1.100':
-    optional: true
-
-  '@napi-rs/canvas-darwin-x64@0.1.100':
-    optional: true
-
-  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.100':
-    optional: true
-
-  '@napi-rs/canvas-linux-arm64-gnu@0.1.100':
-    optional: true
-
-  '@napi-rs/canvas-linux-arm64-musl@0.1.100':
-    optional: true
-
-  '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
-    optional: true
-
-  '@napi-rs/canvas-linux-x64-gnu@0.1.100':
-    optional: true
-
-  '@napi-rs/canvas-linux-x64-musl@0.1.100':
-    optional: true
-
-  '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
-    optional: true
-
-  '@napi-rs/canvas-win32-x64-msvc@0.1.100':
-    optional: true
-
-  '@napi-rs/canvas@0.1.100':
-    optionalDependencies:
-      '@napi-rs/canvas-android-arm64': 0.1.100
-      '@napi-rs/canvas-darwin-arm64': 0.1.100
-      '@napi-rs/canvas-darwin-x64': 0.1.100
-      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.100
-      '@napi-rs/canvas-linux-arm64-gnu': 0.1.100
-      '@napi-rs/canvas-linux-arm64-musl': 0.1.100
-      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.100
-      '@napi-rs/canvas-linux-x64-gnu': 0.1.100
-      '@napi-rs/canvas-linux-x64-musl': 0.1.100
-      '@napi-rs/canvas-win32-arm64-msvc': 0.1.100
-      '@napi-rs/canvas-win32-x64-msvc': 0.1.100
-    optional: true
-
-  '@nodable/entities@2.1.0': {}
-
-  '@openclaw/fs-safe@0.2.4':
+  '@openclaw/fs-safe@0.3.0':
     optionalDependencies:
       jszip: 3.10.1
       tar: 7.5.13
@@ -3762,281 +2352,7 @@ snapshots:
 
   '@silvia-odwyer/photon-node@0.3.4': {}
 
-  '@smithy/config-resolver@4.4.17':
-    dependencies:
-      '@smithy/node-config-provider': 4.3.14
-      '@smithy/types': 4.14.1
-      '@smithy/util-config-provider': 4.2.2
-      '@smithy/util-endpoints': 3.4.2
-      '@smithy/util-middleware': 4.2.14
-      tslib: 2.8.1
-
-  '@smithy/core@3.24.1':
-    dependencies:
-      '@aws-crypto/crc32': 5.2.0
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@smithy/credential-provider-imds@4.2.14':
-    dependencies:
-      '@smithy/node-config-provider': 4.3.14
-      '@smithy/property-provider': 4.2.14
-      '@smithy/types': 4.14.1
-      '@smithy/url-parser': 4.2.14
-      tslib: 2.8.1
-
-  '@smithy/eventstream-codec@4.2.14':
-    dependencies:
-      '@aws-crypto/crc32': 5.2.0
-      '@smithy/types': 4.14.1
-      '@smithy/util-hex-encoding': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/eventstream-serde-browser@4.2.14':
-    dependencies:
-      '@smithy/eventstream-serde-universal': 4.2.14
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@smithy/eventstream-serde-config-resolver@4.3.14':
-    dependencies:
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@smithy/eventstream-serde-node@4.2.14':
-    dependencies:
-      '@smithy/eventstream-serde-universal': 4.2.14
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@smithy/eventstream-serde-universal@4.2.14':
-    dependencies:
-      '@smithy/eventstream-codec': 4.2.14
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@smithy/fetch-http-handler@5.3.17':
-    dependencies:
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/querystring-builder': 4.2.14
-      '@smithy/types': 4.14.1
-      '@smithy/util-base64': 4.3.2
-      tslib: 2.8.1
-
-  '@smithy/hash-node@4.2.14':
-    dependencies:
-      '@smithy/types': 4.14.1
-      '@smithy/util-buffer-from': 4.2.2
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/invalid-dependency@4.2.14':
-    dependencies:
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@smithy/is-array-buffer@2.2.0':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/is-array-buffer@4.2.2':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/middleware-content-length@4.2.14':
-    dependencies:
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@smithy/middleware-endpoint@4.4.32':
-    dependencies:
-      '@smithy/core': 3.24.1
-      '@smithy/middleware-serde': 4.2.20
-      '@smithy/node-config-provider': 4.3.14
-      '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
-      '@smithy/url-parser': 4.2.14
-      '@smithy/util-middleware': 4.2.14
-      tslib: 2.8.1
-
-  '@smithy/middleware-retry@4.6.1':
-    dependencies:
-      '@smithy/core': 3.24.1
-      tslib: 2.8.1
-
-  '@smithy/middleware-serde@4.2.20':
-    dependencies:
-      '@smithy/core': 3.24.1
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@smithy/middleware-stack@4.2.14':
-    dependencies:
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@smithy/node-config-provider@4.3.14':
-    dependencies:
-      '@smithy/property-provider': 4.2.14
-      '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@smithy/node-http-handler@4.6.1':
-    dependencies:
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/querystring-builder': 4.2.14
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@smithy/property-provider@4.2.14':
-    dependencies:
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@smithy/protocol-http@5.3.14':
-    dependencies:
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@smithy/querystring-builder@4.2.14':
-    dependencies:
-      '@smithy/types': 4.14.1
-      '@smithy/util-uri-escape': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/querystring-parser@4.2.14':
-    dependencies:
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@smithy/shared-ini-file-loader@4.4.9':
-    dependencies:
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@smithy/signature-v4@5.3.14':
-    dependencies:
-      '@smithy/is-array-buffer': 4.2.2
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/types': 4.14.1
-      '@smithy/util-hex-encoding': 4.2.2
-      '@smithy/util-middleware': 4.2.14
-      '@smithy/util-uri-escape': 4.2.2
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/smithy-client@4.12.13':
-    dependencies:
-      '@smithy/core': 3.24.1
-      '@smithy/middleware-endpoint': 4.4.32
-      '@smithy/middleware-stack': 4.2.14
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/types': 4.14.1
-      '@smithy/util-stream': 4.5.25
-      tslib: 2.8.1
-
-  '@smithy/types@4.14.1':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/url-parser@4.2.14':
-    dependencies:
-      '@smithy/querystring-parser': 4.2.14
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@smithy/util-base64@4.3.2':
-    dependencies:
-      '@smithy/util-buffer-from': 4.2.2
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/util-body-length-browser@4.2.2':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/util-body-length-node@4.2.3':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/util-buffer-from@2.2.0':
-    dependencies:
-      '@smithy/is-array-buffer': 2.2.0
-      tslib: 2.8.1
-
-  '@smithy/util-buffer-from@4.2.2':
-    dependencies:
-      '@smithy/is-array-buffer': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/util-config-provider@4.2.2':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/util-defaults-mode-browser@4.3.49':
-    dependencies:
-      '@smithy/property-provider': 4.2.14
-      '@smithy/smithy-client': 4.12.13
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@smithy/util-defaults-mode-node@4.2.54':
-    dependencies:
-      '@smithy/config-resolver': 4.4.17
-      '@smithy/credential-provider-imds': 4.2.14
-      '@smithy/node-config-provider': 4.3.14
-      '@smithy/property-provider': 4.2.14
-      '@smithy/smithy-client': 4.12.13
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@smithy/util-endpoints@3.4.2':
-    dependencies:
-      '@smithy/node-config-provider': 4.3.14
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@smithy/util-hex-encoding@4.2.2':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/util-middleware@4.2.14':
-    dependencies:
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@smithy/util-retry@4.4.1':
-    dependencies:
-      '@smithy/core': 3.24.1
-      tslib: 2.8.1
-
-  '@smithy/util-stream@4.5.25':
-    dependencies:
-      '@smithy/fetch-http-handler': 5.3.17
-      '@smithy/node-http-handler': 4.6.1
-      '@smithy/types': 4.14.1
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-buffer-from': 4.2.2
-      '@smithy/util-hex-encoding': 4.2.2
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/util-uri-escape@4.2.2':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/util-utf8@2.3.0':
-    dependencies:
-      '@smithy/util-buffer-from': 2.2.0
-      tslib: 2.8.1
-
-  '@smithy/util-utf8@4.2.2':
-    dependencies:
-      '@smithy/util-buffer-from': 4.2.2
-      tslib: 2.8.1
+  '@stablelib/base64@1.0.1': {}
 
   '@tokenizer/inflate@0.4.1':
     dependencies:
@@ -4132,8 +2448,6 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
-  argparse@2.0.1: {}
-
   asn1.js@5.4.1:
     dependencies:
       bn.js: 4.12.3
@@ -4168,8 +2482,6 @@ snapshots:
   boolbase@1.0.0: {}
 
   bottleneck@2.19.5: {}
-
-  bowser@2.14.1: {}
 
   brace-expansion@5.0.5:
     dependencies:
@@ -4212,6 +2524,8 @@ snapshots:
       readdirp: 5.0.0
 
   chownr@3.0.0: {}
+
+  clawpdf@0.3.0: {}
 
   cliui@6.0.0:
     dependencies:
@@ -4280,10 +2594,7 @@ snapshots:
 
   depd@2.0.0: {}
 
-  detect-libc@2.1.2:
-    optional: true
-
-  diff@8.0.4: {}
+  diff@9.0.0: {}
 
   dijkstrajs@1.0.3: {}
 
@@ -4457,6 +2768,8 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
+  fast-sha256@1.3.0: {}
+
   fast-string-truncated-width@3.0.3: {}
 
   fast-string-width@3.0.2:
@@ -4468,17 +2781,6 @@ snapshots:
   fast-wrap-ansi@0.2.0:
     dependencies:
       fast-string-width: 3.0.2
-
-  fast-xml-builder@1.1.5:
-    dependencies:
-      path-expression-matcher: 1.5.0
-
-  fast-xml-parser@5.7.2:
-    dependencies:
-      '@nodable/entities': 2.1.0
-      fast-xml-builder: 1.1.5
-      path-expression-matcher: 1.5.0
-      strnum: 2.2.3
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -4545,7 +2847,7 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
-  get-east-asian-width@1.5.0: {}
+  get-east-asian-width@1.6.0: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -4592,9 +2894,9 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  grammy@1.42.0:
+  grammy@1.43.0:
     dependencies:
-      '@grammyjs/types': 3.26.0
+      '@grammyjs/types': 3.27.3
       abort-controller: 3.0.0
       debug: 4.4.3
       node-fetch: 2.7.0
@@ -4608,11 +2910,11 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  highlight.js@10.7.3: {}
+  highlight.js@11.11.1: {}
 
   hono@4.12.14: {}
 
-  hosted-git-info@9.0.2:
+  hosted-git-info@10.1.1:
     dependencies:
       lru-cache: 11.3.5
 
@@ -4632,13 +2934,6 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
-
-  http-proxy-agent@7.0.2:
-    dependencies:
-      agent-base: 7.1.4
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   http_ece@1.2.0: {}
 
@@ -4664,8 +2959,6 @@ snapshots:
   ip-address@10.1.0: {}
 
   ipaddr.js@1.9.1: {}
-
-  ipaddr.js@2.4.0: {}
 
   is-fullwidth-code-point@3.0.0: {}
 
@@ -4714,10 +3007,7 @@ snapshots:
       jwa: 2.0.1
       safe-buffer: 5.2.1
 
-  koffi@2.16.1:
-    optional: true
-
-  kysely@0.29.1: {}
+  kysely@0.29.2: {}
 
   lie@3.3.0:
     dependencies:
@@ -4730,10 +3020,6 @@ snapshots:
       html-escaper: 3.0.3
       htmlparser2: 10.1.0
       uhyphen: 0.2.0
-
-  linkify-it@5.0.0:
-    dependencies:
-      uc.micro: 2.1.0
 
   locate-path@5.0.0:
     dependencies:
@@ -4749,20 +3035,9 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  markdown-it@14.1.1:
-    dependencies:
-      argparse: 2.0.1
-      entities: 4.5.0
-      linkify-it: 5.0.0
-      mdurl: 2.0.0
-      punycode.js: 2.3.1
-      uc.micro: 2.1.0
-
   marked@15.0.12: {}
 
   math-intrinsics@1.1.0: {}
-
-  mdurl@2.0.0: {}
 
   media-typer@1.1.0: {}
 
@@ -4801,7 +3076,7 @@ snapshots:
   node-edge-tts@1.2.10:
     dependencies:
       https-proxy-agent: 7.0.6
-      ws: 8.20.1
+      ws: 8.21.0
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
@@ -4836,74 +3111,72 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
-  openai@6.26.0(ws@8.20.1)(zod@4.4.3):
+  openai@6.39.1(ws@8.21.0)(zod@4.4.3):
     optionalDependencies:
-      ws: 8.20.1
+      ws: 8.21.0
       zod: 4.4.3
 
-  openai@6.38.0(ws@8.20.1)(zod@4.4.3):
-    optionalDependencies:
-      ws: 8.20.1
-      zod: 4.4.3
-
-  openclaw@2026.5.19:
+  openclaw@2026.5.31-beta.4:
     dependencies:
-      '@agentclientprotocol/sdk': 0.21.1(zod@4.4.3)
+      '@agentclientprotocol/sdk': 0.22.1(zod@4.4.3)
+      '@anthropic-ai/sdk': 0.100.1(zod@4.4.3)
       '@clack/core': 1.3.1
       '@clack/prompts': 1.4.0
-      '@earendil-works/pi-agent-core': 0.75.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
-      '@earendil-works/pi-ai': 0.75.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
-      '@earendil-works/pi-coding-agent': 0.75.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
-      '@earendil-works/pi-tui': 0.75.1
-      '@google/genai': 2.3.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
-      '@grammyjs/runner': 2.0.3(grammy@1.42.0)
-      '@grammyjs/transformer-throttler': 1.2.1(grammy@1.42.0)
-      '@homebridge/ciao': 1.3.8
+      '@earendil-works/pi-tui': 0.78.0
+      '@google/genai': 2.7.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
+      '@grammyjs/runner': 2.0.3(grammy@1.43.0)
+      '@grammyjs/transformer-throttler': 1.2.1(grammy@1.43.0)
+      '@homebridge/ciao': 1.3.9
       '@lydell/node-pty': 1.2.0-beta.12
+      '@mistralai/mistralai': 2.2.5
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
       '@mozilla/readability': 0.6.0
-      '@openclaw/fs-safe': 0.2.4
+      '@openclaw/fs-safe': 0.3.0
       '@openclaw/proxyline': 0.3.3(undici@8.3.0)
-      ajv: 8.20.0
       chalk: 5.6.2
       chokidar: 5.0.0
+      clawpdf: 0.3.0
       commander: 14.0.3
       croner: 10.0.1
+      cross-spawn: 7.0.6
+      diff: 9.0.0
       dotenv: 17.4.2
       express: 5.2.1
       file-type: 22.0.1
-      grammy: 1.42.0
-      ipaddr.js: 2.4.0
+      glob: 13.0.6
+      grammy: 1.43.0
+      highlight.js: 11.11.1
+      hosted-git-info: 10.1.1
+      ignore: 7.0.5
       jiti: 2.7.0
       json5: 2.2.3
       jszip: 3.10.1
-      kysely: 0.29.1
+      kysely: 0.29.2
       linkedom: 0.18.12
-      markdown-it: 14.1.1
+      minimatch: 10.2.5
       node-edge-tts: 1.2.10
-      openai: 6.38.0(ws@8.20.1)(zod@4.4.3)
-      pdfjs-dist: 5.7.284
+      openai: 6.39.1(ws@8.21.0)(zod@4.4.3)
+      partial-json: 0.1.7
       playwright-core: 1.60.0
+      proper-lockfile: 4.1.2
       qrcode: 1.5.4
-      quickjs-wasi: 2.2.0
+      quickjs-wasi: 3.0.0
+      rastermill: 0.3.1
       tar: 7.5.15
-      tokenjuice: 0.7.1
       tree-sitter-bash: 0.25.1
       tslog: 4.10.2
-      typebox: 1.1.38
+      typebox: 1.1.39
       typescript: 6.0.3
       undici: 8.3.0
       web-push: 3.6.7
-      web-tree-sitter: 0.26.8
-      ws: 8.20.1
+      web-tree-sitter: 0.26.9
+      ws: 8.21.0
       yaml: 2.9.0
       zod: 4.4.3
     optionalDependencies:
-      sharp: 0.34.5
       sqlite-vec: 0.1.9
     transitivePeerDependencies:
       - '@cfworker/json-schema'
-      - aws-crt
       - bufferutil
       - canvas
       - encoding
@@ -4934,8 +3207,6 @@ snapshots:
 
   path-exists@4.0.0: {}
 
-  path-expression-matcher@1.5.0: {}
-
   path-key@3.1.1: {}
 
   path-scurry@2.0.2:
@@ -4948,10 +3219,6 @@ snapshots:
   pathe@2.0.3: {}
 
   pathval@2.0.1: {}
-
-  pdfjs-dist@5.7.284:
-    optionalDependencies:
-      '@napi-rs/canvas': 0.1.100
 
   picocolors@1.1.1: {}
 
@@ -4997,8 +3264,6 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
-  punycode.js@2.3.1: {}
-
   qrcode@1.5.4:
     dependencies:
       dijkstrajs: 1.0.3
@@ -5009,9 +3274,13 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
-  quickjs-wasi@2.2.0: {}
+  quickjs-wasi@3.0.0: {}
 
   range-parser@1.2.1: {}
+
+  rastermill@0.3.1:
+    dependencies:
+      '@silvia-odwyer/photon-node': 0.3.4
 
   raw-body@3.0.2:
     dependencies:
@@ -5091,9 +3360,6 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  semver@7.7.4:
-    optional: true
-
   send@1.2.1:
     dependencies:
       debug: 4.4.3
@@ -5124,38 +3390,6 @@ snapshots:
   setimmediate@1.0.5: {}
 
   setprototypeof@1.2.0: {}
-
-  sharp@0.34.5:
-    dependencies:
-      '@img/colour': 1.1.0
-      detect-libc: 2.1.2
-      semver: 7.7.4
-    optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.34.5
-      '@img/sharp-darwin-x64': 0.34.5
-      '@img/sharp-libvips-darwin-arm64': 1.2.4
-      '@img/sharp-libvips-darwin-x64': 1.2.4
-      '@img/sharp-libvips-linux-arm': 1.2.4
-      '@img/sharp-libvips-linux-arm64': 1.2.4
-      '@img/sharp-libvips-linux-ppc64': 1.2.4
-      '@img/sharp-libvips-linux-riscv64': 1.2.4
-      '@img/sharp-libvips-linux-s390x': 1.2.4
-      '@img/sharp-libvips-linux-x64': 1.2.4
-      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
-      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
-      '@img/sharp-linux-arm': 0.34.5
-      '@img/sharp-linux-arm64': 0.34.5
-      '@img/sharp-linux-ppc64': 0.34.5
-      '@img/sharp-linux-riscv64': 0.34.5
-      '@img/sharp-linux-s390x': 0.34.5
-      '@img/sharp-linux-x64': 0.34.5
-      '@img/sharp-linuxmusl-arm64': 0.34.5
-      '@img/sharp-linuxmusl-x64': 0.34.5
-      '@img/sharp-wasm32': 0.34.5
-      '@img/sharp-win32-arm64': 0.34.5
-      '@img/sharp-win32-ia32': 0.34.5
-      '@img/sharp-win32-x64': 0.34.5
-    optional: true
 
   shebang-command@2.0.0:
     dependencies:
@@ -5232,6 +3466,11 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   statuses@2.0.2: {}
 
   std-env@3.10.0: {}
@@ -5253,8 +3492,6 @@ snapshots:
   strip-literal@3.1.0:
     dependencies:
       js-tokens: 9.0.1
-
-  strnum@2.2.3: {}
 
   strtok3@10.3.5:
     dependencies:
@@ -5300,8 +3537,6 @@ snapshots:
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
 
-  tokenjuice@0.7.1: {}
-
   tr46@0.0.3: {}
 
   tree-sitter-bash@0.25.1:
@@ -5330,11 +3565,11 @@ snapshots:
 
   typebox@1.1.38: {}
 
+  typebox@1.1.39: {}
+
   typescript@5.9.3: {}
 
   typescript@6.0.3: {}
-
-  uc.micro@2.1.0: {}
 
   uhyphen@0.2.0: {}
 
@@ -5439,7 +3674,7 @@ snapshots:
 
   web-streams-polyfill@3.3.3: {}
 
-  web-tree-sitter@0.26.8: {}
+  web-tree-sitter@0.26.9: {}
 
   webidl-conversions@3.0.1: {}
 
@@ -5473,7 +3708,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.20.1: {}
+  ws@8.21.0: {}
 
   y18n@4.0.3: {}
 

--- a/scripts/check-host-version-parity.mjs
+++ b/scripts/check-host-version-parity.mjs
@@ -4,10 +4,11 @@
  *
  * Closes Wave-6 W6-1 (silent doc-vs-reality drift). Asserts that
  * `openclaw.plugin.json` `minHostVersion` is byte-identical to the
- * literal `openclaw` version string declared in `package.json`'s
- * `devDependencies` (the SDK we typecheck + test against). If a
- * future host bump updates one without the other, this script exits
- * non-zero and CI fails before the drift can ship.
+ * `package.json#openclaw.target.version` host target. When that target
+ * is available on npm, the `devDependencies.openclaw` SDK pin must match.
+ * When the target is a GitHub-only prerelease, the SDK fallback must be
+ * declared explicitly so CI can distinguish a deliberate fallback from
+ * silent doc-vs-reality drift.
  *
  * Why this matters
  * ----------------
@@ -24,11 +25,10 @@
  * Scope (intentional)
  * -------------------
  *
- * Exact string match. Both fields are pinned (not range-spec), so
- * an exact compare is the correct semantics here. If the project
- * ever moves to a range-spec in `devDependencies`, this script must
- * be updated to reflect the new invariant (e.g. "minHostVersion must
- * be satisfied by devDependencies.openclaw range").
+ * Exact string match for manifest/runtime/install/peer target fields.
+ * The devDependency only gets an exact-match exemption when
+ * `openclaw.target.npmPackageAvailable === false` and
+ * `openclaw.sdkValidation.npmFallbackVersion` equals the devDependency.
  *
  * Exit codes
  * ----------
@@ -68,6 +68,8 @@ const pkg = loadJson("package.json");
 const minHostVersion = manifest.minHostVersion;
 const devDepOpenclaw = pkg.devDependencies?.openclaw;
 const pkgOpenClaw = pkg.openclaw;
+const target = pkgOpenClaw?.target;
+const sdkValidation = pkgOpenClaw?.sdkValidation;
 
 if (typeof minHostVersion !== "string" || minHostVersion.length === 0) {
   console.error(
@@ -82,20 +84,59 @@ if (typeof devDepOpenclaw !== "string" || devDepOpenclaw.length === 0) {
   process.exit(1);
 }
 
-if (minHostVersion !== devDepOpenclaw) {
+const targetVersion = target?.version;
+if (typeof targetVersion !== "string" || targetVersion.length === 0) {
   console.error(
-    `[host-version-parity] DRIFT: openclaw.plugin.json minHostVersion="${minHostVersion}" does NOT match package.json devDependencies.openclaw="${devDepOpenclaw}".`,
-  );
-  console.error(
-    "  These MUST be byte-identical. The manifest declares the gateway minimum; the devDep is the SDK we typecheck + test against. A mismatch ships a plugin that promises a version the implementation never compiled or tested on.",
-  );
-  console.error(
-    "  Fix: bump the lagging field to match, re-run `pnpm install`, re-run `pnpm parity-harness`.",
+    "[host-version-parity] package.json missing openclaw.target.version.",
   );
   process.exit(2);
 }
 
-const expectedInstallFloor = `>=${minHostVersion}`;
+if (minHostVersion !== targetVersion) {
+  console.error(
+    `[host-version-parity] DRIFT: openclaw.plugin.json minHostVersion="${minHostVersion}" does NOT match package.json openclaw.target.version="${targetVersion}".`,
+  );
+  console.error(
+    "  These MUST be byte-identical. The manifest declares the gateway minimum; the target records the release this package is claiming compatibility with.",
+  );
+  console.error(
+    "  Fix: bump the lagging field to match, re-run `pnpm parity-harness`.",
+  );
+  process.exit(2);
+}
+
+const npmPackageAvailable = target?.npmPackageAvailable !== false;
+if (npmPackageAvailable && minHostVersion !== devDepOpenclaw) {
+  console.error(
+    `[host-version-parity] DRIFT: target ${minHostVersion} is marked npm-available but devDependencies.openclaw="${devDepOpenclaw}".`,
+  );
+  console.error(
+    "  Fix: set devDependencies.openclaw to the exact target version, re-run `pnpm install`, re-run `pnpm parity-harness`.",
+  );
+  process.exit(2);
+}
+if (!npmPackageAvailable) {
+  if (target.source !== "github-release" || typeof target.tag !== "string" || !target.tag) {
+    console.error(
+      "[host-version-parity] GitHub-only OpenClaw target must declare openclaw.target.source=\"github-release\" and openclaw.target.tag.",
+    );
+    process.exit(2);
+  }
+  if (sdkValidation?.npmFallbackVersion !== devDepOpenclaw) {
+    console.error(
+      `[host-version-parity] GitHub-only target must declare openclaw.sdkValidation.npmFallbackVersion="${devDepOpenclaw}"; got ${JSON.stringify(sdkValidation?.npmFallbackVersion)}.`,
+    );
+    process.exit(2);
+  }
+  if (sdkValidation?.githubReleaseTag !== target.tag) {
+    console.error(
+      `[host-version-parity] openclaw.sdkValidation.githubReleaseTag must match openclaw.target.tag (${target.tag}).`,
+    );
+    process.exit(2);
+  }
+}
+
+const expectedInstallFloor = `>=${targetVersion}`;
 if (pkgOpenClaw?.install?.minHostVersion !== expectedInstallFloor) {
   console.error(
     `[host-version-parity] package.json openclaw.install.minHostVersion="${pkgOpenClaw?.install?.minHostVersion}" must be "${expectedInstallFloor}" for OpenClaw's canonical package install gate.`,
@@ -137,14 +178,14 @@ if (!(manifest.contracts?.sessionAttachments ?? []).includes("active-session")) 
 const peerOpenclaw = pkg.peerDependencies?.openclaw;
 if (typeof peerOpenclaw === "string" && peerOpenclaw.startsWith(">=")) {
   const peerPin = peerOpenclaw.slice(2).trim();
-  if (peerPin !== minHostVersion) {
+  if (peerPin !== targetVersion) {
     console.error(
-      `[host-version-parity] peerDependencies.openclaw="${peerOpenclaw}" pins ">=${peerPin}" but minHostVersion="${minHostVersion}". Convention: peer-dep pin = manifest minHostVersion exactly.`,
+      `[host-version-parity] peerDependencies.openclaw="${peerOpenclaw}" pins ">=${peerPin}" but targetVersion="${targetVersion}". Convention: peer-dep pin = manifest target exactly.`,
     );
     process.exit(2);
   }
 }
 
 console.log(
-  `[host-version-parity] OK — manifest minHostVersion=${minHostVersion} == devDependencies.openclaw=${devDepOpenclaw}${peerOpenclaw ? ` (peer=${peerOpenclaw})` : ""}; package install floor=${expectedInstallFloor}; contracts.tools=${requiredTools.join(",")}; sessionAttachments=active-session`,
+  `[host-version-parity] OK — manifest minHostVersion=${minHostVersion} == target=${targetVersion}; devDependencies.openclaw=${devDepOpenclaw}${npmPackageAvailable ? "" : " (declared SDK fallback)"}${peerOpenclaw ? ` (peer=${peerOpenclaw})` : ""}; package install floor=${expectedInstallFloor}; contracts.tools=${requiredTools.join(",")}; sessionAttachments=active-session`,
 );

--- a/scripts/check-host-version-parity.mjs
+++ b/scripts/check-host-version-parity.mjs
@@ -67,6 +67,7 @@ const pkg = loadJson("package.json");
 
 const minHostVersion = manifest.minHostVersion;
 const devDepOpenclaw = pkg.devDependencies?.openclaw;
+const pkgOpenClaw = pkg.openclaw;
 
 if (typeof minHostVersion !== "string" || minHostVersion.length === 0) {
   console.error(
@@ -94,6 +95,41 @@ if (minHostVersion !== devDepOpenclaw) {
   process.exit(2);
 }
 
+const expectedInstallFloor = `>=${minHostVersion}`;
+if (pkgOpenClaw?.install?.minHostVersion !== expectedInstallFloor) {
+  console.error(
+    `[host-version-parity] package.json openclaw.install.minHostVersion="${pkgOpenClaw?.install?.minHostVersion}" must be "${expectedInstallFloor}" for OpenClaw's canonical package install gate.`,
+  );
+  process.exit(2);
+}
+
+if (pkgOpenClaw?.build?.command !== "pnpm build") {
+  console.error(
+    `[host-version-parity] package.json openclaw.build.command must be "pnpm build"; got ${JSON.stringify(pkgOpenClaw?.build?.command)}.`,
+  );
+  process.exit(2);
+}
+
+const requiredTools = [
+  "enter_plan_mode",
+  "exit_plan_mode",
+  "ask_user_question",
+];
+const declaredTools = new Set(manifest.contracts?.tools ?? []);
+const missingTools = requiredTools.filter((tool) => !declaredTools.has(tool));
+if (missingTools.length > 0) {
+  console.error(
+    `[host-version-parity] openclaw.plugin.json contracts.tools missing: ${missingTools.join(", ")}.`,
+  );
+  process.exit(2);
+}
+if (!(manifest.contracts?.sessionAttachments ?? []).includes("active-session")) {
+  console.error(
+    '[host-version-parity] openclaw.plugin.json contracts.sessionAttachments must include "active-session".',
+  );
+  process.exit(2);
+}
+
 // Optional: also sanity-check peerDependencies.openclaw (range-spec
 // allowed; the invariant here is "the range INCLUDES minHostVersion").
 // We do a conservative startsWith on a `>=` prefix to keep this script
@@ -110,5 +146,5 @@ if (typeof peerOpenclaw === "string" && peerOpenclaw.startsWith(">=")) {
 }
 
 console.log(
-  `[host-version-parity] OK — minHostVersion=${minHostVersion} == devDependencies.openclaw=${devDepOpenclaw}${peerOpenclaw ? ` (peer=${peerOpenclaw})` : ""}`,
+  `[host-version-parity] OK — manifest minHostVersion=${minHostVersion} == devDependencies.openclaw=${devDepOpenclaw}${peerOpenclaw ? ` (peer=${peerOpenclaw})` : ""}; package install floor=${expectedInstallFloor}; contracts.tools=${requiredTools.join(",")}; sessionAttachments=active-session`,
 );

--- a/scripts/runtime-registration-gate.mjs
+++ b/scripts/runtime-registration-gate.mjs
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+/**
+ * Smarter-Claw runtime registration gate.
+ *
+ * Loads the built plugin entry exactly the way OpenClaw's plugin loader does
+ * and verifies the release-blocking registration surface:
+ *   - every registered agent tool is declared in openclaw.plugin.json contracts.tools
+ *   - CLI registration includes explicit descriptors for plan-clear
+ *   - slash commands, session actions, Control UI, interactive handlers, and
+ *     session workflow calls are all registered with usable metadata
+ *
+ * This gate stays local/cheap for CI, while still failing on the class of
+ * manifest-vs-runtime drift that broke stable 26.5.18 plugin loads.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const repoRoot = resolve(new URL(".", import.meta.url).pathname, "..");
+
+function readJson(path) {
+  return JSON.parse(readFileSync(resolve(repoRoot, path), "utf8"));
+}
+
+function fail(message) {
+  console.error(`[runtime-registration-gate] FAIL: ${message}`);
+  process.exit(1);
+}
+
+const manifest = readJson("openclaw.plugin.json");
+const pkg = readJson("package.json");
+const requiredTools = ["enter_plan_mode", "exit_plan_mode", "ask_user_question"];
+const requiredActions = [
+  "plan.accept",
+  "plan.edit",
+  "plan.reject",
+  "plan.cancel",
+  "plan.answer",
+  "plan.auto.toggle",
+];
+const requiredCommands = ["plan", "plan-mode"];
+
+const declaredTools = new Set(manifest.contracts?.tools ?? []);
+for (const tool of requiredTools) {
+  if (!declaredTools.has(tool)) {
+    fail(`openclaw.plugin.json contracts.tools missing ${tool}`);
+  }
+}
+if (!(manifest.contracts?.sessionAttachments ?? []).includes("active-session")) {
+  fail('openclaw.plugin.json contracts.sessionAttachments missing "active-session"');
+}
+if (pkg.openclaw?.build?.command !== "pnpm build") {
+  fail("package.json openclaw.build.command must be pnpm build");
+}
+if (pkg.openclaw?.install?.minHostVersion !== `>=${manifest.minHostVersion}`) {
+  fail(
+    "package.json openclaw.install.minHostVersion must be the canonical semver floor " +
+      `>=${manifest.minHostVersion}`,
+  );
+}
+
+const captures = {
+  tools: new Map(),
+  cli: [],
+  commands: new Map(),
+  actions: new Map(),
+  interactiveHandlers: new Map(),
+  controlUis: [],
+  sessionExtensions: [],
+  hooks: new Map(),
+};
+
+const logger = {
+  info() {},
+  warn() {},
+  error() {},
+  debug() {},
+};
+
+const api = {
+  id: "smarter-claw",
+  name: "Smarter-Claw",
+  pluginConfig: {},
+  logger,
+  registerTool(tool, opts = {}) {
+    const name = opts.name ?? tool?.name;
+    if (!name) fail("registerTool called without name metadata");
+    captures.tools.set(name, tool);
+  },
+  registerCli(registrar, opts = {}) {
+    captures.cli.push({ registrar, opts });
+  },
+  registerCommand(command) {
+    if (!command?.name) fail("registerCommand called without command.name");
+    captures.commands.set(command.name, command);
+  },
+  registerInteractiveHandler(registration) {
+    if (!registration?.channel || !registration?.namespace || typeof registration.handler !== "function") {
+      fail("registerInteractiveHandler called without channel/namespace/handler");
+    }
+    captures.interactiveHandlers.set(`${registration.channel}:${registration.namespace}`, registration);
+  },
+  on(name, handler) {
+    const existing = captures.hooks.get(name) ?? [];
+    existing.push(handler);
+    captures.hooks.set(name, existing);
+  },
+  session: {
+    state: {
+      registerSessionExtension(extension) {
+        captures.sessionExtensions.push(extension);
+      },
+    },
+    workflow: {
+      enqueueNextTurnInjection: async (injection) => ({
+        enqueued: true,
+        id: "runtime-gate-injection",
+        sessionKey: injection.sessionKey,
+      }),
+      sendSessionAttachment: async () => ({
+        ok: false,
+        error: "runtime gate does not deliver messages",
+      }),
+    },
+    controls: {
+      registerSessionAction(action) {
+        if (!action?.id || typeof action.handler !== "function") {
+          fail("registerSessionAction called without id/handler");
+        }
+        captures.actions.set(action.id, action);
+      },
+      registerControlUiDescriptor(descriptor) {
+        captures.controlUis.push(descriptor);
+      },
+    },
+  },
+};
+
+const entryUrl = pathToFileURL(resolve(repoRoot, pkg.openclaw?.build?.entry ?? "dist/src/index.js"));
+const module = await import(entryUrl.href);
+const entry = module.default ?? module;
+if (typeof entry?.register !== "function") {
+  fail("built plugin entry has no register(api) function");
+}
+
+entry.register(api);
+
+for (const tool of requiredTools) {
+  if (!captures.tools.has(tool)) {
+    fail(`runtime did not register tool ${tool}`);
+  }
+}
+for (const registeredTool of captures.tools.keys()) {
+  if (!declaredTools.has(registeredTool)) {
+    fail(`runtime registered undeclared tool ${registeredTool}`);
+  }
+}
+for (const action of requiredActions) {
+  if (!captures.actions.has(action)) {
+    fail(`runtime did not register session action ${action}`);
+  }
+}
+for (const command of requiredCommands) {
+  if (!captures.commands.has(command)) {
+    fail(`runtime did not register slash command ${command}`);
+  }
+}
+if (!captures.sessionExtensions.some((entry) => entry.namespace === "plan-mode")) {
+  fail("runtime did not register plan-mode session extension");
+}
+if (!captures.controlUis.some((entry) => entry?.id === "smarter-claw.plan-mode.sidebar")) {
+  fail("runtime did not register plan-mode Control UI descriptor");
+}
+if (!captures.interactiveHandlers.has("telegram:smarter-claw-plan")) {
+  fail("runtime did not register Telegram interactive handler smarter-claw-plan");
+}
+const planClear = captures.cli.find((entry) =>
+  (entry.opts?.descriptors ?? []).some(
+    (descriptor) =>
+      descriptor?.name === "plan-clear" &&
+      descriptor.description &&
+      descriptor.hasSubcommands === false,
+  ),
+);
+if (!planClear) {
+  fail("runtime did not register plan-clear CLI with explicit descriptor metadata");
+}
+
+console.log(
+  `[runtime-registration-gate] OK — tools=${captures.tools.size}, actions=${captures.actions.size}, commands=${captures.commands.size}, interactiveHandlers=${captures.interactiveHandlers.size}`,
+);

--- a/scripts/runtime-registration-gate.mjs
+++ b/scripts/runtime-registration-gate.mjs
@@ -15,9 +15,9 @@
 
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
-const repoRoot = resolve(new URL(".", import.meta.url).pathname, "..");
+const repoRoot = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
 
 function readJson(path) {
   return JSON.parse(readFileSync(resolve(repoRoot, path), "utf8"));
@@ -144,7 +144,7 @@ if (typeof entry?.register !== "function") {
   fail("built plugin entry has no register(api) function");
 }
 
-entry.register(api);
+await entry.register(api);
 
 for (const tool of requiredTools) {
   if (!captures.tools.has(tool)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,7 @@ import { GrantLedger } from "./runtime/grant-ledger.js";
 import { enqueuePlanApprovedInjection } from "./runtime/injection-writer.js";
 import { createPlanModeNotifications } from "./runtime/plan-notifications.js";
 import { decidePlanTierModel } from "./runtime/plan-tier-model.js";
+import { createPlanModeTaskFlowVisibility } from "./runtime/task-flow-visibility.js";
 import { createAskUserQuestionTool } from "./tools/ask-user-question.js";
 import { createEnterPlanModeTool } from "./tools/enter-plan-mode.js";
 import { createExitPlanModeTool } from "./tools/exit-plan-mode.js";
@@ -249,6 +250,13 @@ export default definePluginEntry({
         "[smarter-claw] SMARTER_CLAW_USE_INMEMORY=1 — state NOT persisted across plugin reload. Dev/test only.",
       );
     }
+    const taskFlowVisibility = createPlanModeTaskFlowVisibility({
+      api,
+      logger: {
+        debug: (msg) => api.logger.debug?.(msg),
+        warn: (msg) => api.logger.warn(msg),
+      },
+    });
     // P-14: grant ledger — in-memory correlation of approvalId →
     // (approvalRunId, sessionKey). Populated on exit_plan_mode persist
     // path; queried in debug-log emit for correlation enrichment.
@@ -279,6 +287,8 @@ export default definePluginEntry({
           event.next,
           event.source,
         );
+
+        void taskFlowVisibility.recordTransition(event);
 
         // P-14: grant-ledger updates on persist-approval transitions
         // (where approvalId rotates) and pruning on terminal states.

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,9 @@
  * add those hooks, the warning is already wired.
  */
 
+import { createRequire } from "node:module";
+import * as fs from "node:fs";
+import * as pathModule from "node:path";
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import {
@@ -56,6 +59,7 @@ import {
 import { decideEscalatingRetry } from "./runtime/escalating-retry.js";
 import { GrantLedger } from "./runtime/grant-ledger.js";
 import { enqueuePlanApprovedInjection } from "./runtime/injection-writer.js";
+import { createPlanModeNotifications } from "./runtime/plan-notifications.js";
 import { decidePlanTierModel } from "./runtime/plan-tier-model.js";
 import { createAskUserQuestionTool } from "./tools/ask-user-question.js";
 import { createEnterPlanModeTool } from "./tools/enter-plan-mode.js";
@@ -304,6 +308,31 @@ export default definePluginEntry({
       },
     );
 
+    // P-12: session-actions — operator-side resolution surface.
+    // /plan accept|reject|cancel|edit|answer + plan.auto.toggle. UI
+    // clients dispatch these by (pluginId, actionId). Telegram-native
+    // buttons and typed /plan commands both route through this same map.
+    const sessionActionRegistrations = createPlanModeSessionActions({
+      api,
+      store,
+    });
+    const sessionActionHandlers = new Map<
+      string,
+      (ctx: never) => unknown
+    >();
+    for (const action of sessionActionRegistrations) {
+      api.session.controls.registerSessionAction(action);
+      sessionActionHandlers.set(
+        action.id,
+        action.handler as (ctx: never) => unknown,
+      );
+    }
+    const notifications = createPlanModeNotifications({
+      api,
+      store,
+      actions: sessionActionHandlers as never,
+    });
+
     api.registerTool(createEnterPlanModeTool({ store }), {
       name: "enter_plan_mode",
     });
@@ -354,6 +383,7 @@ export default definePluginEntry({
               : {}),
           },
         },
+        notifications,
         autoApprove: {
           // The trigger mirrors `plan.accept`'s two-step resolution
           // (src/ui/session-actions.ts ~260-302):
@@ -434,34 +464,12 @@ export default definePluginEntry({
       createAskUserQuestionTool({
         store,
         logger: { warn: (msg: string) => api.logger.warn(msg) },
+        notifications,
       }),
       {
         name: "ask_user_question",
       },
     );
-
-    // P-12: session-actions — operator-side resolution surface.
-    // /plan accept|reject|cancel|edit|answer + plan.auto.toggle. UI
-    // clients dispatch these by (pluginId, actionId). Each handler
-    // verifies the approvalId (stale-event guard), then calls the
-    // PlanModeStore mutator + the appropriate injection-writer.
-    const sessionActionRegistrations = createPlanModeSessionActions({
-      api,
-      store,
-    });
-    const sessionActionHandlers = new Map<
-      string,
-      (ctx: never) => unknown
-    >();
-    for (const action of sessionActionRegistrations) {
-      api.session.controls.registerSessionAction(action);
-      // Snapshot the handler for the /plan slash-command dispatcher
-      // below. Keyed on the action id so /plan accept → plan.accept etc.
-      sessionActionHandlers.set(
-        action.id,
-        action.handler as (ctx: never) => unknown,
-      );
-    }
 
     // Hotfix (2026-05-13): register `/plan` and `/plan-mode` slash
     // commands so users can resolve approvals from chat (not just
@@ -491,7 +499,15 @@ export default definePluginEntry({
 
     // P-12: sweep CLI command — `openclaw plan-clear -s <sessionKey>`.
     // Operator rollback drain for sessions stuck in plan mode.
-    api.registerCli(createPlanClearCli({ store }));
+    api.registerCli(createPlanClearCli({ store }), {
+      descriptors: [
+        {
+          name: "plan-clear",
+          description: "Clear Smarter-Claw plan-mode state for a session.",
+          hasSubcommands: false,
+        },
+      ],
+    });
 
     // P-5: mutation gate (`before_tool_call` hook). Blocks mutating
     // tools when planMode === "plan". Algorithm is byte-identical to
@@ -812,21 +828,13 @@ export default definePluginEntry({
  *   - Detection fails (can't find openclaw): silent no-op (returns generic message)
  */
 function buildChatStreamSeamAdvisory(): string {
-  // Lazy-require fs to keep the plugin entry side-effect-free at import
-  // time for tests + parity harness.
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const fs = require("node:fs") as typeof import("node:fs");
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const pathModule = require("node:path") as typeof import("node:path");
-
   // Resolve openclaw install dir from this module's location.
   // The plugin imports `openclaw/plugin-sdk/...`, so Node has resolved
   // openclaw's package directory. We walk up from `require.resolve` if
   // available; otherwise fall back to relative path heuristic.
   let openclawDir: string | null = null;
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const req = require("node:module").createRequire(import.meta.url) as NodeRequire;
+    const req = createRequire(import.meta.url);
     const openclawPkg = req.resolve("openclaw/package.json");
     openclawDir = pathModule.dirname(openclawPkg);
   } catch {

--- a/src/runtime/host-seam-gates.ts
+++ b/src/runtime/host-seam-gates.ts
@@ -1,0 +1,37 @@
+export const OPENCLAW_2026_6_1_ACTIVE_SESSION_ATTACHMENT_BLOCK =
+  "active-session-attachments-bundled-only";
+
+export type PlanNotificationDeliveryFailureCode =
+  | typeof OPENCLAW_2026_6_1_ACTIVE_SESSION_ATTACHMENT_BLOCK
+  | "delivery-unavailable";
+
+export type PlanNotificationDeliveryFailure = {
+  code: PlanNotificationDeliveryFailureCode;
+  releaseGate: boolean;
+  fallback: string;
+  message: string;
+};
+
+const PLAN_NOTIFICATION_FALLBACK =
+  "/plan commands and persisted Markdown plan paths remain authoritative";
+
+export function classifyPlanNotificationDeliveryFailure(
+  error: string,
+): PlanNotificationDeliveryFailure {
+  const normalized = error.trim();
+  if (/session attachments are restricted to bundled plugins/i.test(normalized)) {
+    return {
+      code: OPENCLAW_2026_6_1_ACTIVE_SESSION_ATTACHMENT_BLOCK,
+      releaseGate: true,
+      fallback: PLAN_NOTIFICATION_FALLBACK,
+      message:
+        "OpenClaw stock host rejected active-session attachment delivery for a workspace plugin.",
+    };
+  }
+  return {
+    code: "delivery-unavailable",
+    releaseGate: false,
+    fallback: PLAN_NOTIFICATION_FALLBACK,
+    message: `Plan notification delivery was unavailable: ${normalized || "unknown error"}`,
+  };
+}

--- a/src/runtime/plan-notifications.ts
+++ b/src/runtime/plan-notifications.ts
@@ -1,0 +1,540 @@
+import { randomBytes } from "node:crypto";
+import type {
+  OpenClawPluginApi,
+  PluginSessionActionContext,
+  PluginSessionActionResult,
+} from "openclaw/plugin-sdk/plugin-entry";
+import type { PersistPlanArchetypeMarkdownResult } from "../plan-mode/plan-archetype-persist.js";
+import type { PlanModeStore } from "../state/store.js";
+import type { PlanStep } from "../types.js";
+
+export const TELEGRAM_PLAN_INTERACTIVE_NAMESPACE = "smarter-claw-plan";
+
+type PresentationButtonStyle = "primary" | "secondary" | "success" | "danger";
+
+type MessagePresentation = {
+  title?: string;
+  tone?: "info" | "success" | "warning" | "danger" | "neutral";
+  blocks: Array<
+    | { type: "text"; text: string }
+    | { type: "context"; text: string }
+    | { type: "divider" }
+    | {
+        type: "buttons";
+        buttons: Array<{
+          label: string;
+          value: string;
+          style?: PresentationButtonStyle;
+          priority?: number;
+        }>;
+      }
+  >;
+};
+
+type SessionAttachmentParams = {
+  sessionKey: string;
+  files?: Array<{ path: string }>;
+  text?: string;
+  presentation?: MessagePresentation;
+  forceDocument?: boolean;
+  captionFormat?: "plain" | "html" | "markdown";
+  channelHints?: {
+    telegram?: {
+      disableNotification?: boolean;
+    };
+  };
+};
+
+type TelegramInteractiveContext = {
+  channel: "telegram";
+  auth?: { isAuthorizedSender?: boolean };
+  callback: {
+    payload: string;
+  };
+  respond: {
+    reply?: (params: { text: string }) => Promise<void> | void;
+    clearButtons?: () => Promise<void> | void;
+  };
+};
+
+type RegisterInteractiveHandler = (registration: {
+  channel: "telegram";
+  namespace: string;
+  handler: (ctx: TelegramInteractiveContext) => Promise<{ handled: true }>;
+}) => void;
+
+type OpenClawPluginApiWithRuntimeNotifications = OpenClawPluginApi & {
+  registerInteractiveHandler?: RegisterInteractiveHandler;
+  session?: OpenClawPluginApi["session"] & {
+    workflow?: OpenClawPluginApi["session"]["workflow"] & {
+      sendSessionAttachment?: (params: unknown) => Promise<{ ok: true } | { ok: false; error: string }>;
+    };
+  };
+};
+
+export type SessionActionHandler = (
+  ctx: PluginSessionActionContext,
+) => PluginSessionActionResult | void | Promise<PluginSessionActionResult | void>;
+
+type ApprovalTokenEntry = {
+  kind: "approval";
+  sessionKey: string;
+  approvalId: string;
+  action: "accept" | "revise" | "reject" | "cancel";
+  expiresAt: number;
+};
+
+type QuestionTokenEntry = {
+  kind: "question";
+  sessionKey: string;
+  questionId: string;
+  questionPrompt: string;
+  selectedOption: string;
+  expiresAt: number;
+};
+
+type TokenEntry = ApprovalTokenEntry | QuestionTokenEntry;
+type NewTokenEntry =
+  | Omit<ApprovalTokenEntry, "expiresAt">
+  | Omit<QuestionTokenEntry, "expiresAt">;
+type JsonPayload = Record<string, string | number | boolean | null>;
+
+const TOKEN_TTL_MS = 6 * 60 * 60 * 1000;
+const tokens = new Map<string, TokenEntry>();
+
+export function __resetPlanNotificationTokensForTest(): void {
+  tokens.clear();
+}
+
+function createToken(entry: NewTokenEntry): string {
+  const now = Date.now();
+  for (const [token, existing] of tokens) {
+    if (existing.expiresAt <= now) {
+      tokens.delete(token);
+    }
+  }
+  const token = randomBytes(9).toString("base64url");
+  tokens.set(token, {
+    ...entry,
+    expiresAt: now + TOKEN_TTL_MS,
+  } as TokenEntry);
+  return token;
+}
+
+function readToken(token: string): TokenEntry | undefined {
+  const entry = tokens.get(token);
+  if (!entry) return undefined;
+  if (entry.expiresAt <= Date.now()) {
+    tokens.delete(token);
+    return undefined;
+  }
+  return entry;
+}
+
+function callbackValue(action: string, token: string): string {
+  return `${TELEGRAM_PLAN_INTERACTIVE_NAMESPACE}:${action}:${token}`;
+}
+
+function renderPlanText(input: {
+  title: string;
+  summary?: string;
+  persistedPlan?: PersistPlanArchetypeMarkdownResult;
+}): string {
+  const lines = [`Plan approval requested: ${input.title}`];
+  if (input.summary) {
+    lines.push("", input.summary);
+  }
+  if (input.persistedPlan) {
+    lines.push("", `Markdown plan: ${input.persistedPlan.absPath}`);
+  }
+  lines.push(
+    "",
+    "Fallback commands: /plan approve, /plan revise <feedback>, /plan reject <feedback>, /plan cancel.",
+  );
+  return lines.join("\n");
+}
+
+function renderPlanPresentation(input: {
+  sessionKey: string;
+  approvalId: string;
+  title: string;
+  summary?: string;
+  plan: PlanStep[];
+  persistedPlan?: PersistPlanArchetypeMarkdownResult;
+}): MessagePresentation {
+  const accept = createToken({
+    kind: "approval",
+    sessionKey: input.sessionKey,
+    approvalId: input.approvalId,
+    action: "accept",
+  });
+  const revise = createToken({
+    kind: "approval",
+    sessionKey: input.sessionKey,
+    approvalId: input.approvalId,
+    action: "revise",
+  });
+  const reject = createToken({
+    kind: "approval",
+    sessionKey: input.sessionKey,
+    approvalId: input.approvalId,
+    action: "reject",
+  });
+  const cancel = createToken({
+    kind: "approval",
+    sessionKey: input.sessionKey,
+    approvalId: input.approvalId,
+    action: "cancel",
+  });
+  const firstSteps = input.plan
+    .slice(0, 4)
+    .map((step, index) => `${index + 1}. ${step.step}`)
+    .join("\n");
+  return {
+    title: input.title,
+    tone: "warning",
+    blocks: [
+      ...(input.summary ? [{ type: "text" as const, text: input.summary }] : []),
+      ...(firstSteps ? [{ type: "context" as const, text: firstSteps }] : []),
+      ...(input.persistedPlan
+        ? [
+            {
+              type: "context" as const,
+              text: `Markdown artifact: ${input.persistedPlan.filename}`,
+            },
+          ]
+        : []),
+      {
+        type: "buttons",
+        buttons: [
+          {
+            label: "Approve",
+            value: callbackValue("a", accept),
+            style: "success",
+            priority: 100,
+          },
+          {
+            label: "Revise",
+            value: callbackValue("v", revise),
+            style: "primary",
+            priority: 90,
+          },
+          {
+            label: "Reject",
+            value: callbackValue("r", reject),
+            style: "danger",
+            priority: 80,
+          },
+          {
+            label: "Cancel",
+            value: callbackValue("c", cancel),
+            style: "secondary",
+            priority: 70,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function renderQuestionPresentation(input: {
+  sessionKey: string;
+  questionId: string;
+  questionPrompt: string;
+  options: string[];
+}): MessagePresentation {
+  return {
+    title: "Question",
+    tone: "info",
+    blocks: [
+      { type: "text", text: input.questionPrompt },
+      {
+        type: "buttons",
+        buttons: input.options.map((option, index) => {
+          const token = createToken({
+            kind: "question",
+            sessionKey: input.sessionKey,
+            questionId: input.questionId,
+            questionPrompt: input.questionPrompt,
+            selectedOption: option,
+          });
+          return {
+            label: option,
+            value: callbackValue("q", token),
+            style: index === 0 ? "primary" : "secondary",
+            priority: 100 - index,
+          };
+        }),
+      },
+    ],
+  };
+}
+
+async function sendPresentation(
+  api: OpenClawPluginApiWithRuntimeNotifications,
+  params: SessionAttachmentParams,
+): Promise<void> {
+  const sendSessionAttachment = api.session?.workflow?.sendSessionAttachment;
+  if (!sendSessionAttachment) {
+    api.logger.warn(
+      "[smarter-claw] plan notification skipped: host has no session.workflow.sendSessionAttachment runtime seam",
+    );
+    return;
+  }
+  const result = await sendSessionAttachment(params as unknown);
+  if (!result.ok) {
+    api.logger.warn(
+      `[smarter-claw] plan notification delivery skipped: ${result.error}`,
+    );
+  }
+}
+
+async function reply(ctx: TelegramInteractiveContext, text: string): Promise<void> {
+  await ctx.respond.reply?.({ text });
+}
+
+async function clearButtons(ctx: TelegramInteractiveContext): Promise<void> {
+  await ctx.respond.clearButtons?.();
+}
+
+function isAuthorized(ctx: TelegramInteractiveContext): boolean {
+  return ctx.auth?.isAuthorizedSender === true;
+}
+
+async function dispatchSessionAction(
+  actions: Map<string, SessionActionHandler>,
+  actionId: string,
+  sessionKey: string,
+  payload: JsonPayload,
+): Promise<PluginSessionActionResult | void> {
+  const handler = actions.get(actionId);
+  if (!handler) {
+    return {
+      ok: false,
+      error: `session action not registered: ${actionId}`,
+      code: "ACTION_NOT_REGISTERED",
+    };
+  }
+  return await handler({
+    pluginId: "smarter-claw",
+    actionId,
+    sessionKey,
+    payload,
+  });
+}
+
+function isActionOk(result: PluginSessionActionResult | void): boolean {
+  return Boolean(result && result.ok !== false);
+}
+
+function actionError(result: PluginSessionActionResult | void): string {
+  if (!result || result.ok !== false) {
+    return "unknown action failure";
+  }
+  return `${result.code ?? "ERROR"} - ${result.error}`;
+}
+
+async function handleApprovalCallback(input: {
+  ctx: TelegramInteractiveContext;
+  entry: ApprovalTokenEntry;
+  actions: Map<string, SessionActionHandler>;
+  store: PlanModeStore;
+}): Promise<void> {
+  const snap = await input.store.readSnapshot(input.entry.sessionKey);
+  if (
+    !snap ||
+    snap.approvalId !== input.entry.approvalId ||
+    (snap.approval !== "pending" && snap.approval !== "rejected")
+  ) {
+    await clearButtons(input.ctx);
+    await reply(input.ctx, "That plan button is stale. Use /plan status for the current state.");
+    return;
+  }
+
+  const actionId =
+    input.entry.action === "accept"
+      ? "plan.accept"
+      : input.entry.action === "cancel"
+        ? "plan.cancel"
+        : "plan.reject";
+  const payload: JsonPayload =
+    input.entry.action === "accept"
+      ? { approvalId: input.entry.approvalId }
+      : input.entry.action === "revise"
+        ? {
+            approvalId: input.entry.approvalId,
+            feedback: "Please revise the plan.",
+          }
+        : input.entry.action === "reject"
+          ? {
+              approvalId: input.entry.approvalId,
+              feedback: "Rejected from Telegram.",
+            }
+          : {};
+  const result = await dispatchSessionAction(
+    input.actions,
+    actionId,
+    input.entry.sessionKey,
+    payload,
+  );
+  if (!isActionOk(result)) {
+    await clearButtons(input.ctx);
+    await reply(input.ctx, `Plan action failed: ${actionError(result)}`);
+    return;
+  }
+  await clearButtons(input.ctx);
+  const message =
+    input.entry.action === "accept"
+      ? "Plan approved. The agent will resume."
+      : input.entry.action === "cancel"
+        ? "Plan mode cancelled."
+        : "Plan sent back for revision.";
+  await reply(input.ctx, message);
+}
+
+async function handleQuestionCallback(input: {
+  ctx: TelegramInteractiveContext;
+  entry: QuestionTokenEntry;
+  actions: Map<string, SessionActionHandler>;
+  store: PlanModeStore;
+}): Promise<void> {
+  const snap = await input.store.readSnapshot(input.entry.sessionKey);
+  const pending = snap?.pendingQuestion;
+  if (!pending || pending.questionId !== input.entry.questionId) {
+    await clearButtons(input.ctx);
+    await reply(input.ctx, "That question button is stale. Use /plan status for the current state.");
+    return;
+  }
+  if (!pending.allowFreetext && !pending.options.includes(input.entry.selectedOption)) {
+    await clearButtons(input.ctx);
+    await reply(input.ctx, "That question option is stale. The agent has asked a newer question.");
+    return;
+  }
+
+  const result = await dispatchSessionAction(
+    input.actions,
+    "plan.answer",
+    input.entry.sessionKey,
+    {
+      questionId: input.entry.questionId,
+      questionPrompt: input.entry.questionPrompt,
+      selectedOption: input.entry.selectedOption,
+    },
+  );
+  if (!isActionOk(result)) {
+    await reply(input.ctx, `Answer failed: ${actionError(result)}`);
+    return;
+  }
+  const clear = await input.store.clearPendingQuestion({
+    sessionKey: input.entry.sessionKey,
+    expectedQuestionId: input.entry.questionId,
+  });
+  if (clear.kind === "failed") {
+    await input.ctx.respond.reply?.({
+      text:
+        "Answer recorded, but I could not clear the pending question marker. " +
+        "A repeated click will be ignored by the injection idempotency key.",
+    });
+  }
+  await clearButtons(input.ctx);
+  await reply(input.ctx, "Answer recorded. The agent will resume.");
+}
+
+export interface PlanApprovalNotificationInput {
+  sessionKey: string;
+  approvalId: string;
+  title: string;
+  summary?: string;
+  plan: PlanStep[];
+  persistedPlan?: PersistPlanArchetypeMarkdownResult;
+}
+
+export interface QuestionNotificationInput {
+  sessionKey: string;
+  questionId: string;
+  questionPrompt: string;
+  options: string[];
+}
+
+export interface PlanModeNotificationSink {
+  notifyPlanApproval(input: PlanApprovalNotificationInput): Promise<void>;
+  notifyQuestion(input: QuestionNotificationInput): Promise<void>;
+}
+
+export function createPlanModeNotifications(input: {
+  api: OpenClawPluginApi;
+  store: PlanModeStore;
+  actions: Map<string, SessionActionHandler>;
+}): PlanModeNotificationSink {
+  const api = input.api as OpenClawPluginApiWithRuntimeNotifications;
+  const registerInteractiveHandler = (
+    api as { registerInteractiveHandler?: RegisterInteractiveHandler }
+  ).registerInteractiveHandler;
+  registerInteractiveHandler?.({
+    channel: "telegram",
+    namespace: TELEGRAM_PLAN_INTERACTIVE_NAMESPACE,
+    handler: async (ctx: TelegramInteractiveContext) => {
+      if (!isAuthorized(ctx)) {
+        await reply(ctx, "You are not authorized to use this plan action.");
+        return { handled: true };
+      }
+      const [action, token] = ctx.callback.payload.split(":", 2);
+      if (!action || !token) {
+        await reply(ctx, "Invalid plan action payload.");
+        return { handled: true };
+      }
+      const entry = readToken(token);
+      if (!entry) {
+        await clearButtons(ctx);
+        await reply(ctx, "That plan action has expired. Use /plan status for the current state.");
+        return { handled: true };
+      }
+      if (entry.kind === "approval") {
+        await handleApprovalCallback({
+          ctx,
+          entry,
+          actions: input.actions,
+          store: input.store,
+        });
+        return { handled: true };
+      }
+      if (entry.kind === "question") {
+        await handleQuestionCallback({
+          ctx,
+          entry,
+          actions: input.actions,
+          store: input.store,
+        });
+        return { handled: true };
+      }
+      return { handled: true };
+    },
+  });
+
+  return {
+    async notifyPlanApproval(params) {
+      await sendPresentation(api, {
+        sessionKey: params.sessionKey,
+        files: params.persistedPlan ? [{ path: params.persistedPlan.absPath }] : [],
+        text: renderPlanText(params),
+        presentation: renderPlanPresentation(params),
+        forceDocument: params.persistedPlan ? true : undefined,
+        captionFormat: "plain",
+        channelHints: {
+          telegram: {
+            disableNotification: false,
+          },
+        },
+      });
+    },
+    async notifyQuestion(params) {
+      await sendPresentation(api, {
+        sessionKey: params.sessionKey,
+        files: [],
+        text: `Question: ${params.questionPrompt}`,
+        presentation: renderQuestionPresentation(params),
+        captionFormat: "plain",
+      });
+    },
+  };
+}

--- a/src/runtime/plan-notifications.ts
+++ b/src/runtime/plan-notifications.ts
@@ -370,7 +370,7 @@ async function handleApprovalCallback(input: {
               approvalId: input.entry.approvalId,
               feedback: "Rejected from Telegram.",
             }
-          : {};
+          : { approvalId: input.entry.approvalId };
   const result = await dispatchSessionAction(
     input.actions,
     actionId,

--- a/src/runtime/plan-notifications.ts
+++ b/src/runtime/plan-notifications.ts
@@ -7,6 +7,7 @@ import type {
 import type { PersistPlanArchetypeMarkdownResult } from "../plan-mode/plan-archetype-persist.js";
 import type { PlanModeStore } from "../state/store.js";
 import type { PlanStep } from "../types.js";
+import { classifyPlanNotificationDeliveryFailure } from "./host-seam-gates.js";
 
 export const TELEGRAM_PLAN_INTERACTIVE_NAMESPACE = "smarter-claw-plan";
 
@@ -301,8 +302,11 @@ async function sendPresentation(
   }
   const result = await sendSessionAttachment(params as unknown);
   if (!result.ok) {
+    const gate = classifyPlanNotificationDeliveryFailure(result.error);
     api.logger.warn(
-      `[smarter-claw] plan notification delivery skipped: ${result.error}`,
+      `[smarter-claw] plan notification delivery skipped (${gate.code}${
+        gate.releaseGate ? "; release-gated host seam" : ""
+      }): ${gate.message} Fallback: ${gate.fallback}.`,
     );
     return false;
   }

--- a/src/runtime/plan-notifications.ts
+++ b/src/runtime/plan-notifications.ts
@@ -106,6 +106,10 @@ export function __resetPlanNotificationTokensForTest(): void {
   tokens.clear();
 }
 
+export function __getPlanNotificationTokenCountForTest(): number {
+  return tokens.size;
+}
+
 function createToken(entry: NewTokenEntry): string {
   const now = Date.now();
   for (const [token, existing] of tokens) {
@@ -121,14 +125,20 @@ function createToken(entry: NewTokenEntry): string {
   return token;
 }
 
-function readToken(token: string): TokenEntry | undefined {
+function consumeToken(token: string): TokenEntry | undefined {
   const entry = tokens.get(token);
   if (!entry) return undefined;
+  tokens.delete(token);
   if (entry.expiresAt <= Date.now()) {
-    tokens.delete(token);
     return undefined;
   }
   return entry;
+}
+
+function discardTokens(values: string[]): void {
+  for (const token of values) {
+    tokens.delete(token);
+  }
 }
 
 function callbackValue(action: string, token: string): string {
@@ -161,7 +171,7 @@ function renderPlanPresentation(input: {
   summary?: string;
   plan: PlanStep[];
   persistedPlan?: PersistPlanArchetypeMarkdownResult;
-}): MessagePresentation {
+}): { presentation: MessagePresentation; tokens: string[] } {
   const accept = createToken({
     kind: "approval",
     sessionKey: input.sessionKey,
@@ -191,49 +201,52 @@ function renderPlanPresentation(input: {
     .map((step, index) => `${index + 1}. ${step.step}`)
     .join("\n");
   return {
-    title: input.title,
-    tone: "warning",
-    blocks: [
-      ...(input.summary ? [{ type: "text" as const, text: input.summary }] : []),
-      ...(firstSteps ? [{ type: "context" as const, text: firstSteps }] : []),
-      ...(input.persistedPlan
-        ? [
+    tokens: [accept, revise, reject, cancel],
+    presentation: {
+      title: input.title,
+      tone: "warning",
+      blocks: [
+        ...(input.summary ? [{ type: "text" as const, text: input.summary }] : []),
+        ...(firstSteps ? [{ type: "context" as const, text: firstSteps }] : []),
+        ...(input.persistedPlan
+          ? [
+              {
+                type: "context" as const,
+                text: `Markdown artifact: ${input.persistedPlan.filename}`,
+              },
+            ]
+          : []),
+        {
+          type: "buttons",
+          buttons: [
             {
-              type: "context" as const,
-              text: `Markdown artifact: ${input.persistedPlan.filename}`,
+              label: "Approve",
+              value: callbackValue("a", accept),
+              style: "success",
+              priority: 100,
             },
-          ]
-        : []),
-      {
-        type: "buttons",
-        buttons: [
-          {
-            label: "Approve",
-            value: callbackValue("a", accept),
-            style: "success",
-            priority: 100,
-          },
-          {
-            label: "Revise",
-            value: callbackValue("v", revise),
-            style: "primary",
-            priority: 90,
-          },
-          {
-            label: "Reject",
-            value: callbackValue("r", reject),
-            style: "danger",
-            priority: 80,
-          },
-          {
-            label: "Cancel",
-            value: callbackValue("c", cancel),
-            style: "secondary",
-            priority: 70,
-          },
-        ],
-      },
-    ],
+            {
+              label: "Revise",
+              value: callbackValue("v", revise),
+              style: "primary",
+              priority: 90,
+            },
+            {
+              label: "Reject",
+              value: callbackValue("r", reject),
+              style: "danger",
+              priority: 80,
+            },
+            {
+              label: "Cancel",
+              value: callbackValue("c", cancel),
+              style: "secondary",
+              priority: 70,
+            },
+          ],
+        },
+      ],
+    },
   };
 }
 
@@ -242,51 +255,58 @@ function renderQuestionPresentation(input: {
   questionId: string;
   questionPrompt: string;
   options: string[];
-}): MessagePresentation {
+}): { presentation: MessagePresentation; tokens: string[] } {
+  const mintedTokens: string[] = [];
   return {
-    title: "Question",
-    tone: "info",
-    blocks: [
-      { type: "text", text: input.questionPrompt },
-      {
-        type: "buttons",
-        buttons: input.options.map((option, index) => {
-          const token = createToken({
-            kind: "question",
-            sessionKey: input.sessionKey,
-            questionId: input.questionId,
-            questionPrompt: input.questionPrompt,
-            selectedOption: option,
-          });
-          return {
-            label: option,
-            value: callbackValue("q", token),
-            style: index === 0 ? "primary" : "secondary",
-            priority: 100 - index,
-          };
-        }),
-      },
-    ],
+    tokens: mintedTokens,
+    presentation: {
+      title: "Question",
+      tone: "info",
+      blocks: [
+        { type: "text", text: input.questionPrompt },
+        {
+          type: "buttons",
+          buttons: input.options.map((option, index) => {
+            const token = createToken({
+              kind: "question",
+              sessionKey: input.sessionKey,
+              questionId: input.questionId,
+              questionPrompt: input.questionPrompt,
+              selectedOption: option,
+            });
+            mintedTokens.push(token);
+            return {
+              label: option,
+              value: callbackValue("q", token),
+              style: index === 0 ? "primary" : "secondary",
+              priority: 100 - index,
+            };
+          }),
+        },
+      ],
+    },
   };
 }
 
 async function sendPresentation(
   api: OpenClawPluginApiWithRuntimeNotifications,
   params: SessionAttachmentParams,
-): Promise<void> {
+): Promise<boolean> {
   const sendSessionAttachment = api.session?.workflow?.sendSessionAttachment;
   if (!sendSessionAttachment) {
     api.logger.warn(
       "[smarter-claw] plan notification skipped: host has no session.workflow.sendSessionAttachment runtime seam",
     );
-    return;
+    return false;
   }
   const result = await sendSessionAttachment(params as unknown);
   if (!result.ok) {
     api.logger.warn(
       `[smarter-claw] plan notification delivery skipped: ${result.error}`,
     );
+    return false;
   }
+  return true;
 }
 
 async function reply(ctx: TelegramInteractiveContext, text: string): Promise<void> {
@@ -483,7 +503,7 @@ export function createPlanModeNotifications(input: {
         await reply(ctx, "Invalid plan action payload.");
         return { handled: true };
       }
-      const entry = readToken(token);
+      const entry = consumeToken(token);
       if (!entry) {
         await clearButtons(ctx);
         await reply(ctx, "That plan action has expired. Use /plan status for the current state.");
@@ -513,28 +533,46 @@ export function createPlanModeNotifications(input: {
 
   return {
     async notifyPlanApproval(params) {
-      await sendPresentation(api, {
-        sessionKey: params.sessionKey,
-        files: params.persistedPlan ? [{ path: params.persistedPlan.absPath }] : [],
-        text: renderPlanText(params),
-        presentation: renderPlanPresentation(params),
-        forceDocument: params.persistedPlan ? true : undefined,
-        captionFormat: "plain",
-        channelHints: {
-          telegram: {
-            disableNotification: false,
+      const rendered = renderPlanPresentation(params);
+      try {
+        const delivered = await sendPresentation(api, {
+          sessionKey: params.sessionKey,
+          files: params.persistedPlan ? [{ path: params.persistedPlan.absPath }] : [],
+          text: renderPlanText(params),
+          presentation: rendered.presentation,
+          forceDocument: params.persistedPlan ? true : undefined,
+          captionFormat: "plain",
+          channelHints: {
+            telegram: {
+              disableNotification: false,
+            },
           },
-        },
-      });
+        });
+        if (!delivered) {
+          discardTokens(rendered.tokens);
+        }
+      } catch (error) {
+        discardTokens(rendered.tokens);
+        throw error;
+      }
     },
     async notifyQuestion(params) {
-      await sendPresentation(api, {
-        sessionKey: params.sessionKey,
-        files: [],
-        text: `Question: ${params.questionPrompt}`,
-        presentation: renderQuestionPresentation(params),
-        captionFormat: "plain",
-      });
+      const rendered = renderQuestionPresentation(params);
+      try {
+        const delivered = await sendPresentation(api, {
+          sessionKey: params.sessionKey,
+          files: [],
+          text: `Question: ${params.questionPrompt}`,
+          presentation: rendered.presentation,
+          captionFormat: "plain",
+        });
+        if (!delivered) {
+          discardTokens(rendered.tokens);
+        }
+      } catch (error) {
+        discardTokens(rendered.tokens);
+        throw error;
+      }
     },
   };
 }

--- a/src/runtime/task-flow-visibility.ts
+++ b/src/runtime/task-flow-visibility.ts
@@ -231,7 +231,11 @@ export function createPlanModeTaskFlowVisibility(input: {
           return;
         }
 
-        if (event.next.approval === "approved" || event.next.approval === "edited") {
+        if (
+          event.next.approval === "approved" ||
+          event.next.approval === "edited" ||
+          event.next.approval === "none"
+        ) {
           warnMutationFailure(
             logger,
             "finish",

--- a/src/runtime/task-flow-visibility.ts
+++ b/src/runtime/task-flow-visibility.ts
@@ -1,0 +1,204 @@
+import type { PlanModeSessionState } from "../types.js";
+
+export const PLAN_MODE_TASK_FLOW_CONTROLLER_ID = "smarter-claw.plan-mode";
+
+type Logger = {
+  debug?: (message: string) => void;
+  warn?: (message: string) => void;
+};
+
+type JsonRecord = Record<string, unknown>;
+
+type ManagedTaskFlowRecordLike = {
+  flowId?: unknown;
+  revision?: unknown;
+  controllerId?: unknown;
+  stateJson?: unknown;
+};
+
+type ManagedTaskFlowMutationResultLike = {
+  applied?: boolean;
+  code?: unknown;
+};
+
+type BoundTaskFlowRuntimeLike = {
+  createManaged?: (params: JsonRecord) => ManagedTaskFlowRecordLike | null | undefined;
+  list?: () => ManagedTaskFlowRecordLike[];
+  setWaiting?: (params: JsonRecord) => ManagedTaskFlowMutationResultLike;
+  finish?: (params: JsonRecord) => ManagedTaskFlowMutationResultLike;
+};
+
+type PluginRuntimeTaskFlowLike = {
+  bindSession?: (params: { sessionKey: string }) => BoundTaskFlowRuntimeLike;
+};
+
+export type PlanModeTaskFlowTransition = {
+  sessionKey: string;
+  prev: PlanModeSessionState | undefined;
+  next: PlanModeSessionState;
+  source: string;
+};
+
+export type PlanModeTaskFlowVisibility = {
+  recordTransition(event: PlanModeTaskFlowTransition): Promise<void>;
+};
+
+function isRecord(value: unknown): value is JsonRecord {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function getRuntimeTaskFlow(api: unknown): PluginRuntimeTaskFlowLike | undefined {
+  const runtime = isRecord(api) ? api.runtime : undefined;
+  if (!isRecord(runtime)) return undefined;
+  const tasks = isRecord(runtime.tasks) ? runtime.tasks : undefined;
+  const managedFlows = isRecord(tasks?.managedFlows) ? tasks?.managedFlows : undefined;
+  const legacyTaskFlow = isRecord(runtime.taskFlow) ? runtime.taskFlow : undefined;
+  const candidate = managedFlows ?? legacyTaskFlow;
+  return typeof candidate?.bindSession === "function"
+    ? (candidate as PluginRuntimeTaskFlowLike)
+    : undefined;
+}
+
+function getApprovalIdFromFlow(flow: ManagedTaskFlowRecordLike): string | undefined {
+  if (!isRecord(flow.stateJson)) return undefined;
+  const kind = flow.stateJson.kind;
+  const approvalId = flow.stateJson.approvalId;
+  if (kind !== "smarter-claw.plan-mode" || typeof approvalId !== "string") {
+    return undefined;
+  }
+  return approvalId;
+}
+
+function getRevision(flow: ManagedTaskFlowRecordLike): number | undefined {
+  return typeof flow.revision === "number" && Number.isFinite(flow.revision)
+    ? flow.revision
+    : undefined;
+}
+
+function getFlowId(flow: ManagedTaskFlowRecordLike): string | undefined {
+  return typeof flow.flowId === "string" && flow.flowId.trim().length > 0
+    ? flow.flowId
+    : undefined;
+}
+
+function findFlowForApprovalId(
+  bound: BoundTaskFlowRuntimeLike,
+  approvalId: string,
+): ManagedTaskFlowRecordLike | undefined {
+  const flows = typeof bound.list === "function" ? bound.list() : [];
+  return flows.find(
+    (flow) =>
+      flow.controllerId === PLAN_MODE_TASK_FLOW_CONTROLLER_ID &&
+      getApprovalIdFromFlow(flow) === approvalId,
+  );
+}
+
+function buildStateJson(event: PlanModeTaskFlowTransition): JsonRecord {
+  return {
+    kind: "smarter-claw.plan-mode",
+    sessionKey: event.sessionKey,
+    source: event.source,
+    mode: event.next.mode,
+    approval: event.next.approval,
+    ...(event.next.approvalId ? { approvalId: event.next.approvalId } : {}),
+    ...(event.next.title ? { title: event.next.title } : {}),
+    ...(event.next.lastPlanSteps ? { steps: event.next.lastPlanSteps } : {}),
+    rejectionCount: event.next.rejectionCount,
+    updatedAt: Date.now(),
+  };
+}
+
+function warnMutationFailure(
+  logger: Logger,
+  action: string,
+  result: ManagedTaskFlowMutationResultLike | undefined,
+): void {
+  if (!result || result.applied !== false) return;
+  logger.warn?.(
+    `[smarter-claw] task-flow visibility ${action} skipped: ${String(result.code ?? "unknown")}`,
+  );
+}
+
+export function createPlanModeTaskFlowVisibility(input: {
+  api: unknown;
+  logger?: Logger;
+}): PlanModeTaskFlowVisibility {
+  const taskFlow = getRuntimeTaskFlow(input.api);
+  const logger = input.logger ?? {};
+
+  return {
+    async recordTransition(event) {
+      if (!taskFlow?.bindSession) {
+        logger.debug?.(
+          "[smarter-claw] task-flow visibility skipped: host runtime has no managed TaskFlow API",
+        );
+        return;
+      }
+      const bound = taskFlow.bindSession({ sessionKey: event.sessionKey });
+      try {
+        if (event.next.approval === "pending" && event.next.approvalId) {
+          if (findFlowForApprovalId(bound, event.next.approvalId)) {
+            return;
+          }
+          bound.createManaged?.({
+            controllerId: PLAN_MODE_TASK_FLOW_CONTROLLER_ID,
+            goal: `Plan approval: ${event.next.title ?? event.next.approvalId}`,
+            status: "waiting",
+            currentStep: "Awaiting operator approval",
+            stateJson: buildStateJson(event),
+            waitJson: {
+              kind: "plan_approval",
+              approvalId: event.next.approvalId,
+              sessionKey: event.sessionKey,
+            },
+          });
+          return;
+        }
+
+        const approvalId = event.next.approvalId ?? event.prev?.approvalId;
+        if (!approvalId) return;
+        const flow = findFlowForApprovalId(bound, approvalId);
+        if (!flow) return;
+        const flowId = getFlowId(flow);
+        const expectedRevision = getRevision(flow);
+        if (!flowId || expectedRevision === undefined) return;
+
+        if (event.next.approval === "rejected") {
+          warnMutationFailure(
+            logger,
+            "setWaiting",
+            bound.setWaiting?.({
+              flowId,
+              expectedRevision,
+              currentStep: "Plan rejected; waiting for revised plan",
+              stateJson: buildStateJson(event),
+              waitJson: {
+                kind: "plan_revision",
+                approvalId,
+                feedback: event.next.feedback ?? null,
+                sessionKey: event.sessionKey,
+              },
+            }),
+          );
+          return;
+        }
+
+        if (event.next.approval === "approved" || event.next.approval === "edited") {
+          warnMutationFailure(
+            logger,
+            "finish",
+            bound.finish?.({
+              flowId,
+              expectedRevision,
+              stateJson: buildStateJson(event),
+            }),
+          );
+        }
+      } catch (error) {
+        logger.warn?.(
+          `[smarter-claw] task-flow visibility bridge failed: ${(error as Error).message}`,
+        );
+      }
+    },
+  };
+}

--- a/src/runtime/task-flow-visibility.ts
+++ b/src/runtime/task-flow-visibility.ts
@@ -13,6 +13,7 @@ type ManagedTaskFlowRecordLike = {
   flowId?: unknown;
   revision?: unknown;
   controllerId?: unknown;
+  status?: unknown;
   stateJson?: unknown;
 };
 
@@ -69,6 +70,16 @@ function getApprovalIdFromFlow(flow: ManagedTaskFlowRecordLike): string | undefi
   return approvalId;
 }
 
+function getSessionKeyFromFlow(flow: ManagedTaskFlowRecordLike): string | undefined {
+  if (!isRecord(flow.stateJson)) return undefined;
+  const kind = flow.stateJson.kind;
+  const sessionKey = flow.stateJson.sessionKey;
+  if (kind !== "smarter-claw.plan-mode" || typeof sessionKey !== "string") {
+    return undefined;
+  }
+  return sessionKey;
+}
+
 function getRevision(flow: ManagedTaskFlowRecordLike): number | undefined {
   return typeof flow.revision === "number" && Number.isFinite(flow.revision)
     ? flow.revision
@@ -90,6 +101,19 @@ function findFlowForApprovalId(
     (flow) =>
       flow.controllerId === PLAN_MODE_TASK_FLOW_CONTROLLER_ID &&
       getApprovalIdFromFlow(flow) === approvalId,
+  );
+}
+
+function findActiveFlowForSession(
+  bound: BoundTaskFlowRuntimeLike,
+  sessionKey: string,
+): ManagedTaskFlowRecordLike | undefined {
+  const flows = typeof bound.list === "function" ? bound.list() : [];
+  return flows.find(
+    (flow) =>
+      flow.controllerId === PLAN_MODE_TASK_FLOW_CONTROLLER_ID &&
+      flow.status !== "finished" &&
+      getSessionKeyFromFlow(flow) === sessionKey,
   );
 }
 
@@ -139,6 +163,30 @@ export function createPlanModeTaskFlowVisibility(input: {
         if (event.next.approval === "pending" && event.next.approvalId) {
           if (findFlowForApprovalId(bound, event.next.approvalId)) {
             return;
+          }
+          const existingSessionFlow = findActiveFlowForSession(bound, event.sessionKey);
+          const existingFlowId = existingSessionFlow
+            ? getFlowId(existingSessionFlow)
+            : undefined;
+          const expectedRevision = existingSessionFlow
+            ? getRevision(existingSessionFlow)
+            : undefined;
+          if (existingFlowId && expectedRevision !== undefined && bound.setWaiting) {
+            const result = bound.setWaiting({
+              flowId: existingFlowId,
+              expectedRevision,
+              currentStep: "Awaiting operator approval",
+              stateJson: buildStateJson(event),
+              waitJson: {
+                kind: "plan_approval",
+                approvalId: event.next.approvalId,
+                sessionKey: event.sessionKey,
+              },
+            });
+            warnMutationFailure(logger, "setWaiting", result);
+            if (!result || result.applied !== false) {
+              return;
+            }
           }
           bound.createManaged?.({
             controllerId: PLAN_MODE_TASK_FLOW_CONTROLLER_ID,

--- a/src/runtime/task-flow-visibility.ts
+++ b/src/runtime/task-flow-visibility.ts
@@ -24,7 +24,7 @@ type ManagedTaskFlowMutationResultLike = {
 
 type BoundTaskFlowRuntimeLike = {
   createManaged?: (params: JsonRecord) => ManagedTaskFlowRecordLike | null | undefined;
-  list?: () => ManagedTaskFlowRecordLike[];
+  list?: () => unknown;
   setWaiting?: (params: JsonRecord) => ManagedTaskFlowMutationResultLike;
   finish?: (params: JsonRecord) => ManagedTaskFlowMutationResultLike;
 };
@@ -92,11 +92,18 @@ function getFlowId(flow: ManagedTaskFlowRecordLike): string | undefined {
     : undefined;
 }
 
+function listManagedTaskFlows(bound: BoundTaskFlowRuntimeLike): ManagedTaskFlowRecordLike[] {
+  const listed = typeof bound.list === "function" ? bound.list() : [];
+  return Array.isArray(listed)
+    ? listed.filter((flow): flow is ManagedTaskFlowRecordLike => isRecord(flow))
+    : [];
+}
+
 function findFlowForApprovalId(
   bound: BoundTaskFlowRuntimeLike,
   approvalId: string,
 ): ManagedTaskFlowRecordLike | undefined {
-  const flows = typeof bound.list === "function" ? bound.list() : [];
+  const flows = listManagedTaskFlows(bound);
   return flows.find(
     (flow) =>
       flow.controllerId === PLAN_MODE_TASK_FLOW_CONTROLLER_ID &&
@@ -108,7 +115,7 @@ function findActiveFlowForSession(
   bound: BoundTaskFlowRuntimeLike,
   sessionKey: string,
 ): ManagedTaskFlowRecordLike | undefined {
-  const flows = typeof bound.list === "function" ? bound.list() : [];
+  const flows = listManagedTaskFlows(bound);
   return flows.find(
     (flow) =>
       flow.controllerId === PLAN_MODE_TASK_FLOW_CONTROLLER_ID &&

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -389,24 +389,50 @@ export class PlanModeStore {
    *   In-host the state-transition is wired in the runner; we encode it
    *   in the store directly.
    */
-  async exitPlanMode(input: { sessionKey: string }): Promise<
+  async exitPlanMode(input: { sessionKey: string; expectedApprovalId?: string }): Promise<
     | { kind: "exited"; state: PlanModeSessionState }
     | { kind: "noop"; state: PlanModeSessionState | undefined }
+    | {
+        kind: "skipped";
+        reason: "not_in_plan_mode" | "no_pending_approval" | "stale_approval_id";
+        state: PlanModeSessionState | undefined;
+      }
     | { kind: "failed"; error: Error }
   > {
-    const { sessionKey } = input;
+    const { sessionKey, expectedApprovalId } = input;
     try {
       let outcome:
         | { kind: "exited"; state: PlanModeSessionState }
-        | { kind: "noop"; state: PlanModeSessionState | undefined };
+        | { kind: "noop"; state: PlanModeSessionState | undefined }
+        | {
+            kind: "skipped";
+            reason: "not_in_plan_mode" | "no_pending_approval" | "stale_approval_id";
+            state: PlanModeSessionState | undefined;
+          };
 
       const { transition } = await this.gateway.withLock<{
         prev: PlanModeSessionState | undefined;
         next: PlanModeSessionState;
       }>(sessionKey, async (current) => {
-        // Idempotent: no payload, or already in normal mode.
+        // Idempotent: no payload, or already in normal mode. If the
+        // caller supplied an approval token, preserve the stale/no-pending
+        // distinction inside the same lock so callback races cannot cancel
+        // a newer approval cycle.
         if (!current || current.mode === "normal") {
-          outcome = { kind: "noop", state: current };
+          outcome = expectedApprovalId
+            ? { kind: "skipped", reason: "not_in_plan_mode", state: current }
+            : { kind: "noop", state: current };
+          return { next: null };
+        }
+        if (
+          expectedApprovalId &&
+          (current.approval !== "pending" && current.approval !== "rejected")
+        ) {
+          outcome = { kind: "skipped", reason: "no_pending_approval", state: current };
+          return { next: null };
+        }
+        if (expectedApprovalId && current.approvalId !== expectedApprovalId) {
+          outcome = { kind: "skipped", reason: "stale_approval_id", state: current };
           return { next: null };
         }
         const now = Date.now();

--- a/src/tools/ask-user-question.ts
+++ b/src/tools/ask-user-question.ts
@@ -80,7 +80,7 @@ export interface CreateAskUserQuestionToolInput {
   /**
    * Optional rich-channel notification sink. Production wiring sends
    * Telegram-native question buttons when the host exposes the
-   * active-session presentation seam; stable 26.5.19 falls back to
+   * active-session presentation seam; stock v2026.6.1-beta.1 falls back to
    * typed `/plan answer` when the host returns an unavailable result.
    */
   notifications?: Pick<PlanModeNotificationSink, "notifyQuestion">;

--- a/src/tools/ask-user-question.ts
+++ b/src/tools/ask-user-question.ts
@@ -80,7 +80,7 @@ export interface CreateAskUserQuestionToolInput {
   /**
    * Optional rich-channel notification sink. Production wiring sends
    * Telegram-native question buttons when the host exposes the
-   * active-session presentation seam; stable 26.5.18 falls back to
+   * active-session presentation seam; stable 26.5.19 falls back to
    * typed `/plan answer` when the host returns an unavailable result.
    */
   notifications?: Pick<PlanModeNotificationSink, "notifyQuestion">;

--- a/src/tools/ask-user-question.ts
+++ b/src/tools/ask-user-question.ts
@@ -42,6 +42,7 @@
 
 import { Type } from "typebox";
 import { describeAskUserQuestionTool } from "../plan-mode/tool-descriptions.js";
+import type { PlanModeNotificationSink } from "../runtime/plan-notifications.js";
 import type { PlanModeStore } from "../state/store.js";
 import { ToolInputError, readStringParam } from "./common.js";
 
@@ -76,6 +77,13 @@ export interface CreateAskUserQuestionToolInput {
   logger?: {
     warn?: (message: string) => void;
   };
+  /**
+   * Optional rich-channel notification sink. Production wiring sends
+   * Telegram-native question buttons when the host exposes the
+   * active-session presentation seam; stable 26.5.18 falls back to
+   * typed `/plan answer` when the host returns an unavailable result.
+   */
+  notifications?: Pick<PlanModeNotificationSink, "notifyQuestion">;
 }
 
 const SCHEMA = Type.Object(
@@ -200,6 +208,19 @@ export function createAskUserQuestionTool(
               opts.logger?.warn?.(
                 `ask_user_question: persistPendingQuestion failed (sessionKey=${ctx.sessionKey} questionId=${questionId}): ${result.error.message}`,
               );
+            } else {
+              try {
+                await opts.notifications?.notifyQuestion({
+                  sessionKey: ctx.sessionKey,
+                  questionId,
+                  questionPrompt: question,
+                  options,
+                });
+              } catch (notifyErr) {
+                opts.logger?.warn?.(
+                  `ask_user_question: notifyQuestion failed (sessionKey=${ctx.sessionKey} questionId=${questionId}): ${notifyErr instanceof Error ? notifyErr.message : String(notifyErr)}`,
+                );
+              }
             }
           } catch (persistErr) {
             // Defense-in-depth: persistPendingQuestion already

--- a/src/tools/exit-plan-mode.ts
+++ b/src/tools/exit-plan-mode.ts
@@ -60,6 +60,7 @@ import { computePlanPayloadHash } from "../helpers/payload-hash.js";
 import {
   persistPlanArchetypeMarkdown,
   PlanPersistStorageError,
+  type PersistPlanArchetypeMarkdownResult,
 } from "../plan-mode/plan-archetype-persist.js";
 import { renderFullPlanArchetypeMarkdown } from "../plan-mode/plan-render.js";
 import {
@@ -67,6 +68,7 @@ import {
   EXIT_PLAN_MODE_TOOL_DISPLAY_SUMMARY,
 } from "../plan-mode/tool-descriptions.js";
 import { PlanModeStore } from "../state/store.js";
+import type { PlanModeNotificationSink } from "../runtime/plan-notifications.js";
 import type { PlanStep } from "../types.js";
 import {
   PLAN_STEP_STATUSES,
@@ -234,6 +236,14 @@ export interface CreateExitPlanModeToolInput {
    * host_ref: src/agents/pi-embedded-subscribe.handlers.tools.ts:1949-1962
    */
   autoApprove?: ExitPlanModeAutoApproveOptions;
+  /**
+   * Optional rich-channel notification sink. Production wiring sends the
+   * persisted Markdown plan and native Telegram approval buttons when the
+   * host permits active-session plugin attachments. On plain 26.5.18 the
+   * host rejects that SDK call, so this path logs and the typed `/plan`
+   * fallback remains authoritative.
+   */
+  notifications?: Pick<PlanModeNotificationSink, "notifyPlanApproval">;
 }
 
 interface ToolContext {
@@ -624,8 +634,9 @@ export function createExitPlanModeTool(opts: CreateExitPlanModeToolInput) {
       // the building block a future host-side or bundled-capability
       // notifier would attach. Today, Telegram/Slack users get no
       // signal — the same gap the in-host has on non-Telegram channels.
+      let persistedPlan: PersistPlanArchetypeMarkdownResult | undefined;
       if (r.kind === "persisted") {
-        await persistPlanArchetypeIfConfigured({
+        persistedPlan = await persistPlanArchetypeIfConfigured({
           opts,
           ctx,
           plan: steps,
@@ -645,6 +656,28 @@ export function createExitPlanModeTool(opts: CreateExitPlanModeToolInput) {
             ? { references: archetype.references }
             : {}),
         });
+      }
+
+      if (r.kind === "persisted" && opts.notifications) {
+        try {
+          const snap = await opts.store.readSnapshot(sessionKey);
+          if (snap?.autoApprove !== true) {
+            await opts.notifications.notifyPlanApproval({
+              sessionKey,
+              approvalId: r.approvalId,
+              title,
+              ...(summary !== undefined ? { summary } : {}),
+              plan: steps,
+              ...(persistedPlan ? { persistedPlan } : {}),
+            });
+          }
+        } catch (notifyErr) {
+          opts.persister?.log?.warn?.(
+            `[smarter-claw] exit_plan_mode: plan notification failed: ${
+              notifyErr instanceof Error ? notifyErr.message : String(notifyErr)
+            }`,
+          );
+        }
       }
 
       // W1-F4 fix (2026-05-20): auto-approve trigger.
@@ -752,6 +785,14 @@ export function createExitPlanModeTool(opts: CreateExitPlanModeToolInput) {
           payloadHash,
           stepCount: steps.length,
           plan: steps,
+          ...(persistedPlan
+            ? {
+                persistedPlan: {
+                  path: persistedPlan.absPath,
+                  filename: persistedPlan.filename,
+                },
+              }
+            : {}),
           ...(title ? { title } : {}),
           ...(summary ? { summary } : {}),
           // PR-10 archetype fields. Spread only when the agent supplied
@@ -807,7 +848,7 @@ async function persistPlanArchetypeIfConfigured(input: {
   risks?: Array<{ risk: string; mitigation: string }>;
   verification?: string[];
   references?: string[];
-}): Promise<void> {
+}): Promise<PersistPlanArchetypeMarkdownResult | undefined> {
   const { opts, ctx } = input;
   const log = opts.persister?.log;
   if (!opts.persister) {
@@ -818,14 +859,14 @@ async function persistPlanArchetypeIfConfigured(input: {
       "[smarter-claw] exit_plan_mode: persister not configured; plan markdown NOT written. " +
         "Wire `persister` in createExitPlanModeTool({...}) to fulfil the archetype-prompt persistence promise.",
     );
-    return;
+    return undefined;
   }
   if (!ctx.agentId) {
     log?.warn?.(
       "[smarter-claw] exit_plan_mode: agentId missing from tool context; plan markdown NOT written. " +
         "The host SDK normally supplies agentId on OpenClawPluginToolContext.",
     );
-    return;
+    return undefined;
   }
   try {
     const markdown = renderFullPlanArchetypeMarkdown({
@@ -844,7 +885,7 @@ async function persistPlanArchetypeIfConfigured(input: {
         ? { references: input.references }
         : {}),
     });
-    const { filename } = await persistPlanArchetypeMarkdown({
+    const persisted = await persistPlanArchetypeMarkdown({
       agentId: ctx.agentId,
       title: input.title,
       markdown,
@@ -853,8 +894,9 @@ async function persistPlanArchetypeIfConfigured(input: {
         : {}),
     });
     log?.info?.(
-      `[smarter-claw] exit_plan_mode: persisted plan markdown agentId=${ctx.agentId} filename=${filename}`,
+      `[smarter-claw] exit_plan_mode: persisted plan markdown agentId=${ctx.agentId} filename=${persisted.filename}`,
     );
+    return persisted;
   } catch (err) {
     // Match the in-host bridge's two-bucket failure handling
     // (plan-archetype-bridge.ts:188-203): recoverable storage errors
@@ -867,13 +909,14 @@ async function persistPlanArchetypeIfConfigured(input: {
           `Operator action: check ~/.openclaw free space / permissions. ` +
           `Detail: ${err.message}`,
       );
-      return;
+      return undefined;
     }
     log?.warn?.(
       `[smarter-claw] exit_plan_mode: plan markdown persist failed: ${
         err instanceof Error ? err.message : String(err)
       }`,
     );
+    return undefined;
   }
 }
 

--- a/src/tools/exit-plan-mode.ts
+++ b/src/tools/exit-plan-mode.ts
@@ -239,7 +239,7 @@ export interface CreateExitPlanModeToolInput {
   /**
    * Optional rich-channel notification sink. Production wiring sends the
    * persisted Markdown plan and native Telegram approval buttons when the
-   * host permits active-session plugin attachments. On plain 26.5.19 the
+   * host permits active-session plugin attachments. On stock v2026.6.1-beta.1 the
    * host rejects that SDK call, so this path logs and the typed `/plan`
    * fallback remains authoritative.
    */
@@ -623,7 +623,7 @@ export function createExitPlanModeTool(opts: CreateExitPlanModeToolInput) {
       // "HTML" })` to push the persisted markdown to Telegram as the
       // user's action-required signal. The plugin port stops at the
       // PERSIST half — the push half is unimplementable on SDK
-      // `2026.5.19` because `api.session.workflow.sendSessionAttachment`
+      // `v2026.6.1-beta.1` because `api.session.workflow.sendSessionAttachment`
       // rejects 3P plugins (`host-hook-attachments.ts:216-218` —
       // `if (origin !== "bundled") return { ok: false, error:
       // "session attachments are restricted to bundled plugins" }`).

--- a/src/tools/exit-plan-mode.ts
+++ b/src/tools/exit-plan-mode.ts
@@ -239,7 +239,7 @@ export interface CreateExitPlanModeToolInput {
   /**
    * Optional rich-channel notification sink. Production wiring sends the
    * persisted Markdown plan and native Telegram approval buttons when the
-   * host permits active-session plugin attachments. On plain 26.5.18 the
+   * host permits active-session plugin attachments. On plain 26.5.19 the
    * host rejects that SDK call, so this path logs and the typed `/plan`
    * fallback remains authoritative.
    */
@@ -623,7 +623,7 @@ export function createExitPlanModeTool(opts: CreateExitPlanModeToolInput) {
       // "HTML" })` to push the persisted markdown to Telegram as the
       // user's action-required signal. The plugin port stops at the
       // PERSIST half — the push half is unimplementable on SDK
-      // `2026.5.18` because `api.session.workflow.sendSessionAttachment`
+      // `2026.5.19` because `api.session.workflow.sendSessionAttachment`
       // rejects 3P plugins (`host-hook-attachments.ts:216-218` —
       // `if (origin !== "bundled") return { ok: false, error:
       // "session attachments are restricted to bundled plugins" }`).

--- a/src/types.ts
+++ b/src/types.ts
@@ -223,7 +223,7 @@ export interface PlanModeSessionState {
    *  primary signal a future turn-limit watchdog would consume to
    *  auto-exit plan mode on a runaway loop. The watchdog itself is
    *  deferred — neither the in-host has a parity reference nor does
-   *  SDK 2026.5.18 expose a fit-for-purpose event-driven scheduler
+   *  SDK 2026.5.19 expose a fit-for-purpose event-driven scheduler
    *  seam (`registerSessionSchedulerJob` is cleanup-only;
    *  `scheduleSessionTurn` is cron-driven). See
    *  `docs/audits/parity-refresh/blocker-W1-E1.md` for the

--- a/src/ui/session-actions.ts
+++ b/src/ui/session-actions.ts
@@ -456,11 +456,35 @@ export function createPlanModeSessionActions(
     handler: async (ctx) => {
       const sk = requireSessionKey(ctx);
       if (!sk.ok) return sk.result;
-      const result = await store.exitPlanMode({ sessionKey: sk.sessionKey });
+      const p = readPayload(ctx.payload);
+      if (!p.ok) return p.result;
+      const expectedApprovalId = readStringField(p.value, "approvalId");
+      const result = await store.exitPlanMode({
+        sessionKey: sk.sessionKey,
+        ...(expectedApprovalId !== undefined ? { expectedApprovalId } : {}),
+      });
       if (result.kind === "failed") {
         return err(
           SESSION_ACTION_ERROR_CODES.STORE_ERROR,
           `exitPlanMode failed: ${result.error.message}`,
+        );
+      }
+      if (result.kind === "skipped") {
+        if (result.reason === "stale_approval_id") {
+          return err(
+            SESSION_ACTION_ERROR_CODES.STALE_APPROVAL_ID,
+            "expectedApprovalId did not match current approvalId; event is stale",
+          );
+        }
+        if (result.reason === "no_pending_approval") {
+          return err(
+            SESSION_ACTION_ERROR_CODES.NO_PENDING_APPROVAL,
+            "session has no actionable approval",
+          );
+        }
+        return err(
+          SESSION_ACTION_ERROR_CODES.NOT_IN_PLAN_MODE,
+          "session is not in plan mode",
         );
       }
       log.info(

--- a/tests/eva-live-smokes/harness.ts
+++ b/tests/eva-live-smokes/harness.ts
@@ -39,10 +39,13 @@ export interface HarnessCaptures {
   sessionExtensions: Array<{ namespace: string; description?: string }>;
   controlUis: unknown[];
   enqueuedInjections: unknown[];
+  sessionAttachments: unknown[];
+  interactiveHandlers: Map<string, (ctx: unknown) => unknown>;
   loggerInfo: string[];
   loggerWarn: string[];
   loggerError: string[];
   cliRegistrars: Array<(ctx: unknown) => void>;
+  cliOptions: unknown[];
   /** Slash commands registered via `api.registerCommand` (keyed by name). */
   commands: Map<string, unknown>;
 }
@@ -75,10 +78,13 @@ export function createHarness(options: {
     sessionExtensions: [],
     controlUis: [],
     enqueuedInjections: [],
+    sessionAttachments: [],
+    interactiveHandlers: new Map(),
     loggerInfo: [],
     loggerWarn: [],
     loggerError: [],
     cliRegistrars: [],
+    cliOptions: [],
     commands: new Map(),
   };
 
@@ -109,14 +115,23 @@ export function createHarness(options: {
       const name = opts?.name ?? "<unknown>";
       captures.tools.set(name, tool);
     }),
-    registerCli: vi.fn((registrar: (ctx: unknown) => void) => {
+    registerCli: vi.fn((registrar: (ctx: unknown) => void, opts?: unknown) => {
       captures.cliRegistrars.push(registrar);
+      captures.cliOptions.push(opts);
     }),
     registerCommand: vi.fn((command: { name?: string }) => {
       // `/plan` + `/plan-mode` slash commands (hotfix #93). Keyed by
       // command name so smokes can look them up + invoke the handler.
       captures.commands.set(command?.name ?? "<unknown>", command);
     }),
+    registerInteractiveHandler: vi.fn(
+      (registration: { channel: string; namespace: string; handler: (ctx: unknown) => unknown }) => {
+        captures.interactiveHandlers.set(
+          `${registration.channel}:${registration.namespace}`,
+          registration.handler,
+        );
+      },
+    ),
     session: {
       state: {
         registerSessionExtension: vi.fn(
@@ -132,6 +147,17 @@ export function createHarness(options: {
             enqueued: true,
             id: `inj-${captures.enqueuedInjections.length}`,
             sessionKey: (injection as { sessionKey: string }).sessionKey,
+          };
+        }),
+        sendSessionAttachment: vi.fn(async (attachment: unknown) => {
+          captures.sessionAttachments.push(attachment);
+          return {
+            ok: true,
+            channel: "telegram",
+            deliveredTo: "12345",
+            count: Array.isArray((attachment as { files?: unknown }).files)
+              ? ((attachment as { files: unknown[] }).files.length)
+              : 0,
           };
         }),
       },

--- a/tests/release/host-release-target.test.ts
+++ b/tests/release/host-release-target.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = resolve(import.meta.dirname, "../..");
+
+function readJson(path: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(resolve(ROOT, path), "utf8")) as Record<string, unknown>;
+}
+
+describe("OpenClaw v2026.6.1-beta.1 release target metadata", () => {
+  it("pins the runtime/install floor to the GitHub release target", () => {
+    const manifest = readJson("openclaw.plugin.json");
+    const pkg = readJson("package.json");
+    const openclaw = pkg.openclaw as {
+      target?: Record<string, unknown>;
+      install?: Record<string, unknown>;
+    };
+
+    expect(pkg.version).toBe("1.0.0-port.19");
+    expect(manifest.minHostVersion).toBe("2026.6.1-beta.1");
+    expect(openclaw.target).toEqual(
+      expect.objectContaining({
+        version: "2026.6.1-beta.1",
+        source: "github-release",
+        tag: "v2026.6.1-beta.1",
+        commit: "2fc497e67b9cf40b2c12a9355afd785e7f8672dc",
+        npmPackageAvailable: false,
+      }),
+    );
+    expect(openclaw.install?.minHostVersion).toBe(">=2026.6.1-beta.1");
+    expect((pkg.peerDependencies as Record<string, unknown>).openclaw).toBe(
+      ">=2026.6.1-beta.1",
+    );
+  });
+
+  it("requires explicit SDK fallback metadata while the target is not on npm", () => {
+    const pkg = readJson("package.json");
+    const openclaw = pkg.openclaw as {
+      target?: { npmPackageAvailable?: boolean };
+      sdkValidation?: Record<string, unknown>;
+    };
+    const devOpenClaw = (pkg.devDependencies as Record<string, unknown>).openclaw;
+
+    expect(openclaw.target?.npmPackageAvailable).toBe(false);
+    expect(openclaw.sdkValidation).toEqual(
+      expect.objectContaining({
+        npmFallbackVersion: devOpenClaw,
+        githubReleaseTag: "v2026.6.1-beta.1",
+      }),
+    );
+  });
+});

--- a/tests/runtime/host-seam-gates.test.ts
+++ b/tests/runtime/host-seam-gates.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyPlanNotificationDeliveryFailure,
+  OPENCLAW_2026_6_1_ACTIVE_SESSION_ATTACHMENT_BLOCK,
+} from "../../src/runtime/host-seam-gates.js";
+
+describe("OpenClaw host seam release gates", () => {
+  it("classifies the stock v2026.6.1 active-session attachment block", () => {
+    expect(
+      classifyPlanNotificationDeliveryFailure(
+        "session attachments are restricted to bundled plugins",
+      ),
+    ).toEqual({
+      code: OPENCLAW_2026_6_1_ACTIVE_SESSION_ATTACHMENT_BLOCK,
+      releaseGate: true,
+      fallback: "/plan commands and persisted Markdown plan paths remain authoritative",
+      message:
+        "OpenClaw stock host rejected active-session attachment delivery for a workspace plugin.",
+    });
+  });
+
+  it("keeps unknown delivery failures non-release-gated", () => {
+    expect(classifyPlanNotificationDeliveryFailure("session has no active delivery route")).toEqual({
+      code: "delivery-unavailable",
+      releaseGate: false,
+      fallback: "/plan commands and persisted Markdown plan paths remain authoritative",
+      message: "Plan notification delivery was unavailable: session has no active delivery route",
+    });
+  });
+});

--- a/tests/runtime/plan-notifications.test.ts
+++ b/tests/runtime/plan-notifications.test.ts
@@ -145,6 +145,41 @@ describe("plan notifications", () => {
     });
   });
 
+  it("dispatches Telegram cancel callbacks through plan.cancel with approvalId", async () => {
+    const { api, store, sendSessionAttachment, getHandler } = build();
+    const cancel = vi.fn(async () => ({ ok: true as const, continueAgent: false }));
+    const notifications = createPlanModeNotifications({
+      api: api as never,
+      store,
+      actions: new Map([["plan.cancel", cancel]]),
+    });
+    await notifications.notifyPlanApproval({
+      sessionKey: SESSION_KEY,
+      approvalId: "plan-11111111-1111-4111-8111-111111111111",
+      title: "Ship plan",
+      plan: [{ step: "Run focused tests", status: "pending" }],
+    });
+    const value = firstButtonValue(sendSessionAttachment.mock.calls[0]?.[0], "Cancel");
+    const payload = value.slice(`${TELEGRAM_PLAN_INTERACTIVE_NAMESPACE}:`.length);
+    const ctx = telegramCtx(payload);
+
+    await getHandler()?.(ctx);
+
+    expect(cancel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionId: "plan.cancel",
+        sessionKey: SESSION_KEY,
+        payload: {
+          approvalId: "plan-11111111-1111-4111-8111-111111111111",
+        },
+      }),
+    );
+    expect(ctx.respond.clearButtons).toHaveBeenCalledOnce();
+    expect(ctx.respond.reply).toHaveBeenCalledWith({
+      text: "Plan mode cancelled.",
+    });
+  });
+
   it("rejects stale Telegram approval callbacks without dispatching the action", async () => {
     const { gw, api, store, sendSessionAttachment, getHandler } = build();
     const accept = vi.fn(async () => ({ ok: true as const }));

--- a/tests/runtime/plan-notifications.test.ts
+++ b/tests/runtime/plan-notifications.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  __getPlanNotificationTokenCountForTest,
   __resetPlanNotificationTokensForTest,
   createPlanModeNotifications,
   TELEGRAM_PLAN_INTERACTIVE_NAMESPACE,
@@ -145,6 +146,34 @@ describe("plan notifications", () => {
     });
   });
 
+  it("invalidates Telegram approval callback tokens after first use", async () => {
+    const { api, store, sendSessionAttachment, getHandler } = build();
+    const accept = vi.fn(async () => ({ ok: true as const, continueAgent: true }));
+    const notifications = createPlanModeNotifications({
+      api: api as never,
+      store,
+      actions: new Map([["plan.accept", accept]]),
+    });
+    await notifications.notifyPlanApproval({
+      sessionKey: SESSION_KEY,
+      approvalId: "plan-11111111-1111-4111-8111-111111111111",
+      title: "Ship plan",
+      plan: [{ step: "Run focused tests", status: "pending" }],
+    });
+    const value = firstButtonValue(sendSessionAttachment.mock.calls[0]?.[0], "Approve");
+    const payload = value.slice(`${TELEGRAM_PLAN_INTERACTIVE_NAMESPACE}:`.length);
+
+    await getHandler()?.(telegramCtx(payload));
+    const replayCtx = telegramCtx(payload);
+    await getHandler()?.(replayCtx);
+
+    expect(accept).toHaveBeenCalledTimes(1);
+    expect(replayCtx.respond.clearButtons).toHaveBeenCalledOnce();
+    expect(replayCtx.respond.reply).toHaveBeenCalledWith({
+      text: "That plan action has expired. Use /plan status for the current state.",
+    });
+  });
+
   it("dispatches Telegram cancel callbacks through plan.cancel with approvalId", async () => {
     const { api, store, sendSessionAttachment, getHandler } = build();
     const cancel = vi.fn(async () => ({ ok: true as const, continueAgent: false }));
@@ -253,5 +282,25 @@ describe("plan notifications", () => {
     );
     expect((await store.readSnapshot(SESSION_KEY))?.pendingQuestion).toBeUndefined();
     expect(ctx.respond.clearButtons).toHaveBeenCalledOnce();
+  });
+
+  it("discards callback tokens when attachment delivery fails", async () => {
+    const { api, store, sendSessionAttachment } = build();
+    sendSessionAttachment.mockResolvedValueOnce({
+      ok: false,
+      error: "host rejected active-session attachments",
+    });
+    await createPlanModeNotifications({
+      api: api as never,
+      store,
+      actions: new Map(),
+    }).notifyPlanApproval({
+      sessionKey: SESSION_KEY,
+      approvalId: "plan-11111111-1111-4111-8111-111111111111",
+      title: "Ship plan",
+      plan: [{ step: "Run focused tests", status: "pending" }],
+    });
+
+    expect(__getPlanNotificationTokenCountForTest()).toBe(0);
   });
 });

--- a/tests/runtime/plan-notifications.test.ts
+++ b/tests/runtime/plan-notifications.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  __resetPlanNotificationTokensForTest,
+  createPlanModeNotifications,
+  TELEGRAM_PLAN_INTERACTIVE_NAMESPACE,
+} from "../../src/runtime/plan-notifications.js";
+import { InMemoryGateway } from "../../src/state/in-memory-gateway.js";
+import { PlanModeStore } from "../../src/state/store.js";
+
+const SESSION_KEY = "agent:main:main";
+
+function build() {
+  __resetPlanNotificationTokensForTest();
+  const gw = new InMemoryGateway();
+  gw.seed(SESSION_KEY, {
+    mode: "plan",
+    approval: "pending",
+    approvalId: "plan-11111111-1111-4111-8111-111111111111",
+    rejectionCount: 0,
+  });
+  const store = new PlanModeStore(gw);
+  let handler: ((ctx: unknown) => Promise<{ handled: true }>) | undefined;
+  const sendSessionAttachment = vi.fn(async () => ({
+    ok: true as const,
+    channel: "telegram",
+    deliveredTo: "12345",
+    count: 1,
+  }));
+  const api = {
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+    session: {
+      workflow: {
+        sendSessionAttachment,
+      },
+    },
+    registerInteractiveHandler: vi.fn((registration: { handler: typeof handler }) => {
+      handler = registration.handler;
+    }),
+  };
+  return { gw, store, api, sendSessionAttachment, getHandler: () => handler };
+}
+
+function firstButtonValue(call: unknown, label: string): string {
+  const presentation = (call as { presentation?: { blocks?: unknown[] } }).presentation;
+  const blocks = presentation?.blocks ?? [];
+  for (const block of blocks) {
+    const buttons = (block as { buttons?: Array<{ label: string; value: string }> }).buttons;
+    const found = buttons?.find((button) => button.label === label);
+    if (found) return found.value;
+  }
+  throw new Error(`missing button ${label}`);
+}
+
+function telegramCtx(payload: string) {
+  return {
+    channel: "telegram",
+    auth: { isAuthorizedSender: true },
+    callback: { payload },
+    respond: {
+      reply: vi.fn(async () => {}),
+      clearButtons: vi.fn(async () => {}),
+    },
+  };
+}
+
+describe("plan notifications", () => {
+  it("sends a Markdown plan attachment plus native Telegram approval buttons", async () => {
+    const { api, store, sendSessionAttachment } = build();
+    const actions = new Map();
+    await createPlanModeNotifications({
+      api: api as never,
+      store,
+      actions,
+    }).notifyPlanApproval({
+      sessionKey: SESSION_KEY,
+      approvalId: "plan-11111111-1111-4111-8111-111111111111",
+      title: "Ship plan",
+      summary: "Review before execution.",
+      plan: [{ step: "Run focused tests", status: "pending" }],
+      persistedPlan: {
+        absPath: "/tmp/plan.md",
+        filename: "plan.md",
+      },
+    });
+
+    expect(api.registerInteractiveHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "telegram",
+        namespace: TELEGRAM_PLAN_INTERACTIVE_NAMESPACE,
+      }),
+    );
+    expect(sendSessionAttachment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: SESSION_KEY,
+        files: [{ path: "/tmp/plan.md" }],
+        forceDocument: true,
+        presentation: expect.objectContaining({
+          title: "Ship plan",
+        }),
+      }),
+    );
+    const attachment = sendSessionAttachment.mock.calls[0]?.[0];
+    expect(firstButtonValue(attachment, "Approve")).toMatch(
+      new RegExp(`^${TELEGRAM_PLAN_INTERACTIVE_NAMESPACE}:a:`),
+    );
+  });
+
+  it("dispatches approved Telegram callbacks through plan.accept and clears buttons", async () => {
+    const { api, store, sendSessionAttachment, getHandler } = build();
+    const accept = vi.fn(async () => ({ ok: true as const, continueAgent: true }));
+    const notifications = createPlanModeNotifications({
+      api: api as never,
+      store,
+      actions: new Map([["plan.accept", accept]]),
+    });
+    await notifications.notifyPlanApproval({
+      sessionKey: SESSION_KEY,
+      approvalId: "plan-11111111-1111-4111-8111-111111111111",
+      title: "Ship plan",
+      plan: [{ step: "Run focused tests", status: "pending" }],
+    });
+    const value = firstButtonValue(sendSessionAttachment.mock.calls[0]?.[0], "Approve");
+    const payload = value.slice(`${TELEGRAM_PLAN_INTERACTIVE_NAMESPACE}:`.length);
+    const ctx = telegramCtx(payload);
+
+    await getHandler()?.(ctx);
+
+    expect(accept).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionId: "plan.accept",
+        sessionKey: SESSION_KEY,
+        payload: {
+          approvalId: "plan-11111111-1111-4111-8111-111111111111",
+        },
+      }),
+    );
+    expect(ctx.respond.clearButtons).toHaveBeenCalledOnce();
+    expect(ctx.respond.reply).toHaveBeenCalledWith({
+      text: "Plan approved. The agent will resume.",
+    });
+  });
+
+  it("rejects stale Telegram approval callbacks without dispatching the action", async () => {
+    const { gw, api, store, sendSessionAttachment, getHandler } = build();
+    const accept = vi.fn(async () => ({ ok: true as const }));
+    const notifications = createPlanModeNotifications({
+      api: api as never,
+      store,
+      actions: new Map([["plan.accept", accept]]),
+    });
+    await notifications.notifyPlanApproval({
+      sessionKey: SESSION_KEY,
+      approvalId: "plan-11111111-1111-4111-8111-111111111111",
+      title: "Ship plan",
+      plan: [{ step: "Run focused tests", status: "pending" }],
+    });
+    gw.seed(SESSION_KEY, {
+      mode: "plan",
+      approval: "pending",
+      approvalId: "plan-22222222-2222-4222-8222-222222222222",
+      rejectionCount: 0,
+    });
+    const value = firstButtonValue(sendSessionAttachment.mock.calls[0]?.[0], "Approve");
+    const payload = value.slice(`${TELEGRAM_PLAN_INTERACTIVE_NAMESPACE}:`.length);
+    const ctx = telegramCtx(payload);
+
+    await getHandler()?.(ctx);
+
+    expect(accept).not.toHaveBeenCalled();
+    expect(ctx.respond.clearButtons).toHaveBeenCalledOnce();
+    expect(ctx.respond.reply).toHaveBeenCalledWith({
+      text: "That plan button is stale. Use /plan status for the current state.",
+    });
+  });
+
+  it("dispatches Telegram question option callbacks and clears pending question state", async () => {
+    const { api, store, sendSessionAttachment, getHandler } = build();
+    await store.persistPendingQuestion({
+      sessionKey: SESSION_KEY,
+      questionId: "q-call-1",
+      questionPrompt: "Major or minor bump?",
+      options: ["major", "minor"],
+      allowFreetext: false,
+    });
+    const answer = vi.fn(async () => ({ ok: true as const, continueAgent: true }));
+    const notifications = createPlanModeNotifications({
+      api: api as never,
+      store,
+      actions: new Map([["plan.answer", answer]]),
+    });
+    await notifications.notifyQuestion({
+      sessionKey: SESSION_KEY,
+      questionId: "q-call-1",
+      questionPrompt: "Major or minor bump?",
+      options: ["major", "minor"],
+    });
+    const value = firstButtonValue(sendSessionAttachment.mock.calls[0]?.[0], "major");
+    const payload = value.slice(`${TELEGRAM_PLAN_INTERACTIVE_NAMESPACE}:`.length);
+    const ctx = telegramCtx(payload);
+
+    await getHandler()?.(ctx);
+
+    expect(answer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionId: "plan.answer",
+        sessionKey: SESSION_KEY,
+        payload: {
+          questionId: "q-call-1",
+          questionPrompt: "Major or minor bump?",
+          selectedOption: "major",
+        },
+      }),
+    );
+    expect((await store.readSnapshot(SESSION_KEY))?.pendingQuestion).toBeUndefined();
+    expect(ctx.respond.clearButtons).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/runtime/task-flow-visibility.test.ts
+++ b/tests/runtime/task-flow-visibility.test.ts
@@ -3,6 +3,7 @@ import { createPlanModeTaskFlowVisibility } from "../../src/runtime/task-flow-vi
 
 const SESSION_KEY = "agent:main:main";
 const APPROVAL_ID = "plan-11111111-1111-4111-8111-111111111111";
+const REVISED_APPROVAL_ID = "plan-22222222-2222-4222-8222-222222222222";
 
 function buildTaskFlowRuntime() {
   const flows: Array<Record<string, unknown>> = [];
@@ -19,15 +20,18 @@ function buildTaskFlowRuntime() {
   });
   const setWaiting = vi.fn((input: Record<string, unknown>) => {
     const flow = flows.find((candidate) => candidate.flowId === input.flowId);
-    return flow
-      ? { applied: true, flow: { ...flow, ...input, revision: Number(flow.revision) + 1 } }
-      : { applied: false, code: "not_found" };
+    if (!flow) return { applied: false, code: "not_found" };
+    Object.assign(flow, input, {
+      status: "waiting",
+      revision: Number(flow.revision) + 1,
+    });
+    return { applied: true, flow };
   });
   const finish = vi.fn((input: Record<string, unknown>) => {
     const flow = flows.find((candidate) => candidate.flowId === input.flowId);
-    return flow
-      ? { applied: true, flow: { ...flow, ...input, status: "finished" } }
-      : { applied: false, code: "not_found" };
+    if (!flow) return { applied: false, code: "not_found" };
+    Object.assign(flow, input, { status: "finished" });
+    return { applied: true, flow };
   });
   const bindSession = vi.fn(() => ({
     createManaged,
@@ -82,7 +86,11 @@ describe("task-flow visibility bridge", () => {
       revision: 3,
       syncMode: "managed",
       controllerId: "smarter-claw.plan-mode",
-      stateJson: { kind: "smarter-claw.plan-mode", approvalId: APPROVAL_ID },
+      stateJson: {
+        kind: "smarter-claw.plan-mode",
+        approvalId: APPROVAL_ID,
+        sessionKey: SESSION_KEY,
+      },
     });
     const visibility = createPlanModeTaskFlowVisibility({
       api: { runtime: { taskFlow: { bindSession: runtime.bindSession } } },
@@ -113,6 +121,83 @@ describe("task-flow visibility bridge", () => {
         stateJson: expect.objectContaining({
           approval: "approved",
           source: "recordApproval",
+        }),
+      }),
+    );
+  });
+
+  it("reuses the session task flow when a rejected plan is revised with a new approval id", async () => {
+    const runtime = buildTaskFlowRuntime();
+    const visibility = createPlanModeTaskFlowVisibility({
+      api: { runtime: { tasks: { managedFlows: { bindSession: runtime.bindSession } } } },
+      logger: { debug: vi.fn(), warn: vi.fn() },
+    });
+
+    await visibility.recordTransition({
+      sessionKey: SESSION_KEY,
+      prev: { mode: "plan", approval: "none", rejectionCount: 0 },
+      next: {
+        mode: "plan",
+        approval: "pending",
+        approvalId: APPROVAL_ID,
+        title: "Ship the release",
+        rejectionCount: 0,
+      },
+      source: "persistApprovalRequest",
+    });
+
+    await visibility.recordTransition({
+      sessionKey: SESSION_KEY,
+      prev: {
+        mode: "plan",
+        approval: "pending",
+        approvalId: APPROVAL_ID,
+        rejectionCount: 0,
+      },
+      next: {
+        mode: "plan",
+        approval: "rejected",
+        approvalId: APPROVAL_ID,
+        feedback: "Add a Crabbox smoke",
+        rejectionCount: 1,
+      },
+      source: "recordRejection",
+    });
+
+    await visibility.recordTransition({
+      sessionKey: SESSION_KEY,
+      prev: {
+        mode: "plan",
+        approval: "rejected",
+        approvalId: APPROVAL_ID,
+        feedback: "Add a Crabbox smoke",
+        rejectionCount: 1,
+      },
+      next: {
+        mode: "plan",
+        approval: "pending",
+        approvalId: REVISED_APPROVAL_ID,
+        title: "Ship the revised release",
+        rejectionCount: 1,
+      },
+      source: "persistApprovalRequest",
+    });
+
+    expect(runtime.createManaged).toHaveBeenCalledTimes(1);
+    expect(runtime.flows).toHaveLength(1);
+    expect(runtime.setWaiting).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        flowId: "flow-1",
+        expectedRevision: 2,
+        currentStep: "Awaiting operator approval",
+        waitJson: expect.objectContaining({
+          kind: "plan_approval",
+          approvalId: REVISED_APPROVAL_ID,
+        }),
+        stateJson: expect.objectContaining({
+          approval: "pending",
+          approvalId: REVISED_APPROVAL_ID,
+          sessionKey: SESSION_KEY,
         }),
       }),
     );

--- a/tests/runtime/task-flow-visibility.test.ts
+++ b/tests/runtime/task-flow-visibility.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from "vitest";
+import { createPlanModeTaskFlowVisibility } from "../../src/runtime/task-flow-visibility.js";
+
+const SESSION_KEY = "agent:main:main";
+const APPROVAL_ID = "plan-11111111-1111-4111-8111-111111111111";
+
+function buildTaskFlowRuntime() {
+  const flows: Array<Record<string, unknown>> = [];
+  const createManaged = vi.fn((input: Record<string, unknown>) => {
+    const flow = {
+      ...input,
+      flowId: `flow-${flows.length + 1}`,
+      revision: 1,
+      syncMode: "managed",
+      controllerId: input.controllerId,
+    };
+    flows.push(flow);
+    return flow;
+  });
+  const setWaiting = vi.fn((input: Record<string, unknown>) => {
+    const flow = flows.find((candidate) => candidate.flowId === input.flowId);
+    return flow
+      ? { applied: true, flow: { ...flow, ...input, revision: Number(flow.revision) + 1 } }
+      : { applied: false, code: "not_found" };
+  });
+  const finish = vi.fn((input: Record<string, unknown>) => {
+    const flow = flows.find((candidate) => candidate.flowId === input.flowId);
+    return flow
+      ? { applied: true, flow: { ...flow, ...input, status: "finished" } }
+      : { applied: false, code: "not_found" };
+  });
+  const bindSession = vi.fn(() => ({
+    createManaged,
+    list: () => flows,
+    setWaiting,
+    finish,
+  }));
+  return { flows, bindSession, createManaged, setWaiting, finish };
+}
+
+describe("task-flow visibility bridge", () => {
+  it("creates a managed task flow when a plan enters pending approval", async () => {
+    const runtime = buildTaskFlowRuntime();
+    const visibility = createPlanModeTaskFlowVisibility({
+      api: { runtime: { tasks: { managedFlows: { bindSession: runtime.bindSession } } } },
+      logger: { debug: vi.fn(), warn: vi.fn() },
+    });
+
+    await visibility.recordTransition({
+      sessionKey: SESSION_KEY,
+      prev: { mode: "plan", approval: "none", rejectionCount: 0 },
+      next: {
+        mode: "plan",
+        approval: "pending",
+        approvalId: APPROVAL_ID,
+        title: "Ship the release",
+        lastPlanSteps: [{ step: "Run focused tests", status: "pending" }],
+        rejectionCount: 0,
+      },
+      source: "persistApprovalRequest",
+    });
+
+    expect(runtime.bindSession).toHaveBeenCalledWith({ sessionKey: SESSION_KEY });
+    expect(runtime.createManaged).toHaveBeenCalledWith(
+      expect.objectContaining({
+        controllerId: "smarter-claw.plan-mode",
+        goal: "Plan approval: Ship the release",
+        status: "waiting",
+        currentStep: "Awaiting operator approval",
+        waitJson: expect.objectContaining({
+          kind: "plan_approval",
+          approvalId: APPROVAL_ID,
+        }),
+      }),
+    );
+  });
+
+  it("finishes the matching managed task flow when the plan is approved", async () => {
+    const runtime = buildTaskFlowRuntime();
+    runtime.flows.push({
+      flowId: "flow-1",
+      revision: 3,
+      syncMode: "managed",
+      controllerId: "smarter-claw.plan-mode",
+      stateJson: { kind: "smarter-claw.plan-mode", approvalId: APPROVAL_ID },
+    });
+    const visibility = createPlanModeTaskFlowVisibility({
+      api: { runtime: { taskFlow: { bindSession: runtime.bindSession } } },
+      logger: { debug: vi.fn(), warn: vi.fn() },
+    });
+
+    await visibility.recordTransition({
+      sessionKey: SESSION_KEY,
+      prev: {
+        mode: "plan",
+        approval: "pending",
+        approvalId: APPROVAL_ID,
+        rejectionCount: 0,
+      },
+      next: {
+        mode: "normal",
+        approval: "approved",
+        approvalId: APPROVAL_ID,
+        rejectionCount: 0,
+      },
+      source: "recordApproval",
+    });
+
+    expect(runtime.finish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        flowId: "flow-1",
+        expectedRevision: 3,
+        stateJson: expect.objectContaining({
+          approval: "approved",
+          source: "recordApproval",
+        }),
+      }),
+    );
+  });
+});

--- a/tests/runtime/task-flow-visibility.test.ts
+++ b/tests/runtime/task-flow-visibility.test.ts
@@ -173,6 +173,47 @@ describe("task-flow visibility bridge", () => {
     );
   });
 
+  it("does not throw when the host returns a malformed task-flow list", async () => {
+    const createManaged = vi.fn();
+    const warn = vi.fn();
+    const visibility = createPlanModeTaskFlowVisibility({
+      api: {
+        runtime: {
+          tasks: {
+            managedFlows: {
+              bindSession: () => ({
+                createManaged,
+                list: () => undefined,
+              }),
+            },
+          },
+        },
+      },
+      logger: { debug: vi.fn(), warn },
+    });
+
+    await visibility.recordTransition({
+      sessionKey: SESSION_KEY,
+      prev: { mode: "plan", approval: "none", rejectionCount: 0 },
+      next: {
+        mode: "plan",
+        approval: "pending",
+        approvalId: APPROVAL_ID,
+        title: "Ship the release",
+        rejectionCount: 0,
+      },
+      source: "persistApprovalRequest",
+    });
+
+    expect(createManaged).toHaveBeenCalledWith(
+      expect.objectContaining({
+        controllerId: "smarter-claw.plan-mode",
+        status: "waiting",
+      }),
+    );
+    expect(warn).not.toHaveBeenCalled();
+  });
+
   it("reuses the session task flow when a rejected plan is revised with a new approval id", async () => {
     const runtime = buildTaskFlowRuntime();
     const visibility = createPlanModeTaskFlowVisibility({

--- a/tests/runtime/task-flow-visibility.test.ts
+++ b/tests/runtime/task-flow-visibility.test.ts
@@ -126,6 +126,53 @@ describe("task-flow visibility bridge", () => {
     );
   });
 
+  it("finishes the matching managed task flow when a pending plan is cancelled", async () => {
+    const runtime = buildTaskFlowRuntime();
+    runtime.flows.push({
+      flowId: "flow-1",
+      revision: 4,
+      syncMode: "managed",
+      status: "waiting",
+      controllerId: "smarter-claw.plan-mode",
+      stateJson: {
+        kind: "smarter-claw.plan-mode",
+        approvalId: APPROVAL_ID,
+        sessionKey: SESSION_KEY,
+      },
+    });
+    const visibility = createPlanModeTaskFlowVisibility({
+      api: { runtime: { tasks: { managedFlows: { bindSession: runtime.bindSession } } } },
+      logger: { debug: vi.fn(), warn: vi.fn() },
+    });
+
+    await visibility.recordTransition({
+      sessionKey: SESSION_KEY,
+      prev: {
+        mode: "plan",
+        approval: "pending",
+        approvalId: APPROVAL_ID,
+        rejectionCount: 0,
+      },
+      next: {
+        mode: "normal",
+        approval: "none",
+        rejectionCount: 0,
+      },
+      source: "exitPlanMode",
+    });
+
+    expect(runtime.finish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        flowId: "flow-1",
+        expectedRevision: 4,
+        stateJson: expect.objectContaining({
+          approval: "none",
+          source: "exitPlanMode",
+        }),
+      }),
+    );
+  });
+
   it("reuses the session task flow when a rejected plan is revised with a new approval id", async () => {
     const runtime = buildTaskFlowRuntime();
     const visibility = createPlanModeTaskFlowVisibility({

--- a/tests/tools/ask-user-question.test.ts
+++ b/tests/tools/ask-user-question.test.ts
@@ -238,8 +238,10 @@ describe("W1-F5 ask_user_question — pending-question persistence", () => {
   });
 
   it("when notification sink is wired, sends native question options after persist", async () => {
-    const { store } = stubStore();
-    const notifyQuestion = vi.fn(async () => {});
+    const { store, calls } = stubStore();
+    const notifyQuestion = vi.fn(async () => {
+      expect(calls).toHaveLength(1);
+    });
     const factory = createAskUserQuestionTool({
       store: store as never,
       notifications: { notifyQuestion },

--- a/tests/tools/ask-user-question.test.ts
+++ b/tests/tools/ask-user-question.test.ts
@@ -237,6 +237,28 @@ describe("W1-F5 ask_user_question — pending-question persistence", () => {
     expect(warn).not.toHaveBeenCalled();
   });
 
+  it("when notification sink is wired, sends native question options after persist", async () => {
+    const { store } = stubStore();
+    const notifyQuestion = vi.fn(async () => {});
+    const factory = createAskUserQuestionTool({
+      store: store as never,
+      notifications: { notifyQuestion },
+    });
+    const t = factory({ sessionKey: SESSION_KEY });
+    const r = await t.execute("call-1", {
+      question: "Major or minor bump?",
+      options: ["major", "minor"],
+    });
+
+    expect((r.details as { status: string }).status).toBe("question_submitted");
+    expect(notifyQuestion).toHaveBeenCalledWith({
+      sessionKey: SESSION_KEY,
+      questionId: "q-call-1",
+      questionPrompt: "Major or minor bump?",
+      options: ["major", "minor"],
+    });
+  });
+
   it("when store wired but no sessionKey, skips persist and logs warn", async () => {
     const { store, calls } = stubStore();
     const warn = vi.fn();

--- a/tests/tools/ask-user-question.test.ts
+++ b/tests/tools/ask-user-question.test.ts
@@ -239,8 +239,9 @@ describe("W1-F5 ask_user_question — pending-question persistence", () => {
 
   it("when notification sink is wired, sends native question options after persist", async () => {
     const { store, calls } = stubStore();
+    const callsSeenAtNotify: number[] = [];
     const notifyQuestion = vi.fn(async () => {
-      expect(calls).toHaveLength(1);
+      callsSeenAtNotify.push(calls.length);
     });
     const factory = createAskUserQuestionTool({
       store: store as never,
@@ -253,6 +254,7 @@ describe("W1-F5 ask_user_question — pending-question persistence", () => {
     });
 
     expect((r.details as { status: string }).status).toBe("question_submitted");
+    expect(callsSeenAtNotify).toEqual([1]);
     expect(notifyQuestion).toHaveBeenCalledWith({
       sessionKey: SESSION_KEY,
       questionId: "q-call-1",

--- a/tests/tools/exit-plan-mode.test.ts
+++ b/tests/tools/exit-plan-mode.test.ts
@@ -574,6 +574,9 @@ describe("exit_plan_mode — W1-F2 markdown persister", () => {
         plan: [{ step: "do thing", status: "pending" }],
         persistedPlan: expect.objectContaining({
           filename: expect.stringMatching(/^plan-\d{4}-\d{2}-\d{2}-notify-plan\.md$/),
+          absPath: expect.stringMatching(
+            /\/plans\/plan-\d{4}-\d{2}-\d{2}-notify-plan\.md$/,
+          ),
         }),
       }),
     );

--- a/tests/tools/exit-plan-mode.test.ts
+++ b/tests/tools/exit-plan-mode.test.ts
@@ -19,7 +19,7 @@
 import * as fsp from "node:fs/promises";
 import * as os from "node:os";
 import * as nodePath from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createExitPlanModeTool } from "../../src/tools/exit-plan-mode.js";
 import { isPlanApprovalId } from "../../src/helpers/approval-id.js";
 import { InMemoryGateway } from "../../src/state/in-memory-gateway.js";
@@ -497,6 +497,7 @@ describe("exit_plan_mode — W1-F2 markdown persister", () => {
 
   function buildWithPersister(opts?: {
     extraLog?: { info?: string[]; warn?: string[] };
+    notifyPlanApproval?: ReturnType<typeof vi.fn>;
   }) {
     const gw = new InMemoryGateway();
     gw.seed(SESSION_KEY, {
@@ -517,6 +518,9 @@ describe("exit_plan_mode — W1-F2 markdown persister", () => {
           warn: (m) => warn.push(m),
         },
       },
+      ...(opts?.notifyPlanApproval
+        ? { notifications: { notifyPlanApproval: opts.notifyPlanApproval } }
+        : {}),
     });
     return { gw, store, factory, info, warn };
   }
@@ -542,6 +546,37 @@ describe("exit_plan_mode — W1-F2 markdown persister", () => {
     expect(body).toContain("# Refactor websocket reconnect race");
     expect(body).toContain("## Plan");
     expect(body).toContain("- [ ] do thing");
+    expect((result.details as { persistedPlan?: { path?: string; filename?: string } }).persistedPlan).toEqual({
+      path: path.join(plansDir, filename),
+      filename,
+    });
+  });
+
+  it("sends plan approval notifications with the persisted markdown path when wired", async () => {
+    const notifyPlanApproval = vi.fn(async () => {});
+    const { factory } = buildWithPersister({ notifyPlanApproval });
+    const tool = factory({ sessionKey: SESSION_KEY, agentId: "main" });
+    const result = await tool.execute("c1", {
+      title: "Notify plan",
+      summary: "Review before execution.",
+      plan: [{ step: "do thing", status: "pending" }],
+    });
+
+    expect((result.details as { status: string }).status).toBe(
+      "approval-requested",
+    );
+    expect(notifyPlanApproval).toHaveBeenCalledOnce();
+    expect(notifyPlanApproval.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        sessionKey: SESSION_KEY,
+        title: "Notify plan",
+        summary: "Review before execution.",
+        plan: [{ step: "do thing", status: "pending" }],
+        persistedPlan: expect.objectContaining({
+          filename: expect.stringMatching(/^plan-\d{4}-\d{2}-\d{2}-notify-plan\.md$/),
+        }),
+      }),
+    );
   });
 
   it("writes the full archetype (summary + analysis + assumptions + risks + verification + references)", async () => {

--- a/tests/ui/session-actions.test.ts
+++ b/tests/ui/session-actions.test.ts
@@ -516,6 +516,44 @@ describe("P-12 session-actions — plan.cancel", () => {
     expect(gw.peek(SESSION_KEY)?.mode).toBe("normal");
   });
 
+  it("transitions to normal mode with a matching approvalId", async () => {
+    const gw = new InMemoryGateway();
+    const store = new PlanModeStore(gw);
+    const { api } = makeStubApi();
+    const actions = createPlanModeSessionActions({ api, store });
+    const handler = actions.find((a) => a.id === "plan.cancel")!.handler;
+    gw.seed(SESSION_KEY, planModeSession());
+
+    const r = await handler({
+      pluginId: "smarter-claw",
+      actionId: "plan.cancel",
+      sessionKey: SESSION_KEY,
+      payload: { approvalId: APPROVAL_ID },
+    });
+    if (!r || !r.ok) throw new Error("expected ok");
+    expect(r.continueAgent).toBe(false);
+    expect(gw.peek(SESSION_KEY)?.mode).toBe("normal");
+  });
+
+  it("rejects with STALE_APPROVAL_ID when approvalId mismatches", async () => {
+    const gw = new InMemoryGateway();
+    const store = new PlanModeStore(gw);
+    const { api } = makeStubApi();
+    const actions = createPlanModeSessionActions({ api, store });
+    const handler = actions.find((a) => a.id === "plan.cancel")!.handler;
+    gw.seed(SESSION_KEY, planModeSession());
+
+    const r = await handler({
+      pluginId: "smarter-claw",
+      actionId: "plan.cancel",
+      sessionKey: SESSION_KEY,
+      payload: { approvalId: "plan-different" },
+    });
+    if (!r || r.ok !== false) throw new Error("expected error");
+    expect(r.code).toBe(SESSION_ACTION_ERROR_CODES.STALE_APPROVAL_ID);
+    expect(gw.peek(SESSION_KEY)?.mode).toBe("plan");
+  });
+
   it("idempotent: no-op when already in normal mode", async () => {
     const gw = new InMemoryGateway();
     const store = new PlanModeStore(gw);


### PR DESCRIPTION
## Summary

Supersedes the OpenClaw 2026.5.19 recovery target from #123 with a fresh release branch for OpenClaw `v2026.6.1-beta.1`.

- bumps Smarter-Claw to `1.0.0-port.19`
- pins runtime/install compatibility to OpenClaw `v2026.6.1-beta.1` / `2fc497e67b9cf40b2c12a9355afd785e7f8672dc`
- records that `openclaw@2026.6.1-beta.1` is not published on npm and explicitly uses `openclaw@2026.5.31-beta.4` as the SDK fallback for install/typecheck
- adds host seam classification for stock-host active-session attachment rejection
- adds best-effort managed TaskFlow visibility for pending plan approvals via `api.runtime.tasks.managedFlows` or legacy `api.runtime.taskFlow`
- updates release docs, manifest docs, CI pack smoke, and the host-version parity gate

## Local validation

Working directory: `/Volumes/LEXAR/repos/Smarter-Claw-v2026.6.1-beta.1`

- `npm_config_minimum_release_age=0 CI=true pnpm install --frozen-lockfile`
- `node scripts/check-host-version-parity.mjs`
- `pnpm exec vitest run tests/release/host-release-target.test.ts tests/runtime/host-seam-gates.test.ts tests/runtime/task-flow-visibility.test.ts --pool=threads --poolOptions.threads.maxThreads=1`
- `pnpm typecheck`
- `pnpm build`
- `pnpm runtime-gate`
- `pnpm parity-harness`
- `pnpm test -- --pool=threads --poolOptions.threads.maxThreads=1` (43 files / 886 tests)
- `pnpm pack --pack-destination /Volumes/LEXAR/Codex/artifacts/smarter-claw-v2026.6.1-beta.1`
- extracted tarball smoke: package metadata, `dist/openclaw.plugin.json`, and `dist/src/index.js` present with target/minHost/install metadata aligned

## Release gates still explicit

- Stock OpenClaw `v2026.6.1-beta.1` still restricts active-session attachments to bundled plugins, so native Telegram buttons and Markdown delivery remain best-effort with `/plan` plus persisted Markdown fallback.
- Stock OpenClaw `v2026.6.1-beta.1` does not include the chat-stream renderer seam from openclaw/openclaw#80982, so inline plan cards/input-bar suppression remain upstream-gated.
- GitHub CI and Crabbox/OpenClaw release-host scenarios still need to run before merge/tag/publish.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Telegram-native approval/question buttons, managed TaskFlow visibility, and Markdown plan artifact persistence/attachment.

* **Documentation**
  * Release notes, README, and compatibility matrix updated for OpenClaw v2026.6.1-beta.1 / 1.0.0-port.19; clarified release-gate status and install/typecheck guidance.

* **Chores / CI**
  * Added a runtime registration gate and stricter host-version/manifest parity checks; bumped release channel, package version, and minimum Node requirement.

* **Tests**
  * New/expanded tests for release-target validation, plan notifications, task-flow visibility, tooling, and session-action behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->