### PR TITLE
Add release artifact scenario gate for port.21

### DIFF
--- a/.github/workflows/release-artifact-scenarios.yml
+++ b/.github/workflows/release-artifact-scenarios.yml
@@ -30,6 +30,7 @@ on:
       - "scripts/release-artifact-scenario-smoke.mjs"
       - "src/**"
       - "tests/eva-live-smokes/**"
+      - "tests/release/**"
       - "tests/runtime/task-flow-visibility.test.ts"
   push:
     branches: [main]
@@ -41,6 +42,7 @@ on:
       - "scripts/release-artifact-scenario-smoke.mjs"
       - "src/**"
       - "tests/eva-live-smokes/**"
+      - "tests/release/**"
       - "tests/runtime/task-flow-visibility.test.ts"
 
 concurrency:
@@ -57,16 +59,18 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1
         with:
           version: 10.33.0
           run_install: false
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: "22"
           cache: pnpm
@@ -75,11 +79,11 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build local artifact for PR/push validation
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.tarball_url == '' }}
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         run: pnpm build
 
       - name: Smoke local packed artifact
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.tarball_url == '' }}
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         run: |
           set -euo pipefail
           mkdir -p /tmp/smarter-claw-pack
@@ -92,7 +96,7 @@ jobs:
           node scripts/release-artifact-scenario-smoke.mjs --tarball-path "$tarball"
 
       - name: Smoke published release artifact
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.tarball_url != '' }}
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         env:
           TARBALL_URL: ${{ inputs.tarball_url }}
           EXPECTED_SHA256: ${{ inputs.expected_sha256 }}
@@ -100,6 +104,9 @@ jobs:
           OPENCLAW_REF: ${{ inputs.openclaw_ref }}
         run: |
           set -euo pipefail
+          if [ -z "${TARBALL_URL:-}" ]; then
+            TARBALL_URL="$(node -e "const p=require('./package.json'); console.log(p.openclaw.install.npmSpec)")"
+          fi
           args=(--tarball-url "$TARBALL_URL")
           if [ -n "${EXPECTED_SHA256:-}" ]; then
             args+=(--expected-sha256 "$EXPECTED_SHA256")

