### PR TITLE
Fix port.20 GitHub tarball install spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Plan Mode plugin for [OpenClaw](https://github.com/openclaw/openclaw) — plan-t
 
 ## Status
 
-**`1.0.0-port.19` — OpenClaw `v2026.6.1-beta.1` release target (2026-06-01).**
+**`1.0.0-port.20` — OpenClaw `v2026.6.1-beta.1` release target (2026-06-01).**
 
 The 6-wave parity refresh closed all 2 P0 + 14/17 P1 Wave-1 findings,
 built a 156-case mechanical parity-harness CI gate, and now targets the
@@ -16,7 +16,7 @@ install/typecheck uses the nearest published beta SDK
 `openclaw.plugin.json#minHostVersion`, the peer dependency, and the
 install floor all pin the real 6.1 beta host target.
 
-Port `.19` keeps the stable-load contracts from `.17`/`.18`, adds explicit
+Port `.20` keeps the stable-load contracts from `.17`/`.18`, adds explicit
 release-gate classification for the stock host's active-session attachment
 block, and mirrors pending plan approval state into OpenClaw's managed
 TaskFlow runtime when that 6.1 surface is available. On stock
@@ -110,7 +110,19 @@ What the patcher does:
 
 The patch is a **temporary tactical unblock for the legacy `2026.5.10-beta.5` baseline**. When upstream openclaw merges PR #80982 into a published release, we'll bump `peerDependencies.openclaw` + drop the patcher.
 
-## What works in 1.0.0-port.19
+## Install
+
+The npm package is not published yet. Install this release from its GitHub
+release tarball:
+
+```text
+https://github.com/electricsheephq/Smarter-Claw/releases/download/v1.0.0-port.20/electricsheephq-smarter-claw-1.0.0-port.20.tgz
+```
+
+The same URL is recorded in `package.json#openclaw.install.npmSpec` so
+OpenClaw-compatible installers do not need an npm registry package.
+
+## What works in 1.0.0-port.20
 
 | Feature | Status |
 |---|---|
@@ -200,7 +212,8 @@ pnpm build           # tsc → dist/
 
 | OpenClaw | Smarter Claw |
 |---|---|
-| `v2026.6.1-beta.1` GitHub release | `1.0.0-port.19` (current 6.1 beta target; npm SDK fallback `2026.5.31-beta.4`) |
+| `v2026.6.1-beta.1` GitHub release | `1.0.0-port.20` (current 6.1 beta target; GitHub release tarball install; npm SDK fallback `2026.5.31-beta.4`) |
+| `v2026.6.1-beta.1` GitHub release | `1.0.0-port.19` (superseded by `.20`; install spec pointed at an unpublished npm package) |
 | `2026.5.19` ... `<v2026.6.1-beta.1` | `1.0.0-port.18` (recovery RC) |
 | `2026.5.18` ... `<2026.5.19` | `1.0.0-port.17` (stable-load + Telegram bridge consumer RC) |
 | Historical `2026.5.18` RC, superseded by `1.0.0-port.17` | `1.0.0-port.16` (parity-refresh RC; no Telegram-native button bridge) |

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,33 @@
 # Smarter-Claw Release Notes
 
+## 1.0.0-port.20 — GitHub-tarball install spec for OpenClaw v2026.6.1-beta.1 (2026-06-01)
+
+This follow-up release keeps the `v2026.6.1-beta.1` runtime target from
+`1.0.0-port.19` and fixes the distribution metadata: the package is not
+published to npm in this environment, so `package.json#openclaw.install.npmSpec`
+now points at the GitHub release tarball instead of the absent npm package.
+
+Install spec:
+
+```text
+https://github.com/electricsheephq/Smarter-Claw/releases/download/v1.0.0-port.20/electricsheephq-smarter-claw-1.0.0-port.20.tgz
+```
+
+### What changed since `1.0.0-port.19`
+
+- Bumped the package to `1.0.0-port.20`.
+- Replaced `package.json#openclaw.install.npmSpec` with the GitHub release
+  tarball URL so OpenClaw-compatible installers can fetch the exact artifact
+  without npm registry credentials.
+- Added release metadata coverage so a GitHub-only release fails CI if it
+  points at an unpublished npm package again.
+
+### Validation
+
+- Release gating for this port is the release PR plus final tag checks:
+  host-version parity, release metadata tests, runtime gate, full Vitest, build,
+  pack, extracted tarball metadata smoke, and GitHub PR checks before tagging.
+
 ## 1.0.0-port.19 — OpenClaw v2026.6.1-beta.1 release target (2026-06-01)
 
 This maintenance pass moves the recovery line from `2026.5.x` to the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@electricsheephq/smarter-claw",
-  "version": "1.0.0-port.19",
+  "version": "1.0.0-port.20",
   "description": "Smarter-Claw — Plan-Mode plugin for OpenClaw v2026.6.1-beta.1 with explicit host seam gates for active-session attachments and chat-stream inline UI.",
   "type": "module",
   "main": "dist/src/index.js",
@@ -55,7 +55,7 @@
   "license": "SEE LICENSE IN LICENSE",
   "repository": {
     "type": "git",
-    "url": "https://github.com/electricsheephq/Smarter-Claw.git"
+    "url": "git+https://github.com/electricsheephq/Smarter-Claw.git"
   },
   "homepage": "https://github.com/electricsheephq/Smarter-Claw#readme",
   "bugs": {
@@ -80,7 +80,7 @@
     },
     "install": {
       "minHostVersion": ">=2026.6.1-beta.1",
-      "npmSpec": "@electricsheephq/smarter-claw@1.0.0-port.19"
+      "npmSpec": "https://github.com/electricsheephq/Smarter-Claw/releases/download/v1.0.0-port.20/electricsheephq-smarter-claw-1.0.0-port.20.tgz"
     },
     "build": {
       "command": "pnpm build",

--- a/scripts/check-host-version-parity.mjs
+++ b/scripts/check-host-version-parity.mjs
@@ -144,6 +144,26 @@ if (pkgOpenClaw?.install?.minHostVersion !== expectedInstallFloor) {
   process.exit(2);
 }
 
+const installSpec = pkgOpenClaw?.install?.npmSpec;
+if (typeof installSpec !== "string" || installSpec.length === 0) {
+  console.error(
+    "[host-version-parity] package.json openclaw.install.npmSpec must be a non-empty npm-compatible install spec.",
+  );
+  process.exit(2);
+}
+if (!npmPackageAvailable) {
+  const expectedGitHubTarball = `https://github.com/electricsheephq/Smarter-Claw/releases/download/v${pkg.version}/electricsheephq-smarter-claw-${pkg.version}.tgz`;
+  if (installSpec !== expectedGitHubTarball) {
+    console.error(
+      `[host-version-parity] GitHub-only target must use release tarball install spec "${expectedGitHubTarball}"; got ${JSON.stringify(installSpec)}.`,
+    );
+    console.error(
+      "  The package is not on npm, so an npm package spec would be an unreleasable install path.",
+    );
+    process.exit(2);
+  }
+}
+
 if (pkgOpenClaw?.build?.command !== "pnpm build") {
   console.error(
     `[host-version-parity] package.json openclaw.build.command must be "pnpm build"; got ${JSON.stringify(pkgOpenClaw?.build?.command)}.`,

--- a/tests/release/host-release-target.test.ts
+++ b/tests/release/host-release-target.test.ts
@@ -17,7 +17,7 @@ describe("OpenClaw v2026.6.1-beta.1 release target metadata", () => {
       install?: Record<string, unknown>;
     };
 
-    expect(pkg.version).toBe("1.0.0-port.19");
+    expect(pkg.version).toBe("1.0.0-port.20");
     expect(manifest.minHostVersion).toBe("2026.6.1-beta.1");
     expect(openclaw.target).toEqual(
       expect.objectContaining({
@@ -29,6 +29,9 @@ describe("OpenClaw v2026.6.1-beta.1 release target metadata", () => {
       }),
     );
     expect(openclaw.install?.minHostVersion).toBe(">=2026.6.1-beta.1");
+    expect(openclaw.install?.npmSpec).toBe(
+      "https://github.com/electricsheephq/Smarter-Claw/releases/download/v1.0.0-port.20/electricsheephq-smarter-claw-1.0.0-port.20.tgz",
+    );
     expect((pkg.peerDependencies as Record<string, unknown>).openclaw).toBe(
       ">=2026.6.1-beta.1",
     );


### PR DESCRIPTION
## Summary
- Bump Smarter-Claw to `1.0.0-port.20` for the OpenClaw `v2026.6.1-beta.1` release target.
- Replace `package.json#openclaw.install.npmSpec` with the GitHub release tarball URL because `@electricsheephq/smarter-claw` is not published to npm in this environment.
- Add a release parity guard and metadata test coverage so GitHub-only releases cannot point at an absent npm package again.

## Local validation
- `pwd && node scripts/check-host-version-parity.mjs && pnpm exec vitest run tests/release/host-release-target.test.ts --pool=threads --poolOptions.threads.maxThreads=1`
- `pwd && pnpm typecheck && pnpm build && pnpm runtime-gate && pnpm parity-harness && pnpm exec vitest run --pool=threads --poolOptions.threads.maxThreads=1 && pnpm pack`
- extracted tarball metadata smoke: `version=1.0.0-port.20`, `openclaw.install.npmSpec=https://github.com/electricsheephq/Smarter-Claw/releases/download/v1.0.0-port.20/electricsheephq-smarter-claw-1.0.0-port.20.tgz`, `target.tag=v2026.6.1-beta.1`
- local tarball SHA256 before PR: `c59654e4701099757f4fae7ecf947f22cb0ff259393534c4e41e8c0c95dd3a30`

## External validation note
- Crabbox provider-backed scenario execution is still blocked in this environment by missing provider auth/runtime: Docker daemon unavailable, no Hetzner/E2B/Upstash tokens, and no Blacksmith CLI.