--- a/.github/workflows/release-artifact-scenarios.yml
+++ b/.github/workflows/release-artifact-scenarios.yml
@@ -1,0 +1,113 @@
+name: release-artifact-scenarios
+
+on:
+  workflow_dispatch:
+    inputs:
+      tarball_url:
+        description: "Published Smarter-Claw release tarball URL. Defaults to package.json#openclaw.install.npmSpec."
+        required: false
+        type: string
+      expected_sha256:
+        description: "Expected SHA256 for the release tarball."
+        required: false
+        type: string
+      expected_version:
+        description: "Expected package version. Defaults to package.json#version."
+        required: false
+        type: string
+      openclaw_ref:
+        description: "Expected OpenClaw release tag recorded by the artifact."
+        required: false
+        default: "v2026.6.1-beta.1"
+        type: string
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/release-artifact-scenarios.yml"
+      - "openclaw.plugin.json"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "scripts/release-artifact-scenario-smoke.mjs"
+      - "src/**"
+      - "tests/eva-live-smokes/**"
+      - "tests/runtime/task-flow-visibility.test.ts"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/release-artifact-scenarios.yml"
+      - "openclaw.plugin.json"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "scripts/release-artifact-scenario-smoke.mjs"
+      - "src/**"
+      - "tests/eva-live-smokes/**"
+      - "tests/runtime/task-flow-visibility.test.ts"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  release-artifact-scenarios:
+    name: release-artifact-scenarios
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Build local artifact for PR/push validation
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.tarball_url == '' }}
+        run: pnpm build
+
+      - name: Smoke local packed artifact
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.tarball_url == '' }}
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/smarter-claw-pack
+          pnpm pack --pack-destination /tmp/smarter-claw-pack
+          tarball="$(ls /tmp/smarter-claw-pack/*.tgz | head -1)"
+          if [ -z "$tarball" ]; then
+            echo "FAIL: pnpm pack produced no tarball"
+            exit 1
+          fi
+          node scripts/release-artifact-scenario-smoke.mjs --tarball-path "$tarball"
+
+      - name: Smoke published release artifact
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.tarball_url != '' }}
+        env:
+          TARBALL_URL: ${{ inputs.tarball_url }}
+          EXPECTED_SHA256: ${{ inputs.expected_sha256 }}
+          EXPECTED_VERSION: ${{ inputs.expected_version }}
+          OPENCLAW_REF: ${{ inputs.openclaw_ref }}
+        run: |
+          set -euo pipefail
+          args=(--tarball-url "$TARBALL_URL")
+          if [ -n "${EXPECTED_SHA256:-}" ]; then
+            args+=(--expected-sha256 "$EXPECTED_SHA256")
+          fi
+          if [ -n "${EXPECTED_VERSION:-}" ]; then
+            args+=(--expected-version "$EXPECTED_VERSION")
+          fi
+          if [ -n "${OPENCLAW_REF:-}" ]; then
+            args+=(--openclaw-ref "$OPENCLAW_REF")
+          fi
+          node scripts/release-artifact-scenario-smoke.mjs "${args[@]}"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Plan Mode plugin for [OpenClaw](https://github.com/openclaw/openclaw) — plan-t
 
 ## Status
 
-**`1.0.0-port.20` — OpenClaw `v2026.6.1-beta.1` release target (2026-06-01).**
+**`1.0.0-port.21` — OpenClaw `v2026.6.1-beta.1` release target (2026-06-01).**
 
 The 6-wave parity refresh closed all 2 P0 + 14/17 P1 Wave-1 findings,
 built a 156-case mechanical parity-harness CI gate, and now targets the
@@ -16,7 +16,7 @@ install/typecheck uses the nearest published beta SDK
 `openclaw.plugin.json#minHostVersion`, the peer dependency, and the
 install floor all pin the real 6.1 beta host target.
 
-Port `.20` keeps the stable-load contracts from `.17`/`.18`, adds explicit
+Port `.21` keeps the stable-load contracts from `.17`/`.18`, adds explicit
 release-gate classification for the stock host's active-session attachment
 block, and mirrors pending plan approval state into OpenClaw's managed
 TaskFlow runtime when that 6.1 surface is available. On stock
@@ -116,13 +116,13 @@ The npm package is not published yet. Install this release from its GitHub
 release tarball:
 
 ```text
-https://github.com/electricsheephq/Smarter-Claw/releases/download/v1.0.0-port.20/electricsheephq-smarter-claw-1.0.0-port.20.tgz
+https://github.com/electricsheephq/Smarter-Claw/releases/download/v1.0.0-port.21/electricsheephq-smarter-claw-1.0.0-port.21.tgz
 ```
 
 The same URL is recorded in `package.json#openclaw.install.npmSpec` so
 OpenClaw-compatible installers do not need an npm registry package.
 
-## What works in 1.0.0-port.20
+## What works in 1.0.0-port.21
 
 | Feature | Status |
 |---|---|
@@ -212,7 +212,8 @@ pnpm build           # tsc → dist/
 
 | OpenClaw | Smarter Claw |
 |---|---|
-| `v2026.6.1-beta.1` GitHub release | `1.0.0-port.20` (current 6.1 beta target; GitHub release tarball install; npm SDK fallback `2026.5.31-beta.4`) |
+| `v2026.6.1-beta.1` GitHub release | `1.0.0-port.21` (current 6.1 beta target; GitHub release tarball install; runtime dependency smoke; npm SDK fallback `2026.5.31-beta.4`) |
+| `v2026.6.1-beta.1` GitHub release | `1.0.0-port.20` (superseded by `.21`; `typebox` was dev-only but imported at runtime) |
 | `v2026.6.1-beta.1` GitHub release | `1.0.0-port.19` (superseded by `.20`; install spec pointed at an unpublished npm package) |
 | `2026.5.19` ... `<v2026.6.1-beta.1` | `1.0.0-port.18` (recovery RC) |
 | `2026.5.18` ... `<2026.5.19` | `1.0.0-port.17` (stable-load + Telegram bridge consumer RC) |

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,37 @@
 # Smarter-Claw Release Notes
 
+## 1.0.0-port.21 — Release-artifact runtime dependency gate for OpenClaw v2026.6.1-beta.1 (2026-06-01)
+
+This follow-up release supersedes `1.0.0-port.20`. The new release-artifact
+scenario smoke found that the published `.20` tarball imported `typebox` at
+runtime while listing it only in `devDependencies`. Source and CI tests passed
+because the workspace had dev dependencies installed, but a production consumer
+could fail while loading the shipped plugin entrypoint.
+
+Install spec:
+
+```text
+https://github.com/electricsheephq/Smarter-Claw/releases/download/v1.0.0-port.21/electricsheephq-smarter-claw-1.0.0-port.21.tgz
+```
+
+### What changed since `1.0.0-port.20`
+
+- Bumped the package to `1.0.0-port.21`.
+- Moved `typebox` to production `dependencies` because the shipped tool modules
+  import it at runtime.
+- Added `scripts/release-artifact-scenario-smoke.mjs`, which validates the
+  packed or published tarball with dev dependencies omitted before importing
+  the shipped `dist/` plugin entrypoint.
+- Added a dispatchable `release-artifact-scenarios` GitHub workflow so the
+  published tarball can be re-smoked remotely by URL.
+
+### Validation
+
+- Release gating for this port includes the source checks from `.20` plus the
+  release-artifact scenario smoke: production dependency install, plugin
+  registration surface, plan approve, reject/revise, cancel, managed TaskFlow
+  visibility, and the OpenClaw 6.1 active-session host-seam release gate.
+
 ## 1.0.0-port.20 — GitHub-tarball install spec for OpenClaw v2026.6.1-beta.1 (2026-06-01)
 
 This follow-up release keeps the `v2026.6.1-beta.1` runtime target from

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@electricsheephq/smarter-claw",
-  "version": "1.0.0-port.20",
+  "version": "1.0.0-port.21",
   "description": "Smarter-Claw — Plan-Mode plugin for OpenClaw v2026.6.1-beta.1 with explicit host seam gates for active-session attachments and chat-stream inline UI.",
   "type": "module",
   "main": "dist/src/index.js",
@@ -12,6 +12,7 @@
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "runtime-gate": "node scripts/runtime-registration-gate.mjs",
+    "release-artifact-smoke": "node scripts/release-artifact-scenario-smoke.mjs",
     "parity-harness": "node scripts/check-host-version-parity.mjs && vitest run tests/parity/parity-harness.test.ts",
     "patch:chat-stream-seam": "node scripts/install-chat-stream-seam.mjs",
     "patch:chat-stream-seam:verify": "node scripts/verify-chat-stream-seam.mjs",
@@ -31,11 +32,13 @@
     "TRADEMARK.md",
     "RELEASE_NOTES.md"
   ],
+  "dependencies": {
+    "typebox": "^1.1.38"
+  },
   "devDependencies": {
     "@types/node": "^22.0.0",
     "openclaw": "2026.5.31-beta.4",
     "tsx": "4.20.6",
-    "typebox": "^1.1.38",
     "typescript": "^5.6.0",
     "vitest": "^3.2.0"
   },
@@ -80,7 +83,7 @@
     },
     "install": {
       "minHostVersion": ">=2026.6.1-beta.1",
-      "npmSpec": "https://github.com/electricsheephq/Smarter-Claw/releases/download/v1.0.0-port.20/electricsheephq-smarter-claw-1.0.0-port.20.tgz"
+      "npmSpec": "https://github.com/electricsheephq/Smarter-Claw/releases/download/v1.0.0-port.21/electricsheephq-smarter-claw-1.0.0-port.21.tgz"
     },
     "build": {
       "command": "pnpm build",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      typebox:
+        specifier: ^1.1.38
+        version: 1.1.38
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -17,9 +21,6 @@ importers:
       tsx:
         specifier: 4.20.6
         version: 4.20.6
-      typebox:
-        specifier: ^1.1.38
-        version: 1.1.38
       typescript:
         specifier: ^5.6.0
         version: 5.9.3

--- a/scripts/release-artifact-scenario-smoke.mjs
+++ b/scripts/release-artifact-scenario-smoke.mjs
@@ -1,0 +1,538 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  cp,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(SCRIPT_DIR, "..");
+const SOURCE_PACKAGE = JSON.parse(
+  await readFile(path.join(REPO_ROOT, "package.json"), "utf8"),
+);
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (!arg.startsWith("--")) {
+      throw new Error(`Unexpected positional argument: ${arg}`);
+    }
+    const eq = arg.indexOf("=");
+    if (eq !== -1) {
+      out[arg.slice(2, eq)] = arg.slice(eq + 1);
+      continue;
+    }
+    const key = arg.slice(2);
+    const value = argv[i + 1];
+    if (!value || value.startsWith("--")) {
+      throw new Error(`Missing value for --${key}`);
+    }
+    out[key] = value;
+    i += 1;
+  }
+  return out;
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    encoding: "utf8",
+    stdio: options.stdio ?? "pipe",
+    ...options,
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `${command} ${args.join(" ")} failed with ${result.status}\n${result.stdout ?? ""}${result.stderr ?? ""}`,
+    );
+  }
+  return result;
+}
+
+async function download(url, dest) {
+  const response = await fetch(url, { redirect: "follow" });
+  if (!response.ok) {
+    throw new Error(`Download failed ${response.status} ${response.statusText}: ${url}`);
+  }
+  const bytes = Buffer.from(await response.arrayBuffer());
+  await writeFile(dest, bytes);
+  return bytes;
+}
+
+async function sha256(file) {
+  const bytes = await readFile(file);
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+async function createOpenClawRuntimeStub(packageDir) {
+  const sdkDir = path.join(packageDir, "node_modules", "openclaw", "plugin-sdk");
+  await mkdir(sdkDir, { recursive: true });
+  await writeFile(
+    path.join(packageDir, "node_modules", "openclaw", "package.json"),
+    JSON.stringify(
+      {
+        name: "openclaw",
+        version: "2026.6.1-beta.1",
+        type: "module",
+        exports: {
+          "./plugin-sdk/plugin-entry": "./plugin-sdk/plugin-entry.js",
+          "./plugin-sdk/session-store-runtime": "./plugin-sdk/session-store-runtime.js",
+          "./plugin-sdk/config-runtime": "./plugin-sdk/config-runtime.js",
+        },
+      },
+      null,
+      2,
+    ),
+  );
+  await writeFile(
+    path.join(sdkDir, "plugin-entry.js"),
+    [
+      "export function definePluginEntry(entry) { return entry; }",
+      "export const __releaseSmokeStub = true;",
+      "",
+    ].join("\n"),
+  );
+  await writeFile(
+    path.join(sdkDir, "session-store-runtime.js"),
+    "export function createSessionStoreRuntime() { throw new Error('session-store runtime should not load in release smoke'); }\n",
+  );
+  await writeFile(
+    path.join(sdkDir, "config-runtime.js"),
+    "export function createConfigRuntime() { throw new Error('config runtime should not load in release smoke'); }\n",
+  );
+}
+
+function createTaskFlowRuntime() {
+  const flows = [];
+  const events = [];
+  const createManaged = (input) => {
+    const flow = {
+      ...input,
+      flowId: `flow-${flows.length + 1}`,
+      revision: 1,
+      syncMode: "managed",
+    };
+    flows.push(flow);
+    events.push({ type: "createManaged", flowId: flow.flowId, input });
+    return flow;
+  };
+  const setWaiting = (input) => {
+    const flow = flows.find((candidate) => candidate.flowId === input.flowId);
+    if (!flow) return { applied: false, code: "not_found" };
+    Object.assign(flow, input, {
+      status: "waiting",
+      revision: Number(flow.revision) + 1,
+    });
+    events.push({ type: "setWaiting", flowId: input.flowId, input });
+    return { applied: true, flow };
+  };
+  const finish = (input) => {
+    const flow = flows.find((candidate) => candidate.flowId === input.flowId);
+    if (!flow) return { applied: false, code: "not_found" };
+    Object.assign(flow, input, {
+      status: "finished",
+      revision: Number(flow.revision) + 1,
+    });
+    events.push({ type: "finish", flowId: input.flowId, input });
+    return { applied: true, flow };
+  };
+  return {
+    flows,
+    events,
+    managedFlows: {
+      bindSession: () => ({
+        createManaged,
+        list: () => flows,
+        setWaiting,
+        finish,
+      }),
+    },
+  };
+}
+
+function createHarness(entry) {
+  const taskFlow = createTaskFlowRuntime();
+  const captures = {
+    hooks: new Map(),
+    tools: new Map(),
+    sessionActions: new Map(),
+    sessionExtensions: [],
+    controlUis: [],
+    enqueuedInjections: [],
+    sessionAttachments: [],
+    interactiveHandlers: new Map(),
+    commands: new Map(),
+    logs: [],
+  };
+  const api = {
+    id: "smarter-claw",
+    name: "Smarter-Claw",
+    pluginConfig: {},
+    logger: {
+      info: (message) => captures.logs.push(["info", message]),
+      warn: (message) => captures.logs.push(["warn", message]),
+      error: (message) => captures.logs.push(["error", message]),
+      debug: (message) => captures.logs.push(["debug", message]),
+    },
+    runtime: {
+      tasks: {
+        managedFlows: taskFlow.managedFlows,
+      },
+    },
+    on: (name, handler) => {
+      const list = captures.hooks.get(name) ?? [];
+      list.push(handler);
+      captures.hooks.set(name, list);
+    },
+    registerTool: (tool, opts = {}) => {
+      captures.tools.set(opts.name ?? "<unknown>", tool);
+    },
+    registerCli: () => {},
+    registerCommand: (command) => {
+      captures.commands.set(command?.name ?? "<unknown>", command);
+    },
+    registerInteractiveHandler: (registration) => {
+      captures.interactiveHandlers.set(
+        `${registration.channel}:${registration.namespace}`,
+        registration.handler,
+      );
+    },
+    session: {
+      state: {
+        registerSessionExtension: (extension) => {
+          captures.sessionExtensions.push(extension);
+        },
+      },
+      workflow: {
+        enqueueNextTurnInjection: async (injection) => {
+          captures.enqueuedInjections.push(injection);
+          return {
+            enqueued: true,
+            id: `inj-${captures.enqueuedInjections.length}`,
+            sessionKey: injection.sessionKey,
+          };
+        },
+        sendSessionAttachment: async (attachment) => {
+          captures.sessionAttachments.push(attachment);
+          return { ok: true };
+        },
+      },
+      controls: {
+        registerSessionAction: (action) => {
+          captures.sessionActions.set(action.id, action.handler);
+        },
+        registerControlUiDescriptor: (descriptor) => {
+          captures.controlUis.push(descriptor);
+        },
+      },
+    },
+  };
+
+  entry.register(api);
+
+  return {
+    captures,
+    taskFlow,
+    invokeAction: async (id, ctx) => {
+      const handler = captures.sessionActions.get(id);
+      assert(handler, `Session action not registered: ${id}`);
+      return handler({
+        pluginId: "smarter-claw",
+        actionId: id,
+        ...ctx,
+      });
+    },
+    tool: (name, ctx) => {
+      const factory = captures.tools.get(name);
+      assert(factory, `Tool not registered: ${name}`);
+      return factory(ctx);
+    },
+  };
+}
+
+async function runPlanApproveScenario(entry) {
+  const sessionKey = "artifact:approve";
+  const harness = createHarness(entry);
+  const enter = harness.tool("enter_plan_mode", { sessionKey });
+  const enterResult = await enter.execute("artifact-enter", {});
+  assert(enterResult.details?.status === "entered", "enter_plan_mode did not enter plan mode");
+
+  const exit = harness.tool("exit_plan_mode", { sessionKey });
+  const exitResult = await exit.execute("artifact-exit", {
+    title: "Validate release artifact",
+    plan: [
+      { step: "Download the release tarball", status: "completed" },
+      { step: "Exercise the shipped plugin entrypoint", status: "pending" },
+    ],
+    summary: "Artifact-driven approval smoke.",
+  });
+  const approvalId = exitResult.details?.approvalId;
+  assert(exitResult.details?.status === "approval-requested", "exit_plan_mode did not request approval");
+  assert(typeof approvalId === "string" && approvalId.startsWith("plan-"), "missing approval id");
+  assert(harness.taskFlow.flows.length === 1, "pending plan did not create a managed TaskFlow");
+  assert(harness.taskFlow.flows[0].status === "waiting", "TaskFlow is not waiting on approval");
+
+  const accepted = await harness.invokeAction("plan.accept", {
+    sessionKey,
+    payload: { approvalId },
+  });
+  assert(accepted.ok === true, "plan.accept did not succeed");
+  assert(accepted.continueAgent === true, "plan.accept did not continue the agent");
+  assert(harness.captures.enqueuedInjections.length === 1, "approval did not enqueue a next-turn injection");
+  const injection = harness.captures.enqueuedInjections[0];
+  assert(
+    /^\[PLAN_DECISION\]: approved\n/.test(injection.text),
+    "approval injection does not use the approved decision envelope",
+  );
+  assert(
+    injection.text.includes("Execute it now without re-planning."),
+    "approval injection does not include execution guidance",
+  );
+  assert(harness.taskFlow.flows[0].status === "finished", "approval did not finish the managed TaskFlow");
+  return "plan approve + TaskFlow finish";
+}
+
+async function runRejectReviseScenario(entry) {
+  const sessionKey = "artifact:reject-revise";
+  const harness = createHarness(entry);
+  await harness.tool("enter_plan_mode", { sessionKey }).execute("enter", {});
+  const firstExit = await harness.tool("exit_plan_mode", { sessionKey }).execute("exit-1", {
+    title: "First draft",
+    plan: [{ step: "Do it", status: "pending" }],
+  });
+  const firstApprovalId = firstExit.details?.approvalId;
+  assert(typeof firstApprovalId === "string", "first plan missing approval id");
+  assert(harness.taskFlow.flows.length === 1, "first plan did not create one managed flow");
+
+  const rejected = await harness.invokeAction("plan.reject", {
+    sessionKey,
+    payload: {
+      approvalId: firstApprovalId,
+      feedback: "too broad @channel <@U123>",
+    },
+  });
+  assert(rejected.ok === true, "plan.reject did not succeed");
+  assert(rejected.result?.rejectionCount === 1, "rejection count did not increment");
+  const rejectionInjection = harness.captures.enqueuedInjections.at(-1);
+  assert(
+    rejectionInjection.text ===
+      "[PLAN_DECISION]: rejected\nfeedback: too broad @\u{FE6B}channel <\u{200B}@U123>",
+    "rejection injection does not match in-host runtime sanitizer",
+  );
+  assert(harness.taskFlow.flows[0].currentStep === "Plan rejected; waiting for revised plan", "rejection did not update TaskFlow currentStep");
+
+  const revisedExit = await harness.tool("exit_plan_mode", { sessionKey }).execute("exit-2", {
+    title: "Revised draft",
+    plan: [{ step: "Narrow the change", status: "pending" }],
+  });
+  const revisedApprovalId = revisedExit.details?.approvalId;
+  assert(typeof revisedApprovalId === "string", "revised plan missing approval id");
+  assert(revisedApprovalId !== firstApprovalId, "revised plan reused stale approval id");
+  assert(harness.taskFlow.flows.length === 1, "revised plan created a duplicate managed flow");
+  assert(
+    harness.taskFlow.flows[0].stateJson?.approvalId === revisedApprovalId,
+    "managed flow did not move to the revised approval id",
+  );
+  return "reject + revised approval reuses TaskFlow";
+}
+
+async function runCancelScenario(entry) {
+  const sessionKey = "artifact:cancel";
+  const harness = createHarness(entry);
+  await harness.tool("enter_plan_mode", { sessionKey }).execute("enter", {});
+  const exitResult = await harness.tool("exit_plan_mode", { sessionKey }).execute("exit", {
+    title: "Cancelable plan",
+    plan: [{ step: "Wait for operator", status: "pending" }],
+  });
+  const approvalId = exitResult.details?.approvalId;
+  assert(typeof approvalId === "string", "cancel scenario missing approval id");
+  const cancelled = await harness.invokeAction("plan.cancel", {
+    sessionKey,
+    payload: { approvalId },
+  });
+  assert(cancelled.ok === true, "plan.cancel did not succeed");
+  assert(cancelled.continueAgent === false, "plan.cancel should not continue the agent");
+  assert(harness.taskFlow.flows[0].status === "finished", "cancel did not finish the managed TaskFlow");
+  return "cancel finishes TaskFlow";
+}
+
+function validateRegistrationSurface(entry) {
+  const harness = createHarness(entry);
+  for (const tool of ["enter_plan_mode", "exit_plan_mode", "ask_user_question"]) {
+    assert(harness.captures.tools.has(tool), `missing registered tool ${tool}`);
+  }
+  for (const action of [
+    "plan.accept",
+    "plan.edit",
+    "plan.reject",
+    "plan.cancel",
+    "plan.answer",
+    "plan.auto.toggle",
+  ]) {
+    assert(harness.captures.sessionActions.has(action), `missing session action ${action}`);
+  }
+  assert(harness.captures.commands.has("plan"), "missing /plan command");
+  assert(harness.captures.commands.has("plan-mode"), "missing /plan-mode alias");
+  assert(
+    harness.captures.sessionExtensions.some((extension) => extension.namespace === "plan-mode"),
+    "missing plan-mode session extension",
+  );
+  assert(
+    harness.captures.interactiveHandlers.has("telegram:smarter-claw-plan"),
+    "missing Telegram plan interactive handler",
+  );
+  assert(harness.captures.controlUis.length > 0, "missing control UI descriptor");
+  return "registration surface";
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const expectedVersion = args["expected-version"] ?? SOURCE_PACKAGE.version;
+  const expectedHost = args["expected-host"] ?? SOURCE_PACKAGE.openclaw?.target?.version;
+  const expectedTag = args["openclaw-ref"] ?? SOURCE_PACKAGE.openclaw?.target?.tag;
+  const expectedSha = args["expected-sha256"] ?? "";
+  const tarballUrl = args["tarball-url"] ?? "";
+  const tarballPath = args["tarball-path"] ?? "";
+  const expectedInstallSpec = tarballUrl || SOURCE_PACKAGE.openclaw?.install?.npmSpec;
+
+  assert(tarballUrl || tarballPath, "Pass --tarball-url or --tarball-path");
+
+  const workDir = await mkdtemp(path.join(tmpdir(), "smarter-claw-release-smoke-"));
+  try {
+    const tarballFile = path.join(workDir, `smarter-claw-${expectedVersion}.tgz`);
+    if (tarballUrl) {
+      await download(tarballUrl, tarballFile);
+    } else {
+      await cp(path.resolve(tarballPath), tarballFile);
+    }
+    const actualSha = await sha256(tarballFile);
+    if (expectedSha) {
+      assert(
+        actualSha === expectedSha.toLowerCase(),
+        `SHA256 mismatch: expected ${expectedSha}, got ${actualSha}`,
+      );
+    }
+
+    const extractDir = path.join(workDir, "extract");
+    await mkdir(extractDir, { recursive: true });
+    run("tar", ["-xzf", tarballFile, "-C", extractDir]);
+    const packageDir = path.join(extractDir, "package");
+    const pkg = JSON.parse(await readFile(path.join(packageDir, "package.json"), "utf8"));
+    const manifest = JSON.parse(
+      await readFile(path.join(packageDir, "dist", "openclaw.plugin.json"), "utf8"),
+    );
+
+    assert(pkg.version === expectedVersion, `package version mismatch: ${pkg.version}`);
+    assert(manifest.minHostVersion === expectedHost, `manifest minHostVersion mismatch: ${manifest.minHostVersion}`);
+    assert(pkg.openclaw?.target?.version === expectedHost, "package target version does not match expected host");
+    assert(pkg.openclaw?.target?.tag === expectedTag, "package target tag does not match expected OpenClaw ref");
+    assert(pkg.openclaw?.target?.npmPackageAvailable === false, "package should record npmPackageAvailable=false for this host target");
+    assert(pkg.openclaw?.install?.minHostVersion === `>=${expectedHost}`, "package install floor does not match expected host");
+    assert(pkg.openclaw?.install?.npmSpec === expectedInstallSpec, "package install spec does not match expected artifact URL");
+    for (const tool of ["enter_plan_mode", "exit_plan_mode", "ask_user_question"]) {
+      assert(manifest.contracts?.tools?.includes(tool), `manifest missing tool contract ${tool}`);
+    }
+    assert(
+      manifest.contracts?.sessionAttachments?.includes("active-session"),
+      "manifest missing active-session contract",
+    );
+
+    // Validate through a fresh consumer install so runtime dependencies come
+    // only from the packed package's production dependency graph. We disable
+    // peer auto-install because OpenClaw v2026.6.1-beta.1 is a GitHub release
+    // target, not an npm-published SDK package.
+    const consumerDir = path.join(workDir, "consumer");
+    await mkdir(consumerDir, { recursive: true });
+    await writeFile(
+      path.join(consumerDir, "package.json"),
+      JSON.stringify({ name: "smarter-claw-release-smoke-consumer", type: "module" }, null, 2),
+    );
+    run(
+      "npm",
+      [
+        "install",
+        "--ignore-scripts",
+        "--legacy-peer-deps",
+        "--package-lock=false",
+        "--no-audit",
+        "--no-fund",
+        tarballFile,
+      ],
+      { cwd: consumerDir },
+    );
+    const runtimePackageDir = path.join(
+      consumerDir,
+      "node_modules",
+      "@electricsheephq",
+      "smarter-claw",
+    );
+    const installedPackage = JSON.parse(
+      await readFile(path.join(runtimePackageDir, "package.json"), "utf8"),
+    );
+    assert(installedPackage.version === expectedVersion, "consumer install picked up the wrong package version");
+
+    await createOpenClawRuntimeStub(runtimePackageDir);
+    process.env.SMARTER_CLAW_USE_INMEMORY = "1";
+    const entryUrl = pathToFileURL(path.join(runtimePackageDir, "dist", "src", "index.js")).href;
+    const entry = (await import(`${entryUrl}?release-smoke=${Date.now()}`)).default;
+    assert(entry?.id === "smarter-claw", "plugin entry id mismatch");
+
+    const seam = await import(
+      `${pathToFileURL(path.join(runtimePackageDir, "dist", "src", "runtime", "host-seam-gates.js")).href}?release-smoke=${Date.now()}`
+    );
+    const classified = seam.classifyPlanNotificationDeliveryFailure(
+      "session attachments are restricted to bundled plugins",
+    );
+    assert(classified.releaseGate === true, "active-session host seam is not release-gated");
+    assert(
+      classified.code === "active-session-attachments-bundled-only",
+      `unexpected host seam code: ${classified.code}`,
+    );
+
+    const scenarios = [
+      validateRegistrationSurface(entry),
+      await runPlanApproveScenario(entry),
+      await runRejectReviseScenario(entry),
+      await runCancelScenario(entry),
+      "active-session host seam release gate",
+    ];
+
+    console.log(
+      JSON.stringify(
+        {
+          ok: true,
+          artifact: tarballUrl || path.resolve(tarballPath),
+          version: expectedVersion,
+          host: expectedHost,
+          openclawRef: expectedTag,
+          sha256: actualSha,
+          scenarios,
+        },
+        null,
+        2,
+      ),
+    );
+  } finally {
+    delete process.env.SMTER_CLAW_USE_INMEMORY;
+    delete process.env.SMARTER_CLAW_USE_INMEMORY;
+    await rm(workDir, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(`[release-artifact-scenario-smoke] ${error.stack ?? error.message}`);
+  process.exit(1);
+});

--- a/tests/release/host-release-target.test.ts
+++ b/tests/release/host-release-target.test.ts
@@ -17,7 +17,7 @@ describe("OpenClaw v2026.6.1-beta.1 release target metadata", () => {
       install?: Record<string, unknown>;
     };
 
-    expect(pkg.version).toBe("1.0.0-port.20");
+    expect(pkg.version).toBe("1.0.0-port.21");
     expect(manifest.minHostVersion).toBe("2026.6.1-beta.1");
     expect(openclaw.target).toEqual(
       expect.objectContaining({
@@ -30,7 +30,7 @@ describe("OpenClaw v2026.6.1-beta.1 release target metadata", () => {
     );
     expect(openclaw.install?.minHostVersion).toBe(">=2026.6.1-beta.1");
     expect(openclaw.install?.npmSpec).toBe(
-      "https://github.com/electricsheephq/Smarter-Claw/releases/download/v1.0.0-port.20/electricsheephq-smarter-claw-1.0.0-port.20.tgz",
+      "https://github.com/electricsheephq/Smarter-Claw/releases/download/v1.0.0-port.21/electricsheephq-smarter-claw-1.0.0-port.21.tgz",
     );
     expect((pkg.peerDependencies as Record<string, unknown>).openclaw).toBe(
       ">=2026.6.1-beta.1",


### PR DESCRIPTION
## Summary
- Bump Smarter-Claw to `1.0.0-port.21` for the OpenClaw `v2026.6.1-beta.1` target.
- Move `typebox` from `devDependencies` to production `dependencies`; the published `.20` tarball imports it at runtime, so `.20` can fail in a production consumer despite source tests passing.
- Add `scripts/release-artifact-scenario-smoke.mjs`, which installs the packed/published tarball into a fresh consumer app with peer auto-install disabled, then imports the shipped `dist/` entrypoint and exercises registration, plan approve, reject/revise, cancel, managed TaskFlow visibility, and the 6.1 active-session host-seam release gate.
- Add a `workflow_dispatch`-capable `release-artifact-scenarios` GitHub workflow so Crabbox can dispatch remote release-artifact validation by URL.

## Local validation
- `pwd && node --check scripts/release-artifact-scenario-smoke.mjs && node scripts/check-host-version-parity.mjs && pnpm exec vitest run tests/release/host-release-target.test.ts --pool=threads --poolOptions.threads.maxThreads=1 && pnpm typecheck && pnpm build && pnpm pack ... && node scripts/release-artifact-scenario-smoke.mjs --tarball-path ...`
- `pwd && pnpm typecheck && pnpm build && pnpm runtime-gate && pnpm parity-harness && pnpm exec vitest run --pool=threads --poolOptions.threads.maxThreads=1 && pnpm pack ... && node scripts/release-artifact-scenario-smoke.mjs --tarball-path ... && shasum -a 256 ...`

## Local artifact evidence
- Local `.21` tarball: `/Volumes/LEXAR/Codex/artifacts/smarter-claw-v1.0.0-port.21/electricsheephq-smarter-claw-1.0.0-port.21.tgz`
- SHA256: `3ea8e52b4692a7078af4de9a62f910aeb1687da50c126e90eef2d4553273c1df`
- Full Vitest: `43 files / 889 tests`
- Release-artifact scenarios: registration surface, plan approve + TaskFlow finish, reject + revised approval reuses TaskFlow, cancel finishes TaskFlow, active-session host seam release gate.

## External validation plan after merge
- Tag and publish `v1.0.0-port.21` with the `.21` tarball.
- Use Crabbox's GitHub Actions dispatch wrapper to run `release-artifact-scenarios.yml` on `main` against the published release URL and expected SHA256.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped version to 1.0.0-port.21 for OpenClaw v2026.6.1-beta.1 support.
  * Moved typebox to production dependencies.
  * Updated package download artifacts and URLs to point to the new release.

* **Documentation**
  * Updated README with new release version and installation instructions.
  * Added release notes for v1.0.0-port.21.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->